### PR TITLE
fix: route sub-agent tool calls through permission system

### DIFF
--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -32,15 +32,7 @@ export function createPermissionHandler(
   let sessionId: string | undefined;
 
   const handler: CanUseTool = async (toolName, input, sdkOptions) => {
-    // Sub-agent tool calls: auto-allow
-    if (sdkOptions.agentID) {
-      if (opts.verbose) {
-        logVerbose(`auto-allowing sub-agent ${sdkOptions.agentID}: ${toolName}`);
-      }
-      return { behavior: "allow" as const, updatedInput: input };
-    }
-
-    // Log every user-facing tool request before decision logic
+    // Log every tool request before decision logic
     logToolRequest(toolName, summarizeInput(toolName, input));
 
     // Relay disabled or no config: go straight to interactive
@@ -54,6 +46,7 @@ export function createPermissionHandler(
       tool_name: toolName,
       tool_input: input,
       tool_use_id: sdkOptions.toolUseID,
+      agent_id: sdkOptions.agentID,
       decision_reason: sdkOptions.decisionReason,
       blocked_path: sdkOptions.blockedPath,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface PilotEvent {
   tool_name: string;
   tool_input: Record<string, unknown>;
   tool_use_id: string;
+  agent_id?: string; // set when the call originates from a sub-agent
   decision_reason?: string;
   blocked_path?: string;
   error?: string; // present on retry after malformed response


### PR DESCRIPTION
## Summary
- Removes the auto-allow bypass for sub-agent tool calls in `permissions.ts`
- Sub-agent calls now go through the same relay → retry → interactive fallback path as main conversation calls
- Adds `agent_id` field to `PilotEvent` so mika-dev can see when a call originates from a sub-agent and make informed decisions

Closes #5

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] Sub-agent tool calls are forwarded to the relay (no more auto-allow)
- [ ] `agent_id` appears in the PilotEvent JSON sent to the external agent
- [ ] Main conversation tool calls still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)