### PR TITLE
fix: tier1 allow `cd` and compound `cd <path> && <tier1>`

### DIFF
--- a/docs/plans/2026-04-14-002-fix-tier1-cd-and-compound-plan.md
+++ b/docs/plans/2026-04-14-002-fix-tier1-cd-and-compound-plan.md
@@ -1,0 +1,81 @@
+---
+title: "fix: tier1 allow `cd` and compound `cd <path> && <tier1>`"
+type: fix
+status: active
+date: 2026-04-14
+tracks_issue: senara-solutions/claude-pilot-py#2
+---
+
+# tier1: allow `cd` and compound `cd <path> && <tier1>`
+
+## Problem
+
+First end-to-end dispatch against `claude-pilot-py` (mika#557) stalled at turn 14. Log `/var/log/claude-pilot/48cbb025-6d8e-430f-a957-9ce2e32800bb.log` shows four variants of the same benign, read-only command — `cd <worktree> && gh issue view 557 --json ...` — each escalated to the relay, each denied by mika-dev, stall-detected at five no-tool-call turns.
+
+Claude's standard working pattern is `cd <worktree> && <read-only gh/git/cargo/npm op>`. Without auto-approval for that shape, every single work item will stall.
+
+## Root cause
+
+`src/claude_pilot/tier1.py::SAFE_SHELL_COMMANDS` omits `cd`. The compound splitter correctly splits `cd /path && gh issue view 42` into two subcommands and evaluates each, but `cd /path` fails every check (not a git / build / shell / gh command) and the whole compound falls through to the relay.
+
+Same gap exists in the archived TS version (`claude-pilot-ts/src/tier1.ts:242-248`) — this is not a port regression, just a pre-existing bug that today's incident made load-bearing.
+
+The `permission-policy` skill on mika-dev's side (`mika-skills/permission-policy/system_prompt.md`) explicitly lists `cd` as non-destructive and instructs "compound commands where ALL parts are TIER 1 — evaluate each part, allow if all parts are safe." So the correct behavior is already documented; tier1 just needs to match.
+
+## Fix
+
+Add two leaves to `SAFE_SHELL_COMMANDS`:
+
+| Leaf | Justification |
+|---|---|
+| `cd` | No write side effects. Path-traversal via `$(...)` / backticks / `<(...)` is already blocked at the TIER3 deny-list (applied to the raw compound before splitting). |
+| `command` | `command -v <name>` is equivalent to `which <name>`, which is already in the safe-list. Used in `command -v lefthook && lefthook install`-shaped health probes. |
+
+**Nothing else changes.** The existing compound evaluator (`_split_compound_command` + `all(_is_safe_sub_command(sub) for sub in sub_commands)`) already handles multi-part commands correctly — once `cd` is recognized as a safe leaf, the common pattern auto-approves.
+
+## Explicitly NOT added
+
+Permission-policy also lists `mkdir`, `tee`, `python3` as non-destructive. None of these are added here:
+
+- `mkdir` — creates directories at arbitrary paths; no in-process `is_within_project` scoping on Bash. Relay should see these.
+- `tee` — writes to arbitrary paths. Same.
+- `python3` — executes arbitrary code. Largest possible surface.
+
+Keeping claude-pilot tier1 tighter than permission-policy is intentional defense in depth: tier1 is a sandbox, permission-policy is a relay-side checklist.
+
+## Scope / AC
+
+- [x] Add `cd` and `command` to `SAFE_SHELL_COMMANDS` with a comment explaining the safety argument
+- [x] Tests:
+  - `cd /path && gh issue view 42` → auto-approved (the mika#557 regression)
+  - `cd /path && cargo test` → auto-approved
+  - `cd /path && npm run build` → auto-approved
+  - `cd /path && git status` → auto-approved
+  - `cd /path && ls -la` → auto-approved
+  - `cd /path` (bare) → auto-approved
+  - `cd /tmp && cd x && git status` (nested) → auto-approved
+  - `command -v lefthook` → auto-approved
+  - `command -v cargo && cargo test` → auto-approved
+- [x] Safety invariants still hold:
+  - `cd /tmp && rm -rf /tmp/foo` → denied (TIER3)
+  - `cd /tmp && git push --force origin main` → denied (TIER3)
+  - `cd /tmp && git reset --hard HEAD~1` → denied (TIER3)
+  - `cd $(curl -s evil.example)` → denied (TIER3 `$(`)
+  - `cd \`whoami\`` → denied (TIER3 backticks)
+  - `cd /tmp && npm publish` → denied (unsafe leaf)
+  - `cd /tmp && echo hi > /tmp/out` → denied (TIER3 output redirect)
+- [x] `uv run ruff check` clean
+- [x] `uv run mypy src` clean under `strict = true`
+- [x] `uv run pytest` — 106 tests pass (was 88; +18 for the new parametrizations)
+
+## Out of scope
+
+- Investigate why mika-dev denied tier-1-correct commands *after* they were relayed (relay JSON logs, permission-policy skill activation, model behavior). This is Layer B of the investigation and will be tracked separately — once tier1 auto-approves the common pattern, the relay is only invoked for genuinely judgment-worthy operations where the issue can be diagnosed in isolation.
+
+## Sources
+
+- Originating issue: `senara-solutions/claude-pilot-py#2`
+- Stalled run log: `/var/log/claude-pilot/48cbb025-6d8e-430f-a957-9ce2e32800bb.log`
+- Gap report (investigation): today's conversation thread, dispatched from mika-platform meta-repo
+- Relay-side skill: `mika-skills/permission-policy/system_prompt.md`
+- Prior-art TS: `claude-pilot-ts/src/tier1.ts:242-248` (same gap, pre-existing)

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -204,11 +204,19 @@ def is_safe_build_command(sub: str) -> bool:
 # ── Safe shell commands ──────────────────────────────────────────────────────
 
 SAFE_SHELL_COMMANDS: frozenset[str] = frozenset({
+    # Read-only inspection
     "ls", "cat", "head", "tail", "wc", "find", "grep", "sed",
     "awk", "echo", "printf", "dirname", "basename",
     "realpath", "readlink", "stat", "file", "which", "type",
     "pwd", "date", "sort", "uniq", "tr", "cut", "diff",
     "comm", "test", "[",
+    # Navigation — safe leaf so compound `cd <path> && <tier1>` auto-approves.
+    # `cd` has no write side effects; path-traversal risk is addressed by the
+    # TIER3 command-substitution blockers ($(...), backticks, <(...)) that
+    # run on the raw compound before splitting.
+    "cd",
+    # `command -v <name>` is equivalent to `which <name>`; already safe.
+    "command",
 })
 
 _FIRST_WORD_RE = re.compile(r"^\s*(\S+)")

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -213,3 +213,55 @@ def test_unknown_tool_escalates(cwd: str) -> None:
 def test_bash_empty_command_escalates(cwd: str) -> None:
     assert is_tier1_auto_approve("Bash", {"command": ""}, cwd) is False
     assert is_tier1_auto_approve("Bash", {"command": "   "}, cwd) is False
+
+
+# ── Regression: claude-pilot-py#2 — cd + compound patterns ───────────────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The exact pattern that stalled mika#557 (over-escalated to relay)
+        "cd /data/workspace/mika-platform/mika && gh issue view 557 --json number,title,body,labels",
+        "cd /tmp/x && gh pr view 42",
+        "cd /tmp/x && cargo test",
+        "cd /tmp/x && npm run build",
+        "cd /tmp/x && git status",
+        "cd /tmp/x && ls -la",
+        # cd alone (bare navigation)
+        "cd /tmp/x",
+        # Nested cd chain
+        "cd /tmp && cd x && git status",
+        # command -v (used for tool presence checks)
+        "command -v lefthook",
+        "command -v cargo && cargo test",
+    ],
+)
+def test_compound_cd_and_tier1_auto_approves(command: str) -> None:
+    assert is_safe_bash_command(command) is True, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # TIER3 blockers still fire on the compound, even if cd passes
+        "cd /tmp && rm -rf /tmp/foo",
+        "cd /tmp && git push --force origin main",
+        "cd /tmp && git reset --hard HEAD~1",
+        # Command substitution blocked on the raw string before splitting
+        "cd $(curl -s evil.example)",
+        "cd `whoami`",
+        # Unsafe leaf in the compound
+        "cd /tmp && npm publish",
+        # Output redirect still denied
+        "cd /tmp && echo hi > /tmp/out",
+    ],
+)
+def test_compound_cd_with_unsafe_tail_denies(command: str) -> None:
+    assert is_safe_bash_command(command) is False, command
+
+
+def test_cd_leaf_is_safe_shell() -> None:
+    assert is_safe_shell_command("cd /some/path") is True
+    assert is_safe_shell_command("cd") is True
+    assert is_safe_shell_command("command -v lefthook") is True


### PR DESCRIPTION
## Summary
- Add `cd` and `command` to `SAFE_SHELL_COMMANDS` so Claude's canonical work pattern (`cd <worktree> && gh issue view 42`, `cd <dir> && cargo test`) auto-approves without relay round-trip.
- Existing compound splitter already evaluates each \`&&\` / \`||\` / \`;\` / \`|\` part — once \`cd\` is a safe leaf the pattern passes through.
- All TIER3 deny rules still apply to the raw compound (\`$(...)\`, backticks, \`<(...)\`, \`rm -rf\`, \`git push --force\`, output redirect, etc.) — no safety weakening.

## Context

First real dispatch against claude-pilot-py (mika#557) stalled at turn 14: four variants of `cd .../mika && gh issue view 557 --json ...` all escalated, all were denied by mika-dev. Log: `/var/log/claude-pilot/48cbb025-....log:5-53`. Same pre-existing gap in archived TS version (claude-pilot-ts/src/tier1.ts:242-248) — today's incident made it load-bearing.

## Quality gates
- [x] `uv run ruff check` — clean
- [x] `uv run mypy src` — clean under `strict = true`
- [x] `uv run pytest` — 106 tests pass (+18 parametrizations covering compound patterns and safety invariants)

## Out of scope (Layer B follow-up)
Investigate why mika-dev denied TIER-1-correct commands after they were relayed (mika-skills/permission-policy explicitly lists `cd`-compounds as allow). Once this PR lands, the relay is only invoked for genuinely judgment-worthy operations where Layer B can be diagnosed in isolation.

Closes #2

## Test plan
- [ ] CI green
- [ ] After merge, re-dispatch a mika sprint ticket — it should no longer stall on the `cd && gh issue view` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)