### PR TITLE
fix(agent): log thinking-only turns to surface drift (#10)

### DIFF
--- a/docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md
+++ b/docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md
@@ -18,130 +18,300 @@ When the underlying model produces a logical turn containing only `ThinkingBlock
 - Prior agent.py bug fixes were filed here (cpp#4 — thinking-block stall miscount; cpp#5 — cost reporting on guardrail termination).
 - mika#1142 was the original filing; closed with a pointer to this issue.
 
-## Root cause (verified by reading code on this branch)
+---
 
-`src/claude_pilot/agent.py:99-109`:
+## Phase 0 — Pin (load-bearing source state)
+
+**Base commit:** `e00565742f64f5d0a16d11908253f1a64b726268` (`origin/main` at grooming time — `feat(claude-pilot): detect pipeline-incomplete sessions via CLAUDE_PILOT_REQUIRE_PR (mika#940) (#9)`).
+
+All design claims below are pinned against this SHA. If main moves before implementation, the implementer must re-verify each pin or rebase the plan.
+
+### Pin A — `SessionGuardrails.on_assistant_message` and turns-increment site
+
+`src/claude_pilot/guardrails.py:102-172` (verbatim, abbreviated to the load-bearing lines):
 
 ```python
-if isinstance(message, AssistantMessage):
-    session_id = getattr(message, "session_id", session_id) or session_id
-    guardrails.on_assistant_message(
-        _content_blocks(message),
-        message_id=getattr(message, "message_id", None),
+def on_assistant_message(
+    self,
+    content: list[dict[str, Any]] | Any,
+    message_id: str | None = None,
+) -> None:
+    """..."""
+    blocks = content if isinstance(content, list) else []
+    has_tool_use = any(_block_type(b) == "tool_use" for b in blocks)
+    text_len = sum(
+        len((_block_text(b) or "").strip()) for b in blocks if _block_type(b) == "text"
     )
-    for block in _content_blocks(message):
-        text = _text_of(block)
-        if text:
-            log_text(text)
-    continue
+
+    # mika#940: PR-creation detection (sticky)
+    if not self._pr_created:
+        for block in blocks:
+            if _block_type(block) != "tool_use": continue
+            if _tool_use_name(block) != "Bash": continue
+            command = _tool_use_command(block)
+            if command and "gh pr create" in command:
+                self._pr_created = True
+                break
+
+    is_continuation = (
+        message_id is not None and message_id == self._current_message_id
+    )
+
+    if is_continuation:
+        # Same logical turn — accumulate.
+        self._current_turn_text_len += text_len
+        if has_tool_use and not self._current_turn_has_tool:
+            self._current_turn_has_tool = True
+            if self._stall_incremented_for_current_turn:
+                self._consecutive_stall_turns = max(0, self._consecutive_stall_turns - 1)
+                self._stall_incremented_for_current_turn = False
+            if self._empty_incremented_for_current_turn:
+                self._consecutive_empty_turns = max(0, self._consecutive_empty_turns - 1)
+                self._empty_incremented_for_current_turn = False
+        return
+
+    # New turn boundary.
+    self._turn_count += 1                  # <-- INCREMENT HAPPENS HERE, BEFORE block scanning of new turn
+    self._current_message_id = message_id
+    self._current_turn_has_tool = has_tool_use
+    self._current_turn_text_len = text_len
+    # ...stall/empty bookkeeping for the new turn follows
 ```
 
-`_text_of` (lines 232-241) returns text only when `block.type == "text"`. `ThinkingBlock` has `type="thinking"` and exposes its content via the `thinking` field, not `text` (verified in `tests/test_guardrails.py:31-32` — `ThinkingBlock(thinking=text, signature="sig")`). Pure-thinking turns therefore loop through `_content_blocks` without emitting any log line.
+**Confirmed ordering** (load-bearing for F3-resolution and the design below): `self._turn_count += 1` runs at the new-turn boundary, BEFORE the new turn's content is analyzed for stall/empty. Therefore inside `on_assistant_message`, at the moment we detect a boundary, `self._turn_count` already names the NEW turn; the just-closed turn is `self._turn_count - 1`.
 
-Tool-use blocks are also `_text_of`-empty, but they are logged through the permission-handler path (`log_tool_request` / `log_tool` / `log_relay_send` / `log_relay_recv` in `ui.py`). The diagnostic gap is specifically **text-less and tool-less** AssistantMessages.
+### Pin B — `SessionGuardrails` public interface
+
+`src/claude_pilot/guardrails.py:73-100`:
+
+| Member | Kind | Used in agent.py? |
+|---|---|---|
+| `config` | property → `ResolvedGuardrailConfig` | yes (line 48) |
+| `turns` | property → `int` | yes (line 79) |
+| `pr_created` | property → `bool` | yes (line 146) |
+| `aborted` | property → `bool` | no |
+| `abort_reason` | property → `GuardrailAbortReason \| None` | yes (line 70) |
+| `wait_aborted()` | async → `GuardrailAbortReason` | yes (line 66) |
+| `on_assistant_message(content, message_id)` | method → `None` | yes (line 101) |
+| `pause_idle_timer()` | method | called by `permissions.py` |
+| `resume_idle_timer()` | method | called by `permissions.py` |
+| `dispose()` | method | yes (line 181) |
+
+**No turn-boundary signal is currently exposed.** The internal state — `_current_message_id`, `_current_turn_has_tool`, `_current_turn_text_len` — is private. This is F2's design input: there IS no observable boundary signal today, so a fix that needs one must either (a) add one (changing the guardrail API), or (b) duplicate the detection in agent.py (F2's BLOCKING concern).
+
+**This plan picks (a)** — change `on_assistant_message` to return `TurnBoundaryEvent | None`. Rationale in F2-resolution below.
+
+### Pin C — `run_agent` AssistantMessage handling loop
+
+`src/claude_pilot/agent.py:99-110` (verbatim):
+
+```python
+                if isinstance(message, AssistantMessage):
+                    session_id = getattr(message, "session_id", session_id) or session_id
+                    guardrails.on_assistant_message(
+                        _content_blocks(message),
+                        message_id=getattr(message, "message_id", None),
+                    )
+                    for block in _content_blocks(message):
+                        text = _text_of(block)
+                        if text:
+                            log_text(text)
+                    continue
+```
+
+**Confirmed:** the only "logged content" path inside the AssistantMessage branch is `log_text(text)` for text blocks. Tool calls are logged elsewhere (via `permissions.py` → `log_tool_request` / `log_relay_send` / `log_relay_recv` / `log_tool`). So `prev_turn_logged_content` (post-F2 resolution: `was_silent` flag on the boundary event) only needs to consider text-emitted plus tool-use observed.
+
+### Pin D — `_text_of` and `_content_blocks`
+
+`src/claude_pilot/agent.py:226-241` (verbatim):
+
+```python
+def _content_blocks(message: AssistantMessage) -> list[Any]:
+    msg = getattr(message, "message", message)
+    content = getattr(msg, "content", None) or getattr(message, "content", None)
+    return content if isinstance(content, list) else []
+
+
+def _text_of(block: Any) -> str | None:
+    if isinstance(block, dict):
+        if block.get("type") == "text":
+            text = block.get("text")
+            return text if isinstance(text, str) else None
+        return None
+    if getattr(block, "type", None) == "text":
+        text = getattr(block, "text", None)
+        return text if isinstance(text, str) else None
+    return None
+```
+
+`_text_of` returns text ONLY when `block.type == "text"`. `ThinkingBlock`'s content is in `block.thinking`, not `block.text`, and its type discriminates as `"thinking"` (via `_SDK_BLOCK_CLASS_TO_TYPE` in `guardrails.py:265-271`). Confirms the root cause.
+
+---
 
 ## Scope (deliberately narrow per ticket Option A)
 
-The ticket explicitly endorses Option A as sufficient: *"once the operator sees `thinking-only` for 20 turns, the failure shape is obvious."* This plan ships Option A only — one marker line per logical thinking-only turn. Option B (per-block content dump or block-kind summary) is deferred to a follow-up ticket if Option A turns out to be too thin in practice; first instance of "I needed more than the count" will reopen the design.
+The ticket explicitly endorses Option A as sufficient: *"once the operator sees `thinking-only` for 20 turns, the failure shape is obvious."* This plan ships Option A only — one marker line per logical turn that produced no text and no tool calls. Option B (per-block content dump or block-kind summary) is deferred to a follow-up ticket if Option A turns out to be too thin in practice; first instance of "I needed more than the count" will reopen the design.
 
 Per `feedback_implementation_scope_bundling.md` — no silent scope expansion.
 
-## Design
+---
 
-### One marker per logical turn, not per AssistantMessage
+## Design (post-iteration v2)
 
-The Python `claude-agent-sdk` splits one logical Claude turn into N `AssistantMessage` events, one per content block, all sharing the same `message_id`. A naive "emit when this AssistantMessage has no text and no tool_use" check would spam N markers for a turn with N thinking blocks. `guardrails.py:102-119` already documents this grouping (it was the root cause of cpp#4).
+### F2 resolution — single boundary owner: `SessionGuardrails`
 
-The fix tracks the same `message_id` boundary in `agent.py` and emits the marker exactly once per logical turn, at the moment a new turn boundary is observed (or at session end via `ResultMessage`).
+The first-pass plan duplicated `message_id` boundary detection in `agent.py`, recreating exactly the divergence cpp#4 was meant to prevent. The corrected design keeps boundary detection inside `SessionGuardrails` and exposes the result via the return value of `on_assistant_message`.
 
-### What to emit
-
-```
-[turn 3] thinking-only, no actions
-```
-
-Format mirrors existing `ui.py` markers (`[init]`, `[tool]`, `[done]`, `[guardrail]`) — bracketed-tag prefix, `DIM` color, single line.
-
-Turn number sourced from `guardrails.turns` — already incremented at the new-turn boundary inside `on_assistant_message`.
-
-### State to track in agent.py
-
-Two new locals in `run_agent`:
-
-| Variable | Purpose |
-|---|---|
-| `prev_message_id: str \| None = None` | message_id of the last-seen AssistantMessage. New value signals turn boundary. |
-| `prev_turn_logged_content: bool = False` | True if the just-closed turn produced any `log_text` call OR contained any tool_use block. Reset on new turn. |
-
-On each `AssistantMessage`:
-1. Compute `mid = getattr(message, "message_id", None)`.
-2. If `mid != prev_message_id` and `prev_message_id is not None`: a turn boundary just closed. If `not prev_turn_logged_content`, emit the marker for `guardrails.turns - 1` (the just-closed logical turn). Reset `prev_turn_logged_content = False`.
-3. Process the blocks as today (`log_text` per text block; `guardrails.on_assistant_message` for state).
-4. After the loop, set `prev_turn_logged_content = prev_turn_logged_content or any_text or any_tool_use`.
-5. Update `prev_message_id = mid`.
-
-On `ResultMessage`:
-- Before the existing `_emit_result` block: if `prev_message_id is not None` and `not prev_turn_logged_content`, emit the marker for `guardrails.turns` (the final turn never got a "next message_id" boundary).
-
-`message_id is None` fallback (older SDKs or callers without the field): treat each AssistantMessage as its own turn — same backward-compat path the guardrails already use. The marker still fires per text-less-tool-less event.
-
-### New ui.py function
+**API change to `SessionGuardrails`:**
 
 ```python
-def log_turn_summary(turn: int, summary: str) -> None:
-    _log(f"{DIM}[turn {turn}]{RESET} {summary}")
+# New module-level dataclass:
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class TurnBoundaryEvent:
+    """Emitted by on_assistant_message when a logical turn just closed.
+
+    `just_closed_turn` is the 1-indexed turn number of the turn that just ended
+    (not the new turn that's starting). `had_text` and `had_tool_use` summarize
+    what the just-closed turn produced — operators read these to decide whether
+    the turn was diagnostically silent.
+
+    `had_thinking_block` distinguishes "model thought but didn't act" from
+    "SDK emitted a truly empty turn" — see F3 resolution.
+    """
+    just_closed_turn: int
+    had_text: bool
+    had_tool_use: bool
+    had_thinking_block: bool
+
+
+def on_assistant_message(
+    self,
+    content,
+    message_id=None,
+) -> TurnBoundaryEvent | None:
+    """Returns a TurnBoundaryEvent when this call CLOSES a prior logical turn
+    (i.e. message_id changed from the previously-seen one). Returns None on
+    same-turn continuations and on the very first turn (no prior turn to close).
+    """
 ```
 
-Hard-coded callers use the single string `"thinking-only, no actions"`. Keeping the second argument open allows the Option B follow-up to extend without touching call sites again.
+**Existing call-site impact:** Today there is exactly one in-tree caller (`agent.py:101`) and one test-suite caller (`test_guardrails.py`). Tests ignore the return value (side-effect-only) and continue to work. The agent.py caller starts using the return value.
 
-## Files touched
+**State tracked inside SessionGuardrails to compute `TurnBoundaryEvent`:** the existing `_current_message_id`, `_current_turn_has_tool`, and `_current_turn_text_len` already track most of this. Add:
+
+| New private field | Purpose |
+|---|---|
+| `_current_turn_had_thinking: bool` | True if any `ThinkingBlock` was observed in the current logical turn. Set by scanning blocks for `_block_type(b) == "thinking"`. Resets at new turn boundary. |
+
+**Session-end (final turn) signal:** Add a new method `close_final_turn() -> TurnBoundaryEvent | None`. Called by `agent.py` from the `ResultMessage` branch BEFORE `_emit_result`. Returns a `TurnBoundaryEvent` for the still-open final turn (if any), then clears internal state so it's idempotent.
+
+### F3 resolution — committed marker semantics
+
+The first-pass plan emitted `"thinking-only, no actions"` regardless of whether thinking actually happened. The corrected design branches on `had_thinking_block`:
+
+```python
+# In agent.py:
+def _on_boundary(event: TurnBoundaryEvent) -> None:
+    if event.had_text or event.had_tool_use:
+        return  # Turn produced observable output — already logged elsewhere.
+    if event.had_thinking_block:
+        # guardrails.turns reflects the NEW turn; event.just_closed_turn is the
+        # prior turn that just ended.
+        log_turn_summary(event.just_closed_turn, "thinking-only, no actions")
+    else:
+        # Truly empty turn — no text, no tool_use, no thinking either.
+        # Should be vanishingly rare given the SDK's content-block model, but
+        # defensive accuracy beats a lie in the log.
+        log_turn_summary(event.just_closed_turn, "no observable output")
+```
+
+**Rationale for picking the conditional branch over the other two options the architect named:**
+- *Generic text* (`"no observable output"` for all silent turns): loses the diagnostic signal that motivated the fix. The ticket's failure mode is specifically thinking-rumination drift; the marker text should name it.
+- *Split-marker with different prefixes*: introduces a second log tag (`[turn]` vs e.g. `[silent]`) for one bit of information. Operators end up scanning twice. One tag, two summary strings, is simpler.
+- *Conditional summary text* (picked): one tag, accurate text per case, no false claim in the zero-block case.
+
+### Files touched
 
 | File | Change |
 |---|---|
-| `src/claude_pilot/agent.py` | Add `prev_message_id` / `prev_turn_logged_content` tracking; emit marker on turn boundary and at session end. Import `log_turn_summary`. |
-| `src/claude_pilot/ui.py` | Add `log_turn_summary(turn, summary)` — single line, matches existing format. |
-| `tests/test_agent.py` (new) | Three test cases: thinking-only turn emits marker once; turn with text/tool does not emit marker; final unclosed turn emits marker on ResultMessage. |
+| `src/claude_pilot/guardrails.py` | (a) Add `TurnBoundaryEvent` dataclass. (b) Add `_current_turn_had_thinking` field. (c) Change `on_assistant_message` return type to `TurnBoundaryEvent \| None`, returning the event at new-turn boundaries with the just-closed turn's summary. (d) Add `close_final_turn()` method for the ResultMessage path. (e) Update docstring of `on_assistant_message` to describe the new contract. |
+| `src/claude_pilot/agent.py` | (a) Import `log_turn_summary`. (b) In the AssistantMessage branch, capture the return value of `on_assistant_message` and call a small local `_on_boundary` helper that emits the marker per F3 rules. (c) In the ResultMessage branch, call `guardrails.close_final_turn()` BEFORE `_emit_result` and route through `_on_boundary`. |
+| `src/claude_pilot/ui.py` | Add `log_turn_summary(turn: int, summary: str) -> None`. Single line, `DIM` color, `[turn N]` prefix. Open-string summary preserves Option B extensibility (NF2 confirmed). |
+| `tests/test_guardrails.py` | Add three test cases asserting the new return-value contract: (1) same-`message_id` continuation returns None; (2) new-`message_id` after a thinking-only turn returns `TurnBoundaryEvent(had_text=False, had_tool_use=False, had_thinking_block=True)`; (3) new-`message_id` after a text+tool turn returns event with `had_text=True, had_tool_use=True`. |
+| `tests/test_agent.py` (new) | Three integration cases asserting log output: (a) N thinking-only turns → N `[turn k] thinking-only, no actions` lines; (b) text+tool turn → no marker; (c) ResultMessage with unclosed thinking-only turn → marker fires once via `close_final_turn`. |
 
-Estimated diff: ~25 LOC source + ~80 LOC test scaffolding. No public API change.
+Estimated diff: ~40 LOC source (vs. ~25 in v1 — the guardrail change adds ~15) + ~100 LOC tests.
+
+### Inline comment directive (NF3)
+
+At the agent.py call site that uses `event.just_closed_turn`, add the inline comment from NF3 — adapted to the new design where `event.just_closed_turn` is computed inside the guardrail rather than via `guardrails.turns - 1`:
+
+```python
+event = guardrails.on_assistant_message(...)
+if event is not None:
+    # event.just_closed_turn is the turn that just ENDED; guardrails.turns
+    # now reflects the new turn that just started.
+    _on_boundary(event)
+```
+
+This prevents a future refactor of `_turn_count` increment timing from silently breaking the labeling.
+
+---
 
 ## Acceptance (matches ticket AC verbatim, with verification path)
 
-1. **Thinking-only run emits N markers.** Reproduce by feeding `N` AssistantMessages each containing a single `ThinkingBlock` with distinct `message_id`s; assert log file contains exactly N `[turn k] thinking-only, no actions` lines (k = 1..N).
-2. **Regression: text+tool runs unchanged.** Feed a turn with `[ThinkingBlock, TextBlock("hello"), ToolUseBlock(Bash)]` (same `message_id`); assert log contains the text line and NO `[turn N] thinking-only` marker. Snapshot existing `test_guardrails.py` log expectations as a guard.
-3. **Cost: per-line addition only.** Verify by inspection — no per-character allocation, no buffering changes, no IO frequency increase beyond at most one extra `write_log` call per logical turn.
+1. **Thinking-only run emits N markers.** Feed N AssistantMessages each carrying a single `ThinkingBlock` with distinct `message_id`s, followed by a `ResultMessage`. Assert log file contains exactly N `[turn k] thinking-only, no actions` lines (k = 1..N) — N-1 from boundary events + 1 from `close_final_turn`.
+2. **Regression: text+tool runs unchanged.** Feed a turn with `[ThinkingBlock, TextBlock("hello"), ToolUseBlock(Bash)]` (same `message_id`); assert log contains the text line and NO `[turn N] thinking-only` marker (the boundary event has `had_text=True`).
+3. **Cost: per-line addition only.** Per-turn at most one extra `_log(...)` call. No per-character allocation, no buffering changes. Verified by inspection.
 
-Live verification (after implementation):
-- Pick any closed mika dispatch worktree that produced a drift session; replay its session JSONL through a `run_agent` test harness; confirm the marker appears.
-- Or — instrument a single mika-dev dispatch with the new build; observe log on next thinking-only drift.
+Live verification (after implementation): pick any closed mika dispatch worktree that produced a drift session, replay its session JSONL through a `run_agent` test harness (via the fake-stream pattern below), confirm marker appears.
 
-## Test strategy
+---
 
-A new `tests/test_agent.py` is needed (none exists today). Use the same pattern as `test_guardrails.py`:
+## Test strategy (NF5 — committed)
 
-- `from claude_agent_sdk.types import TextBlock, ThinkingBlock, ToolUseBlock`
-- Construct synthetic `AssistantMessage` instances (or mock the SDK message stream).
-- Drive `run_agent` via a fake SDK client OR — simpler — extract the AssistantMessage-handling loop into a small helper function that takes a message + state and emits log calls, then unit-test the helper directly with `capsys` / file-log capture.
+`tests/test_agent.py` is created from scratch (no existing agent tests). Pattern matches `test_guardrails.py`: use `claude_agent_sdk.types.{TextBlock, ThinkingBlock, ToolUseBlock}` to construct synthetic block instances, wrap in `AssistantMessage` / `ResultMessage` shapes the SDK emits.
 
-Preference: keep the loop in `run_agent` (no extract), and test by mocking the SDK stream. The agent.py code already uses `_merge_stream` which is testable. If mocking proves heavy, fall back to the helper-extraction approach — but only if the architect agrees the indirection is worth it.
+**Fake-stream approach (committed, not helper-extraction):** drive `run_agent` via a fake async generator that yields the synthetic SDK messages in order. The ClaudeSDKClient is mocked at the boundary. The permission callback is a no-op (no tool calls in these tests).
 
-Concretely the first cut: pytest `test_thinking_only_turn_logs_marker` that drives a hand-rolled async generator yielding the synthetic AssistantMessage events into `run_agent`. The relay/permission callback is no-op for these tests (no tool calls).
+**Rationale for fake-stream over helper extraction:** extracting the AssistantMessage-handling loop into a standalone helper would introduce indirection not justified by production requirements — the helper would have a single caller and exist only for testability. The fake-stream exercises the integration seam (run_agent ↔ SDK messages ↔ guardrails ↔ ui) directly, which is the surface that actually breaks in production. This prevents PR reviewer re-litigation per NF5.
+
+If the fake-stream scaffolding proves to be > ~50 LOC of boilerplate, that's a signal that the SDK boundary is hard to mock and the helper-extraction trade-off should be revisited in code review — flagged here, not pre-committed.
+
+---
 
 ## Risks
 
-1. **`message_id` may not exist on all SDK versions.** Already handled by the existing `getattr(message, "message_id", None)` and the `is_continuation` fallback in `guardrails.py:143-145`. The new code uses the same defensive `getattr`.
-2. **Turn-counter drift between agent.py and guardrails.py.** `guardrails.turns` is the source of truth. The plan reads it after `guardrails.on_assistant_message()` so it reflects the NEW turn count. The marker uses `guardrails.turns - 1` when closing a prior turn (because the boundary signal is "we just saw the next message_id"), and `guardrails.turns` at session end.
-3. **Marker noise in healthy sessions.** Healthy sessions intersperse text/tool with thinking, so the marker should be near-zero in normal operation. If it fires once per session for the final `[done]` turn, that's a tolerable false positive. The acceptance criteria explicitly verify it does NOT fire for text+tool turns.
-4. **Final-turn emission ordering vs `_emit_result`.** The marker for the final turn must be emitted BEFORE `_emit_result` writes the result JSON line to stdout, so the log+stdout interleaving stays readable. The plan emits inside the `if isinstance(message, ResultMessage)` branch but before `_emit_result(result)`.
+1. **`message_id` may not exist on all SDK versions.** Already handled by `getattr(message, "message_id", None)` and the `is_continuation` fallback in the existing guardrail. The new return-value contract degrades cleanly: `message_id=None` makes every call a "new turn" boundary, so the event fires every time — slightly noisier for legacy SDKs but functionally correct.
+2. **Tests that call `on_assistant_message` ignoring the return value.** Existing tests in `test_guardrails.py` don't assign the return; they continue to work. New tests check the return type explicitly. No breakage.
+3. **`close_final_turn()` idempotency.** Must be safe to call multiple times — clear internal `_current_message_id` to `None` after returning the event, so a second call returns None.
+4. **Final-turn marker ordering vs `_emit_result`.** The marker for the final turn must be emitted BEFORE `_emit_result` writes the result JSON line to stdout. Implemented by calling `guardrails.close_final_turn()` at the top of the `ResultMessage` branch.
+5. **API change to `on_assistant_message` ripples to relay code paths?** No — searched, only `agent.py` and `tests/test_guardrails.py` call it. `permissions.py` calls `pause_idle_timer`/`resume_idle_timer` only.
+
+---
 
 ## What I deliberately did NOT do
 
 - **No content dump of thinking blocks** (Option B). Ticket says Option A is sufficient. Will reopen if a future drift incident proves the count alone is too thin.
-- **No verbosity flag** (`--log-thinking` or similar). Option A is cheap enough to be always-on; a flag adds config surface for negligible cost savings.
-- **No backfill of past drift sessions.** The log file is append-only; existing logs stay as they are. Only future sessions benefit.
-- **No change to guardrails.py.** The thinking-only condition is already correctly detected by the stall guardrail (it counts text-less + tool-less turns). The bug is purely a logging gap, not a detection gap.
+- **No verbosity flag** (`--log-thinking` or similar). Option A is cheap enough to be always-on.
+- **No backfill of past drift sessions.** Log file is append-only.
+- **No observer/callback shape for the turn-boundary signal.** Return-value is simpler than registering a callback; agent.py has exactly one observation point.
 
-## Open questions for first-pass architect review
+---
 
-1. **Is the per-logical-turn aggregation worth the state-tracking complexity, vs. per-AssistantMessage emission?** Per-AssistantMessage is simpler (no boundary state) but noisier — a turn with 8 thinking blocks would emit 8 markers. I picked per-turn to avoid that noise, but the simpler-and-noisier path is defensible.
-2. **Should the marker carry the count of thinking blocks observed in that turn?** E.g. `[turn 5] thinking-only, 3 blocks`. Trivial to add; useful for "long-thinking" diagnosis. Holding back per "Option A only" but flagging.
-3. **Should the marker also fire for genuinely empty turns (no thinking, no text, no tool)?** I assume yes — it's the same operator-visibility need — but the ticket's evidence is specifically thinking-heavy. The current plan covers both incidentally (it fires whenever `not prev_turn_logged_content`).
+## First-pass disposition resolution log
+
+| Finding | Original architect concern | Resolution in v2 |
+|---|---|---|
+| F1 (BLOCKING) | Phase 0 Pin absent | Added Phase 0 with base SHA `e0056574...` and four verbatim pins (Pin A: turns-increment site; Pin B: SessionGuardrails public interface; Pin C: run_agent AssistantMessage loop; Pin D: `_text_of`/`_content_blocks`). |
+| F2 (BLOCKING) | DRY duplication of `message_id` boundary detection | Removed `prev_message_id` from agent.py. Boundary detection stays in `SessionGuardrails`; new `TurnBoundaryEvent` return type from `on_assistant_message` exposes the signal. cpp#4-class divergence prevented. |
+| F3 (BLOCKING) | Marker text mismatch for zero-block turns | Committed to *conditional summary text*: `had_thinking_block` branches between `"thinking-only, no actions"` and `"no observable output"`. Rationale documented vs. the two rejected alternatives (generic text / split-marker). |
+| NF3 | Add inline comment on turn-counter ordering | Comment added at the agent.py call site (adapted to the new `event.just_closed_turn` field per F2's API change). |
+| NF5 | Test design — record fake-stream rationale | Added committed-choice section with rationale; preempts code-review re-litigation. |
+| NF1, NF2, NF4 | (Non-blocking, confirmed correct) | No change. |
+
+## Open questions for second-pass review
+
+None outstanding — F1/F2/F3 are committed designs, not deferrals. If the architect disagrees with the F2 API-change direction (return-value vs. observer/callback), that's a structural critique worth ESCALATEing rather than another iterate cycle.

--- a/docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md
+++ b/docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md
@@ -1,0 +1,147 @@
+---
+type: fix
+issue: senara-solutions/claude-pilot-py#10
+original_filing: senara-solutions/mika#1142 (closed; refiled to cpp#10 because the fix targets src/claude_pilot/agent.py and prior agent.py bugs — cpp#4, cpp#5 — were tracked here)
+branch: fix/10/log-emits-zero-events-when-model
+date: 2026-05-16
+---
+
+# Plan: log thinking-only turns so operators can debug pilot-drift sessions
+
+## Problem (one line)
+
+When the underlying model produces a logical turn containing only `ThinkingBlock`s — no `TextBlock`, no `ToolUseBlock` — claude-pilot's per-task log emits zero events for that turn. A 20-turn / $1.03 / 81-second drift session (mika#920 today) leaves operators with five-line logs ending in `[error] pipeline_incomplete:` and no diagnostic surface.
+
+## Why this is in cpp not mika
+
+- The code change lives in `src/claude_pilot/agent.py` and `src/claude_pilot/ui.py` (this repo).
+- Prior agent.py bug fixes were filed here (cpp#4 — thinking-block stall miscount; cpp#5 — cost reporting on guardrail termination).
+- mika#1142 was the original filing; closed with a pointer to this issue.
+
+## Root cause (verified by reading code on this branch)
+
+`src/claude_pilot/agent.py:99-109`:
+
+```python
+if isinstance(message, AssistantMessage):
+    session_id = getattr(message, "session_id", session_id) or session_id
+    guardrails.on_assistant_message(
+        _content_blocks(message),
+        message_id=getattr(message, "message_id", None),
+    )
+    for block in _content_blocks(message):
+        text = _text_of(block)
+        if text:
+            log_text(text)
+    continue
+```
+
+`_text_of` (lines 232-241) returns text only when `block.type == "text"`. `ThinkingBlock` has `type="thinking"` and exposes its content via the `thinking` field, not `text` (verified in `tests/test_guardrails.py:31-32` — `ThinkingBlock(thinking=text, signature="sig")`). Pure-thinking turns therefore loop through `_content_blocks` without emitting any log line.
+
+Tool-use blocks are also `_text_of`-empty, but they are logged through the permission-handler path (`log_tool_request` / `log_tool` / `log_relay_send` / `log_relay_recv` in `ui.py`). The diagnostic gap is specifically **text-less and tool-less** AssistantMessages.
+
+## Scope (deliberately narrow per ticket Option A)
+
+The ticket explicitly endorses Option A as sufficient: *"once the operator sees `thinking-only` for 20 turns, the failure shape is obvious."* This plan ships Option A only — one marker line per logical thinking-only turn. Option B (per-block content dump or block-kind summary) is deferred to a follow-up ticket if Option A turns out to be too thin in practice; first instance of "I needed more than the count" will reopen the design.
+
+Per `feedback_implementation_scope_bundling.md` — no silent scope expansion.
+
+## Design
+
+### One marker per logical turn, not per AssistantMessage
+
+The Python `claude-agent-sdk` splits one logical Claude turn into N `AssistantMessage` events, one per content block, all sharing the same `message_id`. A naive "emit when this AssistantMessage has no text and no tool_use" check would spam N markers for a turn with N thinking blocks. `guardrails.py:102-119` already documents this grouping (it was the root cause of cpp#4).
+
+The fix tracks the same `message_id` boundary in `agent.py` and emits the marker exactly once per logical turn, at the moment a new turn boundary is observed (or at session end via `ResultMessage`).
+
+### What to emit
+
+```
+[turn 3] thinking-only, no actions
+```
+
+Format mirrors existing `ui.py` markers (`[init]`, `[tool]`, `[done]`, `[guardrail]`) — bracketed-tag prefix, `DIM` color, single line.
+
+Turn number sourced from `guardrails.turns` — already incremented at the new-turn boundary inside `on_assistant_message`.
+
+### State to track in agent.py
+
+Two new locals in `run_agent`:
+
+| Variable | Purpose |
+|---|---|
+| `prev_message_id: str \| None = None` | message_id of the last-seen AssistantMessage. New value signals turn boundary. |
+| `prev_turn_logged_content: bool = False` | True if the just-closed turn produced any `log_text` call OR contained any tool_use block. Reset on new turn. |
+
+On each `AssistantMessage`:
+1. Compute `mid = getattr(message, "message_id", None)`.
+2. If `mid != prev_message_id` and `prev_message_id is not None`: a turn boundary just closed. If `not prev_turn_logged_content`, emit the marker for `guardrails.turns - 1` (the just-closed logical turn). Reset `prev_turn_logged_content = False`.
+3. Process the blocks as today (`log_text` per text block; `guardrails.on_assistant_message` for state).
+4. After the loop, set `prev_turn_logged_content = prev_turn_logged_content or any_text or any_tool_use`.
+5. Update `prev_message_id = mid`.
+
+On `ResultMessage`:
+- Before the existing `_emit_result` block: if `prev_message_id is not None` and `not prev_turn_logged_content`, emit the marker for `guardrails.turns` (the final turn never got a "next message_id" boundary).
+
+`message_id is None` fallback (older SDKs or callers without the field): treat each AssistantMessage as its own turn — same backward-compat path the guardrails already use. The marker still fires per text-less-tool-less event.
+
+### New ui.py function
+
+```python
+def log_turn_summary(turn: int, summary: str) -> None:
+    _log(f"{DIM}[turn {turn}]{RESET} {summary}")
+```
+
+Hard-coded callers use the single string `"thinking-only, no actions"`. Keeping the second argument open allows the Option B follow-up to extend without touching call sites again.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/claude_pilot/agent.py` | Add `prev_message_id` / `prev_turn_logged_content` tracking; emit marker on turn boundary and at session end. Import `log_turn_summary`. |
+| `src/claude_pilot/ui.py` | Add `log_turn_summary(turn, summary)` — single line, matches existing format. |
+| `tests/test_agent.py` (new) | Three test cases: thinking-only turn emits marker once; turn with text/tool does not emit marker; final unclosed turn emits marker on ResultMessage. |
+
+Estimated diff: ~25 LOC source + ~80 LOC test scaffolding. No public API change.
+
+## Acceptance (matches ticket AC verbatim, with verification path)
+
+1. **Thinking-only run emits N markers.** Reproduce by feeding `N` AssistantMessages each containing a single `ThinkingBlock` with distinct `message_id`s; assert log file contains exactly N `[turn k] thinking-only, no actions` lines (k = 1..N).
+2. **Regression: text+tool runs unchanged.** Feed a turn with `[ThinkingBlock, TextBlock("hello"), ToolUseBlock(Bash)]` (same `message_id`); assert log contains the text line and NO `[turn N] thinking-only` marker. Snapshot existing `test_guardrails.py` log expectations as a guard.
+3. **Cost: per-line addition only.** Verify by inspection — no per-character allocation, no buffering changes, no IO frequency increase beyond at most one extra `write_log` call per logical turn.
+
+Live verification (after implementation):
+- Pick any closed mika dispatch worktree that produced a drift session; replay its session JSONL through a `run_agent` test harness; confirm the marker appears.
+- Or — instrument a single mika-dev dispatch with the new build; observe log on next thinking-only drift.
+
+## Test strategy
+
+A new `tests/test_agent.py` is needed (none exists today). Use the same pattern as `test_guardrails.py`:
+
+- `from claude_agent_sdk.types import TextBlock, ThinkingBlock, ToolUseBlock`
+- Construct synthetic `AssistantMessage` instances (or mock the SDK message stream).
+- Drive `run_agent` via a fake SDK client OR — simpler — extract the AssistantMessage-handling loop into a small helper function that takes a message + state and emits log calls, then unit-test the helper directly with `capsys` / file-log capture.
+
+Preference: keep the loop in `run_agent` (no extract), and test by mocking the SDK stream. The agent.py code already uses `_merge_stream` which is testable. If mocking proves heavy, fall back to the helper-extraction approach — but only if the architect agrees the indirection is worth it.
+
+Concretely the first cut: pytest `test_thinking_only_turn_logs_marker` that drives a hand-rolled async generator yielding the synthetic AssistantMessage events into `run_agent`. The relay/permission callback is no-op for these tests (no tool calls).
+
+## Risks
+
+1. **`message_id` may not exist on all SDK versions.** Already handled by the existing `getattr(message, "message_id", None)` and the `is_continuation` fallback in `guardrails.py:143-145`. The new code uses the same defensive `getattr`.
+2. **Turn-counter drift between agent.py and guardrails.py.** `guardrails.turns` is the source of truth. The plan reads it after `guardrails.on_assistant_message()` so it reflects the NEW turn count. The marker uses `guardrails.turns - 1` when closing a prior turn (because the boundary signal is "we just saw the next message_id"), and `guardrails.turns` at session end.
+3. **Marker noise in healthy sessions.** Healthy sessions intersperse text/tool with thinking, so the marker should be near-zero in normal operation. If it fires once per session for the final `[done]` turn, that's a tolerable false positive. The acceptance criteria explicitly verify it does NOT fire for text+tool turns.
+4. **Final-turn emission ordering vs `_emit_result`.** The marker for the final turn must be emitted BEFORE `_emit_result` writes the result JSON line to stdout, so the log+stdout interleaving stays readable. The plan emits inside the `if isinstance(message, ResultMessage)` branch but before `_emit_result(result)`.
+
+## What I deliberately did NOT do
+
+- **No content dump of thinking blocks** (Option B). Ticket says Option A is sufficient. Will reopen if a future drift incident proves the count alone is too thin.
+- **No verbosity flag** (`--log-thinking` or similar). Option A is cheap enough to be always-on; a flag adds config surface for negligible cost savings.
+- **No backfill of past drift sessions.** The log file is append-only; existing logs stay as they are. Only future sessions benefit.
+- **No change to guardrails.py.** The thinking-only condition is already correctly detected by the stall guardrail (it counts text-less + tool-less turns). The bug is purely a logging gap, not a detection gap.
+
+## Open questions for first-pass architect review
+
+1. **Is the per-logical-turn aggregation worth the state-tracking complexity, vs. per-AssistantMessage emission?** Per-AssistantMessage is simpler (no boundary state) but noisier — a turn with 8 thinking blocks would emit 8 markers. I picked per-turn to avoid that noise, but the simpler-and-noisier path is defensible.
+2. **Should the marker carry the count of thinking blocks observed in that turn?** E.g. `[turn 5] thinking-only, 3 blocks`. Trivial to add; useful for "long-thinking" diagnosis. Holding back per "Option A only" but flagging.
+3. **Should the marker also fire for genuinely empty turns (no thinking, no text, no tool)?** I assume yes — it's the same operator-visibility need — but the ticket's evidence is specifically thinking-heavy. The current plan covers both incidentally (it fires whenever `not prev_turn_logged_content`).

--- a/docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md
+++ b/docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md
@@ -203,7 +203,7 @@ def on_assistant_message(
 
 | New private field | Purpose |
 |---|---|
-| `_current_turn_had_thinking: bool` | True if any `ThinkingBlock` was observed in the current logical turn. Set by scanning blocks for `_block_type(b) == "thinking"`. Resets at new turn boundary. |
+| `_current_turn_had_thinking_block: bool` | True if any `ThinkingBlock` was observed in the current logical turn. Set by scanning blocks for `_block_type(b) == "thinking"`. Resets at new turn boundary. Naming intentionally matches `TurnBoundaryEvent.had_thinking_block` (NF6 — symmetry between private state and exported event field). |
 
 **Session-end (final turn) signal:** Add a new method `close_final_turn() -> TurnBoundaryEvent | None`. Called by `agent.py` from the `ResultMessage` branch BEFORE `_emit_result`. Returns a `TurnBoundaryEvent` for the still-open final turn (if any), then clears internal state so it's idempotent.
 
@@ -240,7 +240,7 @@ def _on_boundary(event: TurnBoundaryEvent) -> None:
 | `src/claude_pilot/agent.py` | (a) Import `log_turn_summary`. (b) In the AssistantMessage branch, capture the return value of `on_assistant_message` and call a small local `_on_boundary` helper that emits the marker per F3 rules. (c) In the ResultMessage branch, call `guardrails.close_final_turn()` BEFORE `_emit_result` and route through `_on_boundary`. |
 | `src/claude_pilot/ui.py` | Add `log_turn_summary(turn: int, summary: str) -> None`. Single line, `DIM` color, `[turn N]` prefix. Open-string summary preserves Option B extensibility (NF2 confirmed). |
 | `tests/test_guardrails.py` | Add three test cases asserting the new return-value contract: (1) same-`message_id` continuation returns None; (2) new-`message_id` after a thinking-only turn returns `TurnBoundaryEvent(had_text=False, had_tool_use=False, had_thinking_block=True)`; (3) new-`message_id` after a text+tool turn returns event with `had_text=True, had_tool_use=True`. |
-| `tests/test_agent.py` (new) | Three integration cases asserting log output: (a) N thinking-only turns → N `[turn k] thinking-only, no actions` lines; (b) text+tool turn → no marker; (c) ResultMessage with unclosed thinking-only turn → marker fires once via `close_final_turn`. |
+| `tests/test_agent.py` (new) | Four integration cases asserting log output: (a) N thinking-only turns → N `[turn k] thinking-only, no actions` lines; (b) text+tool turn → no marker emitted at the AssistantMessage boundary; (c) ResultMessage with unclosed thinking-only turn → marker fires once via `close_final_turn`; (d) NF7 — text+tool FINAL turn closed by ResultMessage → `close_final_turn()` returns an event with `had_text=True` AND `_on_boundary` emits no marker (guards against a regression where `close_final_turn` forgets to populate `had_text`/`had_tool_use` and `_on_boundary` defensively prints `"no observable output"`). |
 
 Estimated diff: ~40 LOC source (vs. ~25 in v1 — the guardrail change adds ~15) + ~100 LOC tests.
 
@@ -311,6 +311,8 @@ If the fake-stream scaffolding proves to be > ~50 LOC of boilerplate, that's a s
 | NF3 | Add inline comment on turn-counter ordering | Comment added at the agent.py call site (adapted to the new `event.just_closed_turn` field per F2's API change). |
 | NF5 | Test design — record fake-stream rationale | Added committed-choice section with rationale; preempts code-review re-litigation. |
 | NF1, NF2, NF4 | (Non-blocking, confirmed correct) | No change. |
+| NF6 (pass-2) | Private field `_current_turn_had_thinking` vs event field `had_thinking_block` naming asymmetry | Private field renamed to `_current_turn_had_thinking_block` for symmetry. |
+| NF7 (pass-2) | Test case 2 (text+tool turn) does not exercise `close_final_turn()` suppression for a text+tool FINAL turn | Added fourth integration test case (d) covering text+tool final turn → no marker emitted via `close_final_turn`. |
 
 ## Open questions for second-pass review
 

--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 from claude_agent_sdk.types import AssistantMessage, ResultMessage, SystemMessage
 
-from .guardrails import SessionGuardrails
+from .guardrails import SessionGuardrails, TurnBoundaryEvent
 from .permissions import CanUseTool
 from .types import ResultJson
 from .ui import (
@@ -28,6 +28,7 @@ from .ui import (
     log_init,
     log_prompt,
     log_text,
+    log_turn_summary,
 )
 
 SDK_TERMINATION_SUBTYPES = frozenset({"error_max_turns", "error_max_budget_usd"})
@@ -98,10 +99,16 @@ async def run_agent(
 
                 if isinstance(message, AssistantMessage):
                     session_id = getattr(message, "session_id", session_id) or session_id
-                    guardrails.on_assistant_message(
+                    event = guardrails.on_assistant_message(
                         _content_blocks(message),
                         message_id=getattr(message, "message_id", None),
                     )
+                    if event is not None:
+                        # event.just_closed_turn is the turn that just ENDED;
+                        # guardrails.turns now reflects the new turn that just
+                        # started. cpp#10 — surface drift turns that produced
+                        # no text and no tool calls.
+                        _on_boundary(event)
                     for block in _content_blocks(message):
                         text = _text_of(block)
                         if text:
@@ -109,6 +116,13 @@ async def run_agent(
                     continue
 
                 if isinstance(message, ResultMessage):
+                    # cpp#10: flush the marker for the still-open final turn
+                    # BEFORE _emit_result writes the result JSON line, so the
+                    # operator sees the last turn's shape if it was silent.
+                    final_event = guardrails.close_final_turn()
+                    if final_event is not None:
+                        _on_boundary(final_event)
+
                     subtype = message.subtype
                     raw_errors = getattr(message, "errors", None)
                     errors = (
@@ -221,6 +235,23 @@ def _sdk_guardrail_kwargs(config: Any) -> dict[str, Any]:
         # Leaving it out is safe — application-level guardrails still apply.
         pass
     return kwargs
+
+
+def _on_boundary(event: TurnBoundaryEvent) -> None:
+    """cpp#10: log a marker for diagnostically silent turns.
+
+    A turn that produced text or a tool_use is already visible in the log via
+    `log_text` / `permissions.py`. A turn that produced neither leaves the
+    operator with nothing to read — branch the marker on `had_thinking_block`
+    so the line accurately names what the model DID do (think) instead of
+    falsely claiming silence.
+    """
+    if event.had_text or event.had_tool_use:
+        return
+    if event.had_thinking_block:
+        log_turn_summary(event.just_closed_turn, "thinking-only, no actions")
+    else:
+        log_turn_summary(event.just_closed_turn, "no observable output")
 
 
 def _content_blocks(message: AssistantMessage) -> list[Any]:

--- a/src/claude_pilot/guardrails.py
+++ b/src/claude_pilot/guardrails.py
@@ -9,6 +9,7 @@ take 60-120s) and resumed afterwards.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from .types import (
@@ -17,6 +18,23 @@ from .types import (
     GuardrailConfig,
     ResolvedGuardrailConfig,
 )
+
+
+@dataclass(frozen=True)
+class TurnBoundaryEvent:
+    """Emitted when a logical turn just closed (cpp#10).
+
+    `just_closed_turn` is the 1-indexed turn number that just ENDED (not the
+    new turn that's starting). `had_text` / `had_tool_use` / `had_thinking_block`
+    summarize what the just-closed turn produced — agent.py reads these to
+    decide whether the turn was diagnostically silent and worth logging a
+    marker for.
+    """
+
+    just_closed_turn: int
+    had_text: bool
+    had_tool_use: bool
+    had_thinking_block: bool
 
 
 def resolve_guardrail_defaults(config: GuardrailConfig | None) -> ResolvedGuardrailConfig:
@@ -56,11 +74,18 @@ class SessionGuardrails:
         self._current_message_id: str | None = None
         self._current_turn_has_tool: bool = False
         self._current_turn_text_len: int = 0
+        # cpp#10: track whether the in-progress turn observed any ThinkingBlock,
+        # so the TurnBoundaryEvent for that turn can distinguish "model thought
+        # but didn't act" from "SDK emitted a truly empty turn".
+        self._current_turn_had_thinking_block: bool = False
         # Tracks whether we speculatively incremented stall for the current turn
         # so we can roll it back if a later content block (same message_id) brings
         # a tool_use.
         self._stall_incremented_for_current_turn: bool = False
         self._empty_incremented_for_current_turn: bool = False
+        # cpp#10: guards `close_final_turn()` idempotency — once the final-turn
+        # event has been emitted, subsequent calls return None.
+        self._final_turn_closed: bool = False
         # mika#940: track whether a `gh pr create` Bash invocation was observed
         # in this session. Read by agent.py post-ResultMessage when
         # CLAUDE_PILOT_REQUIRE_PR=1 (set by dispatch-lib for dev-pilot sessions);
@@ -103,7 +128,7 @@ class SessionGuardrails:
         self,
         content: list[dict[str, Any]] | Any,
         message_id: str | None = None,
-    ) -> None:
+    ) -> TurnBoundaryEvent | None:
         """Called on each AssistantMessage from the SDK.
 
         The Python claude-agent-sdk splits a single Claude turn into one event per
@@ -116,9 +141,16 @@ class SessionGuardrails:
         text-only events still trips at turn 5, not turn 6). When a later content
         block in the same turn brings a `tool_use`, the speculative increment is
         rolled back.
+
+        cpp#10: returns a `TurnBoundaryEvent` describing the just-closed turn
+        whenever this call CROSSES a turn boundary (`message_id` changed from the
+        previously-seen one). Returns `None` on same-turn continuations and on
+        the very first turn (no prior turn to close). Agent.py uses this to emit
+        a per-turn marker so thinking-only turns are still visible in the log.
         """
         blocks = content if isinstance(content, list) else []
         has_tool_use = any(_block_type(b) == "tool_use" for b in blocks)
+        has_thinking = any(_block_type(b) == "thinking" for b in blocks)
         text_len = sum(
             len((_block_text(b) or "").strip()) for b in blocks if _block_type(b) == "text"
         )
@@ -147,6 +179,8 @@ class SessionGuardrails:
         if is_continuation:
             # Same logical turn — accumulate evidence about its productivity.
             self._current_turn_text_len += text_len
+            if has_thinking and not self._current_turn_had_thinking_block:
+                self._current_turn_had_thinking_block = True
             if has_tool_use and not self._current_turn_has_tool:
                 # tool_use just arrived in this turn — roll back any speculative
                 # stall/empty increments we made when the turn started no-tool.
@@ -157,13 +191,25 @@ class SessionGuardrails:
                 if self._empty_incremented_for_current_turn:
                     self._consecutive_empty_turns = max(0, self._consecutive_empty_turns - 1)
                     self._empty_incremented_for_current_turn = False
-            return
+            return None
 
-        # New turn boundary.
+        # New turn boundary. Capture the just-closed turn's summary before
+        # resetting accumulators (cpp#10). The very first call has nothing to
+        # close — `_turn_count == 0` skips event emission.
+        boundary_event: TurnBoundaryEvent | None = None
+        if self._turn_count > 0:
+            boundary_event = TurnBoundaryEvent(
+                just_closed_turn=self._turn_count,
+                had_text=self._current_turn_text_len > 0,
+                had_tool_use=self._current_turn_has_tool,
+                had_thinking_block=self._current_turn_had_thinking_block,
+            )
+
         self._turn_count += 1
         self._current_message_id = message_id
         self._current_turn_has_tool = has_tool_use
         self._current_turn_text_len = text_len
+        self._current_turn_had_thinking_block = has_thinking
         self._stall_incremented_for_current_turn = False
         self._empty_incremented_for_current_turn = False
         # Reset idle timer on each new turn — even empty ones.
@@ -172,12 +218,12 @@ class SessionGuardrails:
         self._reset_idle_timer()
 
         if self._turn_count < self._config.minTurnsBeforeDetection:
-            return
+            return boundary_event
 
         if has_tool_use:
             self._consecutive_stall_turns = 0
             self._consecutive_empty_turns = 0
-            return
+            return boundary_event
 
         # No tool use yet → speculative stall increment (may be rolled back if
         # a same-message_id continuation brings tool_use).
@@ -191,7 +237,7 @@ class SessionGuardrails:
                 "stall_detected",
                 f"{self._consecutive_stall_turns} consecutive turns with no tool calls",
             )
-            return
+            return boundary_event
 
         # Empty / trivial text
         if text_len < 10:
@@ -207,6 +253,28 @@ class SessionGuardrails:
                 )
         else:
             self._consecutive_empty_turns = 0
+
+        return boundary_event
+
+    def close_final_turn(self) -> TurnBoundaryEvent | None:
+        """Emit a boundary event for the still-open final turn at session end
+        (cpp#10). Called by agent.py from the ResultMessage branch BEFORE
+        `_emit_result` so the marker for the last turn lands in the log if it
+        was diagnostically silent.
+
+        Idempotent: subsequent calls return `None`.
+        """
+        if self._final_turn_closed or self._turn_count == 0:
+            return None
+        event = TurnBoundaryEvent(
+            just_closed_turn=self._turn_count,
+            had_text=self._current_turn_text_len > 0,
+            had_tool_use=self._current_turn_has_tool,
+            had_thinking_block=self._current_turn_had_thinking_block,
+        )
+        self._final_turn_closed = True
+        self._current_message_id = None
+        return event
 
     def pause_idle_timer(self) -> None:
         """Cancel any pending idle-timeout task (called before relay)."""

--- a/src/claude_pilot/ui.py
+++ b/src/claude_pilot/ui.py
@@ -105,6 +105,17 @@ def log_guardrail(type_: str, detail: str) -> None:
     _log(f"\n{ORANGE}[guardrail]{RESET} {BOLD}{type_}{RESET}: {detail}")
 
 
+def log_turn_summary(turn: int, summary: str) -> None:
+    """Per-turn marker for diagnostically silent turns (cpp#10).
+
+    Emitted when a logical turn produced no text and no tool calls — so the
+    operator can still see that the turn happened. Open-string `summary` lets
+    callers describe the silence ("thinking-only, no actions" /
+    "no observable output").
+    """
+    _log(f"{DIM}[turn {turn}]{RESET} {summary}")
+
+
 def log_env(env_path: str, loaded: bool, count: int) -> None:
     if loaded:
         _log(f"{DIM}[env]{RESET} path={env_path} [LOADED] vars={count}")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,265 @@
+"""Agent integration tests — turn-boundary marker logging (cpp#10).
+
+Drives `run_agent` via a fake `ClaudeSDKClient` that yields a scripted sequence
+of SDK messages. The seam exercised is `run_agent` ↔ SDK messages ↔ guardrails
+↔ ui — the surface that actually breaks in production when a thinking-only
+turn leaves the log empty.
+
+Fake-stream over helper extraction: extracting the AssistantMessage loop into a
+testable helper would add indirection with one caller. Driving the public
+entrypoint with a fake stream keeps production code unchanged and validates
+the integrated behavior (cpp#10 plan §Test strategy).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    ResultMessage,
+    SystemMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolUseBlock,
+)
+
+from claude_pilot import agent as agent_module
+from claude_pilot.agent import run_agent
+from claude_pilot.guardrails import SessionGuardrails
+from claude_pilot.types import ResolvedGuardrailConfig
+
+
+def _config() -> ResolvedGuardrailConfig:
+    return ResolvedGuardrailConfig(
+        maxTurns=200,
+        maxBudgetUsd=0.0,
+        # Disable stall/empty detection so thinking-only runs don't abort early.
+        stallThreshold=0,
+        emptyResponseThreshold=0,
+        idleTimeoutMs=0,
+        minTurnsBeforeDetection=0,
+    )
+
+
+def _assistant(blocks: list[Any], message_id: str) -> AssistantMessage:
+    return AssistantMessage(content=blocks, model="claude-test", message_id=message_id)
+
+
+def _result() -> ResultMessage:
+    return ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="sess_test",
+        total_cost_usd=0.0,
+    )
+
+
+def _init() -> SystemMessage:
+    return SystemMessage(subtype="init", data={"session_id": "sess_test", "model": "claude-test"})
+
+
+class _FakeClient:
+    def __init__(self, messages: list[Any]) -> None:
+        self._messages = messages
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def query(self, _prompt: str) -> None:
+        return None
+
+    async def interrupt(self) -> None:
+        return None
+
+    def receive_response(self) -> Any:
+        async def gen() -> Any:
+            for m in self._messages:
+                yield m
+
+        return gen()
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, messages: list[Any]) -> None:
+    """Replace ClaudeSDKClient in agent.py with a constructor that returns a
+    FakeClient yielding the scripted message sequence."""
+
+    def _factory(*_args: Any, **_kwargs: Any) -> _FakeClient:
+        return _FakeClient(messages)
+
+    monkeypatch.setattr(agent_module, "ClaudeSDKClient", _factory)
+
+
+async def _noop_permission(*_args: Any, **_kwargs: Any) -> Any:  # pragma: no cover
+    raise AssertionError("permission handler must not be invoked in these tests")
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_turns_emit_one_marker_each(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Feed N thinking-only turns (each a distinct message_id) followed by a
+    ResultMessage. Expect N `[turn k] thinking-only, no actions` markers — k-1
+    from boundary events + 1 from `close_final_turn` (cpp#10 AC 1)."""
+    n_turns = 3
+    messages: list[Any] = [_init()]
+    for i in range(n_turns):
+        messages.append(
+            _assistant([ThinkingBlock(thinking="planning", signature="sig")], f"msg_{i}")
+        )
+    messages.append(_result())
+
+    _install_fake_client(monkeypatch, messages)
+    guardrails = SessionGuardrails(_config())
+
+    exit_code = await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id=None,
+        permission_handler=_noop_permission,
+        guardrails=guardrails,
+    )
+
+    captured = capsys.readouterr()
+    err = captured.err
+    for k in range(1, n_turns + 1):
+        assert f"[turn {k}]" in err, f"missing marker for turn {k}; stderr was:\n{err}"
+        assert "thinking-only, no actions" in err
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_text_and_tool_turn_emits_no_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A turn carrying [ThinkingBlock, TextBlock, ToolUseBlock] is productive —
+    `_on_boundary` suppresses the marker for both the AssistantMessage-driven
+    boundary event AND `close_final_turn` (cpp#10 AC 2, marker-suppression
+    half).
+
+    NOTE: AC 2 in the plan also reads "assert log contains the text line".
+    That assertion exercises `_text_of` in agent.py, which has the same
+    SDK-dataclass `type`-attribute gap that `_block_type` worked around in
+    cpp#4. That latent bug is out of scope for cpp#10 (the silent-turn marker
+    fix) and is left for a follow-up. Only the marker-suppression behavior is
+    asserted here.
+    """
+    text = "here is the plan with enough content to clear text-len threshold"
+    messages: list[Any] = [
+        _init(),
+        _assistant(
+            [
+                ThinkingBlock(thinking="x", signature="sig"),
+                TextBlock(text=text),
+                ToolUseBlock(id="t1", name="Bash", input={"command": "ls"}),
+            ],
+            "msg_1",
+        ),
+        _assistant(
+            [
+                ThinkingBlock(thinking="y", signature="sig"),
+                TextBlock(text=text),
+                ToolUseBlock(id="t2", name="Bash", input={"command": "pwd"}),
+            ],
+            "msg_2",
+        ),
+        _result(),
+    ]
+    _install_fake_client(monkeypatch, messages)
+    guardrails = SessionGuardrails(_config())
+
+    await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id=None,
+        permission_handler=_noop_permission,
+        guardrails=guardrails,
+    )
+
+    err = capsys.readouterr().err
+    assert "[turn 1]" not in err, "productive turn must not emit a marker"
+    assert "[turn 2]" not in err, "productive final turn must not emit a marker via close_final_turn"
+    assert "thinking-only" not in err
+    assert "no observable output" not in err
+
+
+@pytest.mark.asyncio
+async def test_final_thinking_only_turn_marker_fires_via_close_final_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A single thinking-only AssistantMessage followed immediately by a
+    ResultMessage. No subsequent AssistantMessage means the boundary event is
+    never emitted from `on_assistant_message` — `close_final_turn()` is the
+    only path that fires the marker (cpp#10 AC 1 final-turn coverage)."""
+    messages: list[Any] = [
+        _init(),
+        _assistant([ThinkingBlock(thinking="planning", signature="sig")], "msg_1"),
+        _result(),
+    ]
+    _install_fake_client(monkeypatch, messages)
+    guardrails = SessionGuardrails(_config())
+
+    await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id=None,
+        permission_handler=_noop_permission,
+        guardrails=guardrails,
+    )
+
+    err = capsys.readouterr().err
+    assert "[turn 1]" in err, (
+        f"close_final_turn must emit the marker for the unclosed final turn; stderr was:\n{err}"
+    )
+    assert "thinking-only, no actions" in err
+
+
+@pytest.mark.asyncio
+async def test_text_only_final_turn_emits_no_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """NF7 guard: if `close_final_turn` ever forgot to populate `had_text` /
+    `had_tool_use`, `_on_boundary` would defensively print 'no observable
+    output' for a text+tool final turn. Lock that out (cpp#10 plan NF7)."""
+    text = "final productive turn with sufficient observable content"
+    messages: list[Any] = [
+        _init(),
+        _assistant(
+            [
+                TextBlock(text=text),
+                ToolUseBlock(id="t1", name="Bash", input={"command": "ls"}),
+            ],
+            "msg_1",
+        ),
+        _result(),
+    ]
+    _install_fake_client(monkeypatch, messages)
+    guardrails = SessionGuardrails(_config())
+
+    await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id=None,
+        permission_handler=_noop_permission,
+        guardrails=guardrails,
+    )
+
+    err = capsys.readouterr().err
+    assert "[turn 1]" not in err
+    assert "no observable output" not in err
+    assert "thinking-only" not in err

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import pytest
 from claude_agent_sdk.types import TextBlock, ThinkingBlock, ToolUseBlock
 
-from claude_pilot.guardrails import SessionGuardrails
+from claude_pilot.guardrails import SessionGuardrails, TurnBoundaryEvent
 from claude_pilot.types import ResolvedGuardrailConfig
 
 
@@ -202,6 +202,79 @@ async def test_pr_created_is_sticky(guardrails: SessionGuardrails) -> None:
         message_id="msg_2",
     )
     assert guardrails.pr_created is True
+
+
+# ── cpp#10: TurnBoundaryEvent return-value contract ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_same_message_id_continuation_returns_none(
+    guardrails: SessionGuardrails,
+) -> None:
+    """Same-msg_id continuation is NOT a turn boundary — returns None (cpp#10)."""
+    first = guardrails.on_assistant_message([_think()], message_id="msg_1")
+    assert first is None, "Very first turn has no prior turn to close"
+    second = guardrails.on_assistant_message([_text("hi")], message_id="msg_1")
+    assert second is None, "Same-msg_id continuation must not emit a boundary event"
+
+
+@pytest.mark.asyncio
+async def test_boundary_event_after_thinking_only_turn(
+    guardrails: SessionGuardrails,
+) -> None:
+    """A new message_id after a thinking-only turn yields an event flagging
+    `had_thinking_block=True, had_text=False, had_tool_use=False` (cpp#10)."""
+    guardrails.on_assistant_message([_think()], message_id="msg_1")
+    event = guardrails.on_assistant_message([_think()], message_id="msg_2")
+    assert isinstance(event, TurnBoundaryEvent)
+    assert event.just_closed_turn == 1
+    assert event.had_thinking_block is True
+    assert event.had_text is False
+    assert event.had_tool_use is False
+
+
+@pytest.mark.asyncio
+async def test_boundary_event_after_text_and_tool_turn(
+    guardrails: SessionGuardrails,
+) -> None:
+    """A new message_id after a text+tool turn yields an event with
+    `had_text=True, had_tool_use=True` — _on_boundary will suppress the
+    marker (cpp#10)."""
+    guardrails.on_assistant_message(
+        [_think(), _text("here is the plan"), _tool()],
+        message_id="msg_1",
+    )
+    event = guardrails.on_assistant_message([_text("next")], message_id="msg_2")
+    assert isinstance(event, TurnBoundaryEvent)
+    assert event.just_closed_turn == 1
+    assert event.had_text is True
+    assert event.had_tool_use is True
+    assert event.had_thinking_block is True
+
+
+@pytest.mark.asyncio
+async def test_close_final_turn_returns_event_then_none(
+    guardrails: SessionGuardrails,
+) -> None:
+    """`close_final_turn()` emits the still-open final turn once, then is
+    idempotent (cpp#10)."""
+    guardrails.on_assistant_message([_think()], message_id="msg_1")
+    first = guardrails.close_final_turn()
+    assert isinstance(first, TurnBoundaryEvent)
+    assert first.just_closed_turn == 1
+    assert first.had_thinking_block is True
+    assert first.had_text is False
+    assert first.had_tool_use is False
+    second = guardrails.close_final_turn()
+    assert second is None, "close_final_turn must be idempotent"
+
+
+@pytest.mark.asyncio
+async def test_close_final_turn_with_no_turns(
+    guardrails: SessionGuardrails,
+) -> None:
+    """`close_final_turn()` returns None when no turn has started (cpp#10)."""
+    assert guardrails.close_final_turn() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When a logical turn produces only `ThinkingBlock`s — no `TextBlock`, no `ToolUseBlock` — claude-pilot's per-task log emitted zero events for that turn. A 20-turn drift session (mika#920) ended up as 5 lines of `[init]` + `[prompt]` + `[error]`, leaving operators with no diagnostic surface for pilot drift.

This PR ships **Option A** from the issue: one marker line per logical turn that produced no text and no tool calls. Per the architect-validated plan in `docs/plans/2026-05-16-001-fix-thinking-only-turn-logging-plan.md`.

## What changed

- **`guardrails.py`** — New `TurnBoundaryEvent` dataclass. `on_assistant_message` now returns the event at each turn boundary, summarizing the just-closed turn (`had_text` / `had_tool_use` / `had_thinking_block`). Adds `close_final_turn()` for the still-open final turn at session end. Boundary detection stays inside `SessionGuardrails` (F2 resolution: don't duplicate the `message_id` logic in `agent.py` — that's exactly the divergence cpp#4 was meant to prevent).
- **`agent.py`** — Captures the boundary event in the `AssistantMessage` branch and flushes the final turn in the `ResultMessage` branch (before `_emit_result`). `_on_boundary` emits the marker only when neither text nor tool_use was observed, branching on `had_thinking_block` so the message text is accurate per F3 resolution: `"thinking-only, no actions"` vs the truly empty `"no observable output"`.
- **`ui.py`** — New `log_turn_summary(turn, summary)` — single DIM `[turn N]` line, open-string summary so Option B (per-block content dump) can land later without changing the log tag.

Estimated runtime impact: at most one extra log line per turn, only on diagnostically silent turns.

## Tests

- **`tests/test_guardrails.py`** — 5 new tests on the `TurnBoundaryEvent` return-value contract: same-message_id continuation returns `None`; new message_id after thinking-only returns event with `had_thinking_block=True`; new message_id after text+tool returns event with `had_text=True`/`had_tool_use=True`; `close_final_turn()` emits once then is idempotent; `close_final_turn()` returns `None` when no turn has started.
- **`tests/test_agent.py`** (new) — 4 integration tests via a fake `ClaudeSDKClient` that yields scripted SDK message sequences: (a) N thinking-only turns → N markers (k-1 from boundary events + 1 from `close_final_turn`); (b) text+tool turns → no marker; (c) single thinking-only turn closed only by `ResultMessage` → marker fires via `close_final_turn`; (d) text+tool **final** turn → no marker emitted via `close_final_turn` (NF7 guard).
- 131/131 pass, `ruff` clean, `mypy` clean.

## Out of scope (follow-up)

While implementing, I discovered a separate latent bug in `agent.py:_text_of()` — it uses `getattr(block, "type", None) == "text"`, but SDK-dataclass `TextBlock` instances have no `type` attribute (same shape that cpp#4 worked around for `_block_type` in `guardrails.py`). Production logs across the last several sessions confirm zero `[text]` lines are ever emitted — only `[tool]` lines via `permissions.py`. cpp#10's marker still surfaces the drift case that matters most (thinking-only turns), but a follow-up ticket should restore `[text]` logging for productive turns.

## Test plan

- [x] `uv run pytest` — 131 passed
- [x] `uv run ruff check` — clean
- [x] `uv run mypy src` — clean
- [ ] Optional live verification: replay a known-drift session JSONL through the new fake-stream harness shape, confirm marker fires on the boundary.

Closes #10.