### PR TITLE
feat: add --command flag to prepend slash commands to prompts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,10 @@ function parseArgs(argv: string[]): {
           process.stderr.write("Error: --command requires a value\n");
           usage();
         }
+        if (!cmdValue.startsWith("/")) {
+          process.stderr.write("Error: --command must start with / (e.g., /mika)\n");
+          usage();
+        }
         command = cmdValue;
         break;
       }


### PR DESCRIPTION
## Summary
- Adds `--command <cmd>` CLI flag that prepends a slash command to the prompt before passing to Claude Code
- Example: `claude-pilot --command "/mika" "mika-skills#8"` → Claude Code receives `/mika mika-skills#8`
- Optional and backward compatible — omitting `--command` changes nothing

Closes #6

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] `claude-pilot --command "/mika" "mika-skills#8"` sends `/mika mika-skills#8` to Claude Code
- [ ] `claude-pilot "plain prompt"` still works without --command

🤖 Generated with [Claude Code](https://claude.com/claude-code)