### PR TITLE
feat(claude-pilot): detect pipeline-incomplete sessions via CLAUDE_PILOT_REQUIRE_PR (mika#940)

### DIFF
--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -9,6 +9,7 @@ to stdout when the session ends (success, error, or guardrail abort).
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import time
 from typing import Any, Literal
@@ -124,6 +125,33 @@ async def run_agent(
                         else "error"
                     )
 
+                    # mika#940: pipeline-completion contract. If
+                    # CLAUDE_PILOT_REQUIRE_PR=1 (set by dispatch-lib for
+                    # dev-pilot sessions) and the session completed
+                    # "successfully" but never invoked `gh pr create`,
+                    # override to a `pipeline_incomplete` failure shape.
+                    # Catches the premature-EndTurn family observed on
+                    # 2026-05-02 (mika#931, #938, #939) where the model
+                    # emits `[done] Success` after Edit/Compound phases
+                    # before reaching git push + gh pr create. Defense
+                    # in depth with dispatch-lib's actual PR-existence
+                    # check on GitHub.
+                    termination_reason: str | None = (
+                        f"SDK limit reached: {subtype}" if is_sdk_termination else None
+                    )
+                    require_pr = os.environ.get("CLAUDE_PILOT_REQUIRE_PR", "").lower() in (
+                        "1",
+                        "true",
+                    )
+                    if status == "success" and require_pr and not guardrails.pr_created:
+                        subtype = "pipeline_incomplete"
+                        status = "error"
+                        termination_reason = (
+                            "Session completed without 'gh pr create' Bash call. "
+                            "CLAUDE_PILOT_REQUIRE_PR=1 was set. "
+                            "Work may be stranded in worktree."
+                        )
+
                     result = ResultJson(
                         status=status,
                         subtype=subtype,
@@ -133,9 +161,7 @@ async def run_agent(
                         cost_usd=message.total_cost_usd or 0.0,
                         duration_ms=message.duration_ms,
                         errors=errors,
-                        termination_reason=(
-                            f"SDK limit reached: {subtype}" if is_sdk_termination else None
-                        ),
+                        termination_reason=termination_reason,
                     )
                     _emit_result(result)
 

--- a/src/claude_pilot/guardrails.py
+++ b/src/claude_pilot/guardrails.py
@@ -61,6 +61,13 @@ class SessionGuardrails:
         # a tool_use.
         self._stall_incremented_for_current_turn: bool = False
         self._empty_incremented_for_current_turn: bool = False
+        # mika#940: track whether a `gh pr create` Bash invocation was observed
+        # in this session. Read by agent.py post-ResultMessage when
+        # CLAUDE_PILOT_REQUIRE_PR=1 (set by dispatch-lib for dev-pilot sessions);
+        # absence flips ResultJson.subtype to `pipeline_incomplete` and exits 1.
+        # Detection: any ToolUseBlock where name=="Bash" and command contains
+        # "gh pr create" (substring match, false-positives accepted per plan).
+        self._pr_created: bool = False
         self._reset_idle_timer()
 
     @property
@@ -70,6 +77,13 @@ class SessionGuardrails:
     @property
     def turns(self) -> int:
         return self._turn_count
+
+    @property
+    def pr_created(self) -> bool:
+        """True if any Bash tool_use with `gh pr create` substring was observed
+        this session. mika#940 pipeline-completion contract — read by agent.py
+        post-ResultMessage when CLAUDE_PILOT_REQUIRE_PR=1."""
+        return self._pr_created
 
     @property
     def aborted(self) -> bool:
@@ -108,6 +122,23 @@ class SessionGuardrails:
         text_len = sum(
             len((_block_text(b) or "").strip()) for b in blocks if _block_type(b) == "text"
         )
+
+        # mika#940: PR-creation detection. Scan tool_use blocks for Bash
+        # invocations whose command substring includes `gh pr create`. Set
+        # once and sticky for the rest of the session. False positives on
+        # `gh pr create --help` or string-literal occurrences are accepted
+        # per plan §Risks 1 — defense in depth from dispatch-lib's actual
+        # PR-existence check on GitHub.
+        if not self._pr_created:
+            for block in blocks:
+                if _block_type(block) != "tool_use":
+                    continue
+                if _tool_use_name(block) != "Bash":
+                    continue
+                command = _tool_use_command(block)
+                if command and "gh pr create" in command:
+                    self._pr_created = True
+                    break
 
         is_continuation = (
             message_id is not None and message_id == self._current_message_id
@@ -262,3 +293,34 @@ def _block_text(block: Any) -> str | None:
         return text if isinstance(text, str) else None
     text = getattr(block, "text", None)
     return text if isinstance(text, str) else None
+
+
+def _tool_use_name(block: Any) -> str | None:
+    """Extract tool name from a tool_use block (mika#940).
+
+    Mirrors `_block_type` / `_block_text` dual-shape handling for dict-shaped
+    SDK messages and dataclass / object instances (ToolUseBlock).
+    """
+    if isinstance(block, dict):
+        name = block.get("name")
+        return name if isinstance(name, str) else None
+    name = getattr(block, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _tool_use_command(block: Any) -> str | None:
+    """Extract the `command` field from a Bash tool_use block's input (mika#940).
+
+    The SDK normalizes Bash tool inputs to `{"command": "..."}` (string),
+    matching the documented schema. Returns None if input is missing or not a
+    string command.
+    """
+    input_obj: Any
+    if isinstance(block, dict):
+        input_obj = block.get("input")
+    else:
+        input_obj = getattr(block, "input", None)
+    if not isinstance(input_obj, dict):
+        return None
+    command = input_obj.get("command")
+    return command if isinstance(command, str) else None

--- a/src/claude_pilot/types.py
+++ b/src/claude_pilot/types.py
@@ -97,7 +97,21 @@ PilotResponse = PilotResponseAllow | PilotResponseDeny | PilotResponseAnswer
 
 class ResultJson(BaseModel):
     """Single-line JSON written to stdout on completion. Parsed by
-    mika-skills/claude-pilot/handlers/run.sh."""
+    mika-skills/claude-pilot/handlers/run.sh.
+
+    Subtype values:
+        - "success" — SDK ResultMessage reported success.
+        - "early_exit_zero_action" — fewer than CLAUDE_PILOT_MIN_TOOL_CALLS
+          tool calls observed; session re-prompted or terminated.
+        - "pipeline_incomplete" (mika#940) — CLAUDE_PILOT_REQUIRE_PR=1 set
+          (dev-pilot sessions via dispatch-lib) and the session completed
+          successfully but never invoked `gh pr create`. Indicates the
+          premature-EndTurn family — model emits `[done] Success` after
+          Edit/Compound phases without reaching git push + gh pr create.
+          Work may be stranded in the worktree.
+        - SDK termination subtypes (e.g. "error_max_turns", "error_during_execution")
+          — see SDK_TERMINATION_SUBTYPES in agent.py.
+    """
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -136,3 +136,87 @@ async def test_sdk_tool_use_block_dataclass_is_recognized(
     # Now a tool turn must reset it
     guardrails.on_assistant_message([_tool()], message_id="msg_3")
     assert guardrails._consecutive_stall_turns == 0
+
+
+# ── mika#940: pipeline-completion PR-detection ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pr_created_starts_false(guardrails: SessionGuardrails) -> None:
+    """A fresh SessionGuardrails has pr_created == False (mika#940)."""
+    assert guardrails.pr_created is False
+
+
+@pytest.mark.asyncio
+async def test_pr_created_set_by_bash_gh_pr_create(
+    guardrails: SessionGuardrails,
+) -> None:
+    """A Bash tool_use containing `gh pr create` flips pr_created to True
+    (mika#940). The dispatch-lib pipeline-completion contract reads this
+    after CLAUDE_PILOT_REQUIRE_PR=1 sessions to detect premature-EndTurn."""
+    guardrails.on_assistant_message(
+        [_tool(name="Bash", input_data={"command": "gh pr create --fill"})],
+        message_id="msg_1",
+    )
+    assert guardrails.pr_created is True
+
+
+@pytest.mark.asyncio
+async def test_pr_created_not_set_by_other_bash(
+    guardrails: SessionGuardrails,
+) -> None:
+    """Bash tool_use without `gh pr create` substring does NOT flip
+    pr_created (mika#940). False-negative coverage."""
+    guardrails.on_assistant_message(
+        [_tool(name="Bash", input_data={"command": "git add -A && git commit -m x"})],
+        message_id="msg_1",
+    )
+    assert guardrails.pr_created is False
+
+
+@pytest.mark.asyncio
+async def test_pr_created_not_set_by_other_tool(
+    guardrails: SessionGuardrails,
+) -> None:
+    """A non-Bash tool_use (e.g. Edit) does NOT flip pr_created even if its
+    input string contains `gh pr create` (mika#940). Name-guard coverage."""
+    guardrails.on_assistant_message(
+        [_tool(name="Edit", input_data={"command": "gh pr create"})],
+        message_id="msg_1",
+    )
+    assert guardrails.pr_created is False
+
+
+@pytest.mark.asyncio
+async def test_pr_created_is_sticky(guardrails: SessionGuardrails) -> None:
+    """Once pr_created flips True, subsequent turns without `gh pr create`
+    do not reset it (mika#940). The PR-creation contract is per-session,
+    not per-turn."""
+    guardrails.on_assistant_message(
+        [_tool(name="Bash", input_data={"command": "gh pr create --fill"})],
+        message_id="msg_1",
+    )
+    assert guardrails.pr_created is True
+    guardrails.on_assistant_message(
+        [_tool(name="Bash", input_data={"command": "echo done"})],
+        message_id="msg_2",
+    )
+    assert guardrails.pr_created is True
+
+
+@pytest.mark.asyncio
+async def test_pr_created_substring_match(guardrails: SessionGuardrails) -> None:
+    """Substring match is sufficient (mika#940 plan §Risks 1 accepts false
+    positives). `gh pr create` embedded mid-command flips the flag."""
+    guardrails.on_assistant_message(
+        [
+            _tool(
+                name="Bash",
+                input_data={
+                    "command": "cd worktree && gh pr create --title foo && cd .."
+                },
+            )
+        ],
+        message_id="msg_1",
+    )
+    assert guardrails.pr_created is True


### PR DESCRIPTION
Companion PR: senara-solutions/mika (will be opened next)

Implements source-level detection layer (Unit 2) of mika#940. See companion mika PR for the consumption layer (Unit 1 + Unit 3).

## Summary

Adds a session-completion contract for dev-pilot dispatches:
- When `CLAUDE_PILOT_REQUIRE_PR=1` is set (by mika dispatch-lib's dev-pilot case branch), claude-pilot tracks whether any Bash tool_use containing `gh pr create` was observed.
- If the session reports `status=success` but `pr_created` is False, the `ResultJson` `subtype` flips to `pipeline_incomplete`, `status` flips to `error`, and exit code is 1.

## Why

Catches the premature-EndTurn family observed on 2026-05-02 (mika#931, #938, #939) and confirmed N=6+ on 2026-05-15 (mika#1126 alone burned $3.67 across 2 attempts). The model emits `[done] Success` after Edit/Compound phases without reaching `git push` + `gh pr create`. Work strands in worktree as live edits.

## Changes

- `guardrails.py`: `SessionGuardrails` gains `_pr_created` flag + `.pr_created` property + tool_use scanning in `on_assistant_message`. Helper functions `_tool_use_name` / `_tool_use_command` mirror existing `_block_type` / `_block_text` dual-shape handling (dict + SDK dataclass).
- `agent.py`: post-`ResultMessage` check reads `CLAUDE_PILOT_REQUIRE_PR` env var and `guardrails.pr_created`; overrides subtype + status + termination_reason on pipeline_incomplete.
- `types.py`: `ResultJson` docstring documents the new subtype value.

## Tests

- 6 new `test_guardrails` cases covering: starts-False, Bash positive, other-Bash negative, non-Bash negative, sticky, substring-match.
- Full test suite: **122 passed** (was 116 + 6 new).
- `ruff check` clean.

## Plan

`mika-platform/docs/plans/2026-05-14-004-fix-940-pipeline-truncation-detection-plan.md` (architect-validated — mika-arch second-pass ITERATE treated as ESCALATE per two-pass-max rule; remaining Phase 0 verbosity concern addressed proactively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>