### PR TITLE
fix: handle standard POSIX -- argument separator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,10 @@ function parseArgs(argv: string[]): {
       case "-h":
         usage();
         break;
+      case "--":
+        positional.push(...args.slice(i + 1));
+        i = args.length;
+        break;
       default:
         if (args[i].startsWith("-")) {
           process.stderr.write(`Unknown option: ${args[i]}\n`);


### PR DESCRIPTION
## Summary

- Add `case "--":` to CLI argument parser to support the standard POSIX `--` separator
- Collects all tokens after `--` as positional arguments (the prompt)
- Unblocks the autonomous dev loop handler (`mika-skills/claude-pilot/handlers/run.sh`) which correctly uses `--` to guard prompts that might start with `-`

Closes #9

## Test plan

- [ ] `npm run build` — passes
- [ ] `npx tsc --noEmit` — passes
- [ ] `claude-pilot --verbose --log-dir --task-id test -- "hello"` — parses without arg error
- [ ] Re-run mika-dev task for mika#248 to confirm the handler works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)