### PR TITLE
fix: recognize SDK tool blocks + group events by message_id (#4, #5)

### DIFF
--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -76,7 +76,7 @@ async def run_agent(
                             task_id=task_id,
                             session_id=session_id,
                             turns=guardrails.turns,
-                            cost_usd=0.0,
+                            cost_usd=None,  # unknown — ResultMessage not yet received
                             duration_ms=duration_ms,
                             termination_reason=reason.detail,
                         )
@@ -97,7 +97,10 @@ async def run_agent(
 
                 if isinstance(message, AssistantMessage):
                     session_id = getattr(message, "session_id", session_id) or session_id
-                    guardrails.on_assistant_message(_content_blocks(message))
+                    guardrails.on_assistant_message(
+                        _content_blocks(message),
+                        message_id=getattr(message, "message_id", None),
+                    )
                     for block in _content_blocks(message):
                         text = _text_of(block)
                         if text:

--- a/src/claude_pilot/cli.py
+++ b/src/claude_pilot/cli.py
@@ -158,7 +158,7 @@ def _emit_fatal(message: str) -> None:
         status="error",
         subtype="fatal",
         turns=0,
-        cost_usd=0.0,
+        cost_usd=None,
         duration_ms=0,
         errors=[message],
     )

--- a/src/claude_pilot/guardrails.py
+++ b/src/claude_pilot/guardrails.py
@@ -48,6 +48,19 @@ class SessionGuardrails:
         self._idle_task: asyncio.Task[None] | None = None
         self._abort_event = asyncio.Event()
         self._abort_reason: GuardrailAbortReason | None = None
+        # Per-turn accumulators for the in-progress turn. The Python claude-agent-sdk
+        # emits one AssistantMessage per *content block* (Thinking, Text, ToolUse...),
+        # all sharing the same `message_id`. A logical turn is the union of all events
+        # carrying the same message_id. Without this grouping, thinking-heavy turns
+        # inflate the stall count (claude-pilot-py#4).
+        self._current_message_id: str | None = None
+        self._current_turn_has_tool: bool = False
+        self._current_turn_text_len: int = 0
+        # Tracks whether we speculatively incremented stall for the current turn
+        # so we can roll it back if a later content block (same message_id) brings
+        # a tool_use.
+        self._stall_incremented_for_current_turn: bool = False
+        self._empty_incremented_for_current_turn: bool = False
         self._reset_idle_timer()
 
     @property
@@ -72,11 +85,57 @@ class SessionGuardrails:
         assert self._abort_reason is not None
         return self._abort_reason
 
-    def on_assistant_message(self, content: list[dict[str, Any]] | Any) -> None:
-        """Called on each assistant message (turn boundary)."""
-        self._turn_count += 1
+    def on_assistant_message(
+        self,
+        content: list[dict[str, Any]] | Any,
+        message_id: str | None = None,
+    ) -> None:
+        """Called on each AssistantMessage from the SDK.
 
-        # Reset idle timer unconditionally on any turn — even empty ones.
+        The Python claude-agent-sdk splits a single Claude turn into one event per
+        content block, all sharing the same `message_id`. We group by message_id
+        to count logical turns correctly (claude-pilot-py#4). When `message_id` is
+        None — older SDKs or callers without the field — each call counts as its
+        own turn (backward-compatible).
+
+        Stall/empty are evaluated speculatively at turn start (so a 5-turn run of
+        text-only events still trips at turn 5, not turn 6). When a later content
+        block in the same turn brings a `tool_use`, the speculative increment is
+        rolled back.
+        """
+        blocks = content if isinstance(content, list) else []
+        has_tool_use = any(_block_type(b) == "tool_use" for b in blocks)
+        text_len = sum(
+            len((_block_text(b) or "").strip()) for b in blocks if _block_type(b) == "text"
+        )
+
+        is_continuation = (
+            message_id is not None and message_id == self._current_message_id
+        )
+
+        if is_continuation:
+            # Same logical turn — accumulate evidence about its productivity.
+            self._current_turn_text_len += text_len
+            if has_tool_use and not self._current_turn_has_tool:
+                # tool_use just arrived in this turn — roll back any speculative
+                # stall/empty increments we made when the turn started no-tool.
+                self._current_turn_has_tool = True
+                if self._stall_incremented_for_current_turn:
+                    self._consecutive_stall_turns = max(0, self._consecutive_stall_turns - 1)
+                    self._stall_incremented_for_current_turn = False
+                if self._empty_incremented_for_current_turn:
+                    self._consecutive_empty_turns = max(0, self._consecutive_empty_turns - 1)
+                    self._empty_incremented_for_current_turn = False
+            return
+
+        # New turn boundary.
+        self._turn_count += 1
+        self._current_message_id = message_id
+        self._current_turn_has_tool = has_tool_use
+        self._current_turn_text_len = text_len
+        self._stall_incremented_for_current_turn = False
+        self._empty_incremented_for_current_turn = False
+        # Reset idle timer on each new turn — even empty ones.
         # Stall/empty detection handles degenerate-content cases; idle timeout
         # is reserved for "nothing at all" from the SDK.
         self._reset_idle_timer()
@@ -84,16 +143,15 @@ class SessionGuardrails:
         if self._turn_count < self._config.minTurnsBeforeDetection:
             return
 
-        blocks = content if isinstance(content, list) else []
-        has_tool_use = any(_block_type(b) == "tool_use" for b in blocks)
-
         if has_tool_use:
             self._consecutive_stall_turns = 0
             self._consecutive_empty_turns = 0
             return
 
-        # No tool use → stall
+        # No tool use yet → speculative stall increment (may be rolled back if
+        # a same-message_id continuation brings tool_use).
         self._consecutive_stall_turns += 1
+        self._stall_incremented_for_current_turn = True
         if (
             self._config.stallThreshold > 0
             and self._consecutive_stall_turns >= self._config.stallThreshold
@@ -105,13 +163,9 @@ class SessionGuardrails:
             return
 
         # Empty / trivial text
-        total_text_len = sum(
-            len((_block_text(b) or "").strip())
-            for b in blocks
-            if _block_type(b) == "text"
-        )
-        if total_text_len < 10:
+        if text_len < 10:
             self._consecutive_empty_turns += 1
+            self._empty_incremented_for_current_turn = True
             if (
                 self._config.emptyResponseThreshold > 0
                 and self._consecutive_empty_turns >= self._config.emptyResponseThreshold
@@ -177,13 +231,29 @@ class SessionGuardrails:
         self._abort_event.set()
 
 
+_SDK_BLOCK_CLASS_TO_TYPE: dict[str, str] = {
+    "TextBlock": "text",
+    "ThinkingBlock": "thinking",
+    "ToolUseBlock": "tool_use",
+    "ToolResultBlock": "tool_result",
+}
+
+
 def _block_type(block: Any) -> str | None:
     """Extract a content-block discriminator that works for both dict-shaped
-    SDK messages and dataclass / object instances."""
+    SDK messages and dataclass / object instances.
+
+    The claude-agent-sdk dataclasses (TextBlock, ThinkingBlock, ToolUseBlock) do
+    NOT carry a `type` attribute — the wire-format `type` field is consumed by
+    the parser. We map class names back to the Anthropic API type strings.
+    """
     if isinstance(block, dict):
         t = block.get("type")
         return t if isinstance(t, str) else None
-    return getattr(block, "type", None) if isinstance(getattr(block, "type", None), str) else type(block).__name__.lower().replace("block", "")
+    t = getattr(block, "type", None)
+    if isinstance(t, str):
+        return t
+    return _SDK_BLOCK_CLASS_TO_TYPE.get(type(block).__name__)
 
 
 def _block_text(block: Any) -> str | None:

--- a/src/claude_pilot/types.py
+++ b/src/claude_pilot/types.py
@@ -106,7 +106,10 @@ class ResultJson(BaseModel):
     task_id: str | None = None
     session_id: str | None = None
     turns: int
-    cost_usd: float
+    # Unknown when the session terminated before a ResultMessage arrived (e.g.
+    # guardrail trip, fatal CLI error). Serialized as absent field via
+    # `exclude_none` so downstream handlers parse it as unknown.
+    cost_usd: float | None = None
     duration_ms: int
     errors: list[str] | None = None
     termination_reason: str | None = None

--- a/src/claude_pilot/ui.py
+++ b/src/claude_pilot/ui.py
@@ -43,9 +43,10 @@ def log_text(text: str) -> None:
     write_log(f"{DIM}{text}{RESET}")
 
 
-def log_done(turns: int, cost_usd: float, duration_ms: int) -> None:
+def log_done(turns: int, cost_usd: float | None, duration_ms: int) -> None:
     secs = f"{duration_ms / 1000:.0f}"
-    _log(f"\n{GREEN}[done]{RESET} Success | {turns} turns | ${cost_usd:.2f} | {secs}s")
+    cost_str = f"${cost_usd:.2f}" if cost_usd is not None else "$?"
+    _log(f"\n{GREEN}[done]{RESET} Success | {turns} turns | {cost_str} | {secs}s")
 
 
 def log_error(subtype: str, errors: list[str]) -> None:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,138 @@
+"""Guardrail tests — turn boundary detection across SDK content-block events.
+
+The Python claude-agent-sdk emits one AssistantMessage per content block (Thinking,
+Text, ToolUse, ...), all sharing the same `message_id` for a single logical Claude
+turn. The TS SDK emits one SDKAssistantMessage per logical turn with all blocks
+inside. The guardrail must group same-message_id events into a single turn or it
+will mis-count stalls — exploding stall count for thinking-heavy turns and tripping
+the abort prematurely (claude-pilot-py#4).
+"""
+
+from __future__ import annotations
+
+import pytest
+from claude_agent_sdk.types import TextBlock, ThinkingBlock, ToolUseBlock
+
+from claude_pilot.guardrails import SessionGuardrails
+from claude_pilot.types import ResolvedGuardrailConfig
+
+
+def _config(stall: int = 5, min_turns: int = 0) -> ResolvedGuardrailConfig:
+    return ResolvedGuardrailConfig(
+        maxTurns=200,
+        maxBudgetUsd=0.0,
+        stallThreshold=stall,
+        emptyResponseThreshold=5,
+        idleTimeoutMs=300_000,
+        minTurnsBeforeDetection=min_turns,
+    )
+
+
+def _think(text: str = "planning") -> ThinkingBlock:
+    return ThinkingBlock(thinking=text, signature="sig")
+
+
+def _text(t: str = "ok") -> TextBlock:
+    return TextBlock(text=t)
+
+
+def _tool(name: str = "Bash", input_data: dict | None = None) -> ToolUseBlock:
+    return ToolUseBlock(id="t1", name=name, input=input_data or {"command": "ls"})
+
+
+@pytest.fixture
+def guardrails() -> SessionGuardrails:
+    """Fresh guardrail with stall=5, no warmup."""
+    return SessionGuardrails(_config())
+
+
+# ── Turn-boundary tests (claude-pilot-py#4) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_consecutive_blocks_with_same_message_id_count_as_one_turn(
+    guardrails: SessionGuardrails,
+) -> None:
+    """The SDK splits one Claude turn across multiple AssistantMessage events
+    sharing the same message_id (Thinking, Text, ToolUse). The guardrail must
+    treat them as ONE turn."""
+    msg_id = "msg_abc"
+    # Same-msg_id sequence: thinking → text → tool_use (all part of turn 1)
+    guardrails.on_assistant_message([_think()], message_id=msg_id)
+    guardrails.on_assistant_message([_text("here is the plan")], message_id=msg_id)
+    guardrails.on_assistant_message([_tool()], message_id=msg_id)
+    assert guardrails.turns == 1, "All same-message_id events form one turn"
+    assert not guardrails.aborted
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_blocks_within_a_turn_do_not_inflate_stall(
+    guardrails: SessionGuardrails,
+) -> None:
+    """A turn containing thinking + text + tool_use should reset the stall
+    counter once. Currently the buggy code increments stall for the thinking
+    sub-event then text sub-event, then resets on tool_use — net wrong if any
+    sub-event is missed."""
+    # Five complete turns, each: thinking → text → tool_use (same msg_id within turn)
+    for i in range(5):
+        mid = f"msg_{i}"
+        guardrails.on_assistant_message([_think()], message_id=mid)
+        guardrails.on_assistant_message([_text(f"step {i}")], message_id=mid)
+        guardrails.on_assistant_message([_tool()], message_id=mid)
+    # Five productive turns: never stall
+    assert guardrails.turns == 5
+    assert not guardrails.aborted, "Productive thinking+text+tool turns must not stall"
+
+
+@pytest.mark.asyncio
+async def test_text_only_distinct_turns_still_trigger_stall(
+    guardrails: SessionGuardrails,
+) -> None:
+    """Preserve existing behavior: 5 text-only turns with DIFFERENT message_ids
+    indicate Claude has stopped using tools — stall trip is correct."""
+    for i in range(5):
+        guardrails.on_assistant_message([_text(f"narrating turn {i}")], message_id=f"msg_{i}")
+    assert guardrails.aborted
+    assert guardrails.abort_reason is not None
+    assert guardrails.abort_reason.guardrail == "stall_detected"
+
+
+@pytest.mark.asyncio
+async def test_message_id_change_marks_new_turn_boundary(
+    guardrails: SessionGuardrails,
+) -> None:
+    """Text-only across two different msg_ids = 2 turns, not 1."""
+    guardrails.on_assistant_message([_text("first")], message_id="msg_1")
+    guardrails.on_assistant_message([_text("second")], message_id="msg_2")
+    assert guardrails.turns == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_message_id_falls_back_to_per_message_turn_count(
+    guardrails: SessionGuardrails,
+) -> None:
+    """Defensive: if the SDK doesn't provide message_id (older versions, edge cases),
+    each call counts as its own turn. Backward-compatible with current behavior."""
+    guardrails.on_assistant_message([_text("a")])  # no message_id
+    guardrails.on_assistant_message([_text("b")])
+    assert guardrails.turns == 2
+
+
+# ── ToolUseBlock recognition (latent bug from the same root cause) ───────────
+
+
+@pytest.mark.asyncio
+async def test_sdk_tool_use_block_dataclass_is_recognized(
+    guardrails: SessionGuardrails,
+) -> None:
+    """SDK dataclass ToolUseBlock has no `type` attribute — the guardrail must
+    still recognize it and reset the stall counter. Regression guard for the
+    class-name fallback returning `tooluse` (without underscore) which never
+    matched `tool_use`."""
+    # Prime stall counter with text-only turns
+    guardrails.on_assistant_message([_text("a"), _text("b")], message_id="msg_1")
+    guardrails.on_assistant_message([_text("c")], message_id="msg_2")
+    assert guardrails._consecutive_stall_turns >= 1
+    # Now a tool turn must reset it
+    guardrails.on_assistant_message([_tool()], message_id="msg_3")
+    assert guardrails._consecutive_stall_turns == 0

--- a/tests/test_result_cost.py
+++ b/tests/test_result_cost.py
@@ -1,0 +1,68 @@
+"""ResultJson cost_usd semantics — claude-pilot-py#5.
+
+When a session terminates with no cost information available (guardrail trip
+before ResultMessage arrives, or fatal CLI error), cost_usd must be `None`
+rather than a misleading `0.0`. The handler in mika-skills/claude-pilot parses
+cost via `jq -r '.cost_usd // empty'` so absent/None is handled as unknown.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from claude_pilot.types import ResultJson
+
+
+def test_result_json_accepts_none_cost() -> None:
+    r = ResultJson(
+        status="terminated",
+        subtype="stall_detected",
+        turns=14,
+        cost_usd=None,
+        duration_ms=71000,
+    )
+    assert r.cost_usd is None
+
+
+def test_result_json_excludes_none_cost_from_serialized_line() -> None:
+    """`to_line()` uses exclude_none — None cost becomes absent field downstream,
+    which the shell handler parses as empty string (unknown)."""
+    r = ResultJson(
+        status="terminated",
+        subtype="stall_detected",
+        turns=14,
+        cost_usd=None,
+        duration_ms=71000,
+    )
+    line = r.to_line()
+    parsed = json.loads(line)
+    assert "cost_usd" not in parsed
+
+
+def test_result_json_preserves_real_cost() -> None:
+    r = ResultJson(
+        status="success",
+        subtype="success",
+        turns=57,
+        cost_usd=3.847488349999999,
+        duration_ms=717835,
+    )
+    parsed = json.loads(r.to_line())
+    assert parsed["cost_usd"] == pytest.approx(3.847488349999999)
+
+
+def test_result_json_rejects_zero_confused_with_unknown() -> None:
+    """0.0 is a valid cost (rare but possible on cached-only runs). We keep
+    the type as float | None so None means unknown and 0.0 means genuinely zero."""
+    r = ResultJson(
+        status="success",
+        subtype="success",
+        turns=1,
+        cost_usd=0.0,
+        duration_ms=100,
+    )
+    parsed = json.loads(r.to_line())
+    # exclude_none leaves 0.0 in the output (0 is not None)
+    assert parsed["cost_usd"] == 0.0


### PR DESCRIPTION
## Summary

Fixes the production stall bug and the misleading `cost_usd: 0.0` on guardrail-terminated runs.

## Root causes

Two independent bugs, same symptom (every claude-pilot run terminated at 14 turns, $0 cost, zero commits):

1. **`_block_type()` didn't recognize SDK dataclass blocks.** `claude_agent_sdk.types.ToolUseBlock` has no `type` attribute, so the class-name fallback ran and stripped `"Block"` → `"tooluse"`. The check `_block_type(b) == "tool_use"` never matched. Every tool call was classified as not-a-tool, so every turn counted as a stall.

2. **Python SDK emits one AssistantMessage per content block.** A single Claude turn of "thinking → text → tool_use" arrived as 3 AssistantMessage events sharing one `message_id`. The guardrail treated each as a separate turn, inflating stall count for thinking-heavy turns.

## Fix

- Explicit `SDK class name → API type string` map in `_block_type`
- `on_assistant_message(content, message_id=None)` now groups events by `message_id`. Speculative stall increment on turn start is rolled back when a later same-`message_id` event brings a `tool_use`. Backward-compatible when `message_id` is `None` (each call = own turn)
- `agent.py` passes `message.message_id` through to the guardrail

## Bonus: `cost_usd` unknown vs zero (#5)

- `ResultJson.cost_usd: float | None` (was `float`). `None` means unknown (guardrail trip or fatal CLI error — `ResultMessage` not received). `exclude_none` keeps the field out of the JSON line; the shell handler's `jq '.cost_usd // empty'` handles absent fields correctly.
- `log_done` renders `$?` when cost is unknown.

## Tests

- **6 new guardrail tests** — message_id grouping, productive thinking+text+tool turns don't stall, distinct-turn text-only runs still stall (regression), SDK-dataclass tool recognition, None/missing message_id fallback
- **4 new ResultJson tests** — None accepted, None excluded from serialized line, real cost preserved, 0.0 vs unknown distinction
- **116/116 pass**, `ruff check` clean, `mypy src` clean

## End-to-end smoke test

Ran `claude-pilot --no-relay --task-id test-... -- "run ls via Bash, then say 'done'"` against a fresh git repo:

```
[done] Success | 2 turns | $0.12 | 5s
{"status":"success","cost_usd":0.117,"turns":2}
```

Real cost, real success, no stall trip.

## Test plan

- [ ] Re-dispatch a blocked sprint ticket (mika#557, #334, or #513) through mika-dev → claude-pilot → verify PR produced end-to-end
- [ ] Confirm the downstream handler (`mika-skills/claude-pilot/handlers/run.sh`) parses the new ResultJson shape (cost_usd may be absent on terminated runs)
- [ ] Watch for any other SDK block types added in future (e.g. new code paths) — the class-name map needs updating when the SDK adds new blocks

Closes #4
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)