### PR TITLE
fix: stop passing --session-id for PilotEvent relay calls

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -38,7 +38,6 @@ export async function runAgent(opts: AgentOptions): Promise<void> {
     for await (const message of q) {
       if (message.type === "system" && message.subtype === "init") {
         sessionId = message.session_id;
-        opts.permissionHandler.setSessionId(sessionId);
         logInit(sessionId, message.model, opts.taskId);
         logPrompt(opts.prompt);
         continue;

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -22,15 +22,11 @@ interface PermissionHandlerOptions {
   verbose: boolean;
 }
 
-export type PermissionHandler = CanUseTool & {
-  setSessionId(id: string): void;
-};
+export type PermissionHandler = CanUseTool;
 
 export function createPermissionHandler(
   opts: PermissionHandlerOptions,
 ): PermissionHandler {
-  let sessionId: string | undefined;
-
   const handler: CanUseTool = async (toolName, input, sdkOptions) => {
     // Log every tool request before decision logic
     logToolRequest(toolName, summarizeInput(toolName, input));
@@ -61,7 +57,6 @@ export function createPermissionHandler(
         event,
         sdkOptions.signal,
         opts.verbose,
-        sessionId,
       );
       logRelayRecv(toolName, response.action, Date.now() - start);
       return mapResponse(toolName, input, response);
@@ -83,7 +78,6 @@ export function createPermissionHandler(
             retryEvent,
             sdkOptions.signal,
             opts.verbose,
-            sessionId,
           );
           logRelayRecv(toolName, response.action, Date.now() - start);
           return mapResponse(toolName, input, response);
@@ -105,11 +99,7 @@ export function createPermissionHandler(
     }
   };
 
-  return Object.assign(handler, {
-    setSessionId(id: string): void {
-      sessionId = id;
-    },
-  });
+  return handler;
 }
 
 function mapResponse(

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -19,13 +19,11 @@ export async function invokeCommand(
   event: PilotEvent,
   signal: AbortSignal,
   verbose: boolean,
-  sessionId?: string,
 ): Promise<PilotResponse> {
   const timeout = config.timeout ?? 120_000;
 
   const args = [...(config.args ?? []), "-"];
   if (config.model) args.push("--model", config.model);
-  if (sessionId) args.push("--session-id", sessionId);
 
   if (verbose) {
     logVerbose(`invoking: ${config.command} ${args.join(" ")}`);


### PR DESCRIPTION
## Summary

- Removes `--session-id` from `mika ask` calls for PilotEvent permission relay
- Each permission request now gets an ephemeral session instead of accumulating in one shared session
- Pure deletion: 15 lines removed, 2 lines added (return type simplification)

**Why:** Permission decisions are stateless (Tier 1/2/3 classification lookup). Sharing a session across 70+ PilotEvents accumulated source code snippets in mika-dev's context window, contaminating the orchestration session. This caused mika-dev to pattern-match on familiar code and do reconnaissance instead of calling `run_claude_pilot`.

The completion callback (via `run.sh --task-id`) is unaffected — it still routes to the orchestration session correctly.

## Test plan

- [ ] Run claude-pilot with relay enabled, verify PilotEvents no longer pass `--session-id`
- [ ] Verify permission decisions still work (Tier 1 auto-approve, Tier 3 escalation)
- [ ] Verify completion callback still arrives at mika-dev's orchestration session
- [ ] After a claude-pilot run completes, verify mika-dev's orchestration session is not polluted with source code from PilotEvents

🤖 Generated with [Claude Code](https://claude.com/claude-code)