### PR TITLE
feat(tier1): port permission-policy TIER 1/1.5 rules (mika#1191 Phase A)

### DIFF
--- a/docs/plans/2026-05-17-001-feat-tier1-expansion-mika1191-companion.md
+++ b/docs/plans/2026-05-17-001-feat-tier1-expansion-mika1191-companion.md
@@ -1,0 +1,42 @@
+---
+type: feat
+issue: mika#1191
+parent: mika#1188 (milestone: Deprecate mika-relay)
+title: Companion plan reference for tier1.py expansion (mika#1191, Phase A)
+date: 2026-05-17
+---
+
+# Companion plan: claude-pilot-py tier1.py expansion (mika#1191, Phase A)
+
+This claude-pilot-py PR implements [mika#1191](https://github.com/senara-solutions/mika/issues/1191) (Phase A of milestone #28, "Deprecate mika-relay").
+
+## Canonical plan location
+
+The architect-groomed plan (two-pass `GROOMED` verdict by `mika-arch`, session `5e52c28c`) lives on the mika repo at:
+
+```
+mika/docs/plans/2026-05-17-004-feat-1191-tier1-expansion-plan.md
+```
+
+committed on the matching branch `feat/1191/port-permission-policy-tier1-rules-into-tier1-py`. The mika companion PR carries the plan doc; this claude-pilot-py PR carries the source implementation that the plan specifies.
+
+## Why the plan lives on mika
+
+The milestone (`Deprecate mika-relay`, mika#1188) is owned by mika because the relay agent is a mika-side concept. Phase A's implementation surface, however, is entirely in claude-pilot-py — the deterministic classifier lives in this repo. Per `mika-platform/CLAUDE.md` cross-repo conventions, the issue/plan home is on the milestone owner's repo while the implementation lands wherever the code is.
+
+## What this PR ships (Phase A)
+
+- `src/claude_pilot/tier1.py`: `is_safe_mika_dispatch` (intra-platform agents allow-list `{mika-arch, mika-dev, mika-qa}`); `SAFE_GH_SUBCOMMANDS["issue"]` extended with `"edit"` and `"comment"`.
+- `src/claude_pilot/permissions.py`: `try_tier_1_5_auto_answer` short-circuit for `compact-safe` AskUserQuestion events — no relay round-trip.
+- `tests/test_tier1.py`: 25 new tests (intra-platform dispatch, gh issue authoring, TIER 3 parity guard, newline-smuggling regression).
+- `tests/test_permissions.py`: 11 new tests for the TIER 1.5 fast path (word-boundary, malformed shapes, partial matches).
+- `tests/replay/replay_relay_decisions.py`: operator-runnable replay harness reading `~/.mika/data/mika.db`, with NF3 anti-vacuous-truth hard-floor.
+- `_COMPOUND_SPLIT_RE` updated to split on `\n` (closes ce:review ADV-1 newline-smuggling regression).
+
+## Companion PR
+
+The mika-side PR carries the plan doc and the milestone bookkeeping. See PR body for cross-repo reference.
+
+## Out of scope
+
+Phase B (`mika#1192` — deterministic policy file replacing the relay invocation path) and Phase C (`mika#1193` — relay retirement) are sequential follow-ups gated on Phase A merging + soaking ≥3 days.

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -71,6 +71,12 @@ def create_permission_handler(
             log_tool(tool_name, _summarize_input(tool_name, tool_input), "AUTO")
             return PermissionResultAllow(updated_input=tool_input)
 
+        # Tier 1.5 fast path — deterministic auto-answer (compact-safe)
+        auto_answer = try_tier_1_5_auto_answer(tool_name, tool_input)
+        if auto_answer is not None:
+            log_tool(tool_name, _summarize_input(tool_name, tool_input), "AUTO")
+            return _map_response(tool_name, tool_input, auto_answer)
+
         # No relay → interactive fallback
         if not relay or config is None:
             return await _interactive_fallback(tool_name, tool_input)
@@ -153,6 +159,48 @@ def _map_response(
             "answers": response.answers,
         }
     )
+
+
+# ── Tier 1.5: deterministic compact-safe auto-answer ─────────────────────────
+#
+# Mirrors mika/skills/bundled/permission-policy/system_prompt.md TIER 1.5
+# (lines 31-32): /ce:compound Phase 0 prompts choose between "full compound"
+# and "compact-safe"; headless sessions always pick "compact-safe" (see #79).
+# Ported into claude-pilot as a deterministic short-circuit so the LLM-backed
+# relay is never invoked for this class of question (mika#1191 Phase A).
+
+_COMPACT_SAFE_RE = re.compile(r"compact-safe", re.IGNORECASE)
+
+
+def try_tier_1_5_auto_answer(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> PilotResponseAnswer | None:
+    """Auto-answer compact-safe compaction-mode questions without relay.
+
+    Returns a `PilotResponseAnswer` selecting "compact-safe" when EVERY
+    question in the tool_input contains the case-insensitive substring
+    `"compact-safe"`. Returns `None` for any other tool call or any
+    AskUserQuestion that includes a non-matching sibling question — those
+    fall through to the relay for normal handling.
+    """
+    if tool_name != "AskUserQuestion":
+        return None
+
+    questions = tool_input.get("questions")
+    if not isinstance(questions, list) or not questions:
+        return None
+
+    answers: dict[str, str] = {}
+    for q in questions:
+        if not isinstance(q, dict):
+            return None
+        question_text = q.get("question", "")
+        if not isinstance(question_text, str) or not _COMPACT_SAFE_RE.search(question_text):
+            return None
+        answers[question_text] = "compact-safe"
+
+    return PilotResponseAnswer(action="answer", answers=answers)
 
 
 async def _interactive_fallback(

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -169,7 +169,7 @@ def _map_response(
 # Ported into claude-pilot as a deterministic short-circuit so the LLM-backed
 # relay is never invoked for this class of question (mika#1191 Phase A).
 
-_COMPACT_SAFE_RE = re.compile(r"compact-safe", re.IGNORECASE)
+_COMPACT_SAFE_RE = re.compile(r"\bcompact-safe\b", re.IGNORECASE)
 
 
 def try_tier_1_5_auto_answer(

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -98,13 +98,19 @@ def is_tier3_dangerous(command: str) -> bool:
 
 # ── Safe Bash command checking ───────────────────────────────────────────────
 
-_COMPOUND_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||[;|])\s*")
+_COMPOUND_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||[;|\n])\s*")
 
 
 def _split_compound_command(command: str) -> list[str]:
-    """Naive split on shell operators. Not quote-aware — unsafe splits inside
-    quoted strings simply won't match any safe pattern and fall through to
-    relay. Safe by design."""
+    """Naive split on shell operators AND raw newlines. Not quote-aware —
+    unsafe splits inside quoted strings simply won't match any safe pattern
+    and fall through to relay. Safe by design.
+
+    `\\n` is included because bash treats a bare newline as a command
+    separator equivalent to `;`. Without splitting on `\\n`, a payload like
+    ``git status\\nrm -rf /`` would be evaluated as one segment, miss the
+    rm-rf regex on the second line, and auto-approve via the safe-git prefix.
+    """
     return [s for s in (part.strip() for part in _COMPOUND_SPLIT_RE.split(command)) if s]
 
 

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -125,6 +125,7 @@ def _is_safe_sub_command(sub: str) -> bool:
         or is_safe_build_command(sub)
         or is_safe_shell_command(sub)
         or is_safe_gh_command(sub)
+        or is_safe_mika_dispatch(sub)
     )
 
 
@@ -245,7 +246,7 @@ def is_safe_shell_command(sub: str) -> bool:
 
 SAFE_GH_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "pr":       frozenset({"create", "view", "list", "checkout", "diff", "checks"}),
-    "issue":    frozenset({"view", "list"}),
+    "issue":    frozenset({"view", "list", "edit", "comment"}),
     "run":      frozenset({"view", "list"}),
     "repo":     frozenset({"view"}),
     "release":  frozenset({"view", "list"}),
@@ -270,6 +271,34 @@ def is_safe_gh_command(sub: str) -> bool:
         return True
 
     return False
+
+
+# ── Safe intra-platform agent dispatch ───────────────────────────────────────
+#
+# Narrow allow-list for `mika ask --agent <agent>` calls between platform
+# agents. The `mika-arch` first-pass / second-pass groom briefs, dev-pilot
+# acceptance pings, and qa-review escalations all flow through this verb.
+# Mirrors the prose entry at mika/skills/bundled/permission-policy/system_prompt.md:21.
+#
+# Sentinel cross-ref: mika/crates/mika-agent/src/well_known_agents.rs:386-396
+# documents this as a deliberately duplicated list across languages with a
+# "if it grows beyond 5 entries OR diverges, escalate to build-time codegen"
+# callout. 3 entries < 5, so manual duplication is acceptable for Phase A.
+
+INTRA_PLATFORM_AGENTS: frozenset[str] = frozenset({
+    "mika-arch",
+    "mika-dev",
+    "mika-qa",
+})
+
+_MIKA_DISPATCH_RE = re.compile(r"^\s*mika\s+ask\s+--agent\s+(\S+)\b")
+
+
+def is_safe_mika_dispatch(sub: str) -> bool:
+    match = _MIKA_DISPATCH_RE.match(sub)
+    if not match:
+        return False
+    return match.group(1) in INTRA_PLATFORM_AGENTS
 
 
 # ── Write/Edit path safety ───────────────────────────────────────────────────

--- a/tests/replay/replay_relay_decisions.py
+++ b/tests/replay/replay_relay_decisions.py
@@ -1,0 +1,346 @@
+"""Replay historical mika-relay decisions against the local tier1 fast-path.
+
+Operator-runnable script (not part of `pytest`). Reads `[claude-pilot] ` events
+from the mika-relay agent's messages in `~/.mika/data/mika.db`, runs each
+through the new tier1 / tier1.5 / tier3 classifier, and reports how many
+would have been resolved locally without invoking the relay.
+
+Usage::
+
+    uv run python tests/replay/replay_relay_decisions.py --days 7
+    uv run python tests/replay/replay_relay_decisions.py --days 7 --emit-latency
+
+Output (single JSON object to stdout)::
+
+    {
+      "days": 7,
+      "events_total": 42,
+      "events_replayable": 38,
+      "events_unreplayable": 4,
+      "resolved_locally": 30,
+      "still_needs_relay": 8,
+      "local_resolution_pct": 78.9,
+      "unreplayable_ratio": 0.095,
+      "disagreement_vs_relay": [
+        {"event_id": "...", "tool": "Bash", "input": "...", "local": "allow", "relay": "deny"}
+      ]
+    }
+
+NF3 hard-floor (anti-vacuous-truth): if ``events_unreplayable / events_total``
+exceeds 0.30, the script exits with status 2 and logs a "harness may be
+broken" message on stderr. A-AC3 measures ``local_resolution_pct`` against the
+**replayable** subset, but a broken harness that drops most events and
+trivially passes the threshold on the surviving 1% would defeat the gate; the
+hard-floor catches that case.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+# Make the local claude-pilot source importable when the script is run via
+# `uv run python tests/replay/replay_relay_decisions.py` from the package
+# root. `uv run` already places the package on sys.path, so this is a
+# defense-in-depth for ad-hoc invocations from outside.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if (_REPO_ROOT / "src").is_dir() and str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from claude_pilot.permissions import try_tier_1_5_auto_answer  # noqa: E402
+from claude_pilot.tier1 import is_tier1_auto_approve, is_tier3_dangerous  # noqa: E402
+
+DEFAULT_DB_PATH = Path.home() / ".mika" / "data" / "mika.db"
+PROMPT_PREFIX = "[claude-pilot] "
+UNREPLAYABLE_HARD_FLOOR = 0.30  # NF3
+
+
+@dataclass
+class ReplayCounters:
+    days: int
+    events_total: int = 0
+    events_replayable: int = 0
+    events_unreplayable: int = 0
+    resolved_locally: int = 0
+    still_needs_relay: int = 0
+    disagreement_vs_relay: list[dict[str, Any]] = field(default_factory=list)
+    latency_samples_ms_pre: list[int] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        unreplayable_ratio = (
+            self.events_unreplayable / self.events_total if self.events_total else 0.0
+        )
+        local_resolution_pct = (
+            (self.resolved_locally / self.events_replayable * 100)
+            if self.events_replayable
+            else 0.0
+        )
+        out: dict[str, Any] = {
+            "days": self.days,
+            "events_total": self.events_total,
+            "events_replayable": self.events_replayable,
+            "events_unreplayable": self.events_unreplayable,
+            "resolved_locally": self.resolved_locally,
+            "still_needs_relay": self.still_needs_relay,
+            "local_resolution_pct": round(local_resolution_pct, 2),
+            "unreplayable_ratio": round(unreplayable_ratio, 4),
+            "disagreement_vs_relay": self.disagreement_vs_relay,
+        }
+        if self.latency_samples_ms_pre:
+            sorted_samples = sorted(self.latency_samples_ms_pre)
+            n = len(sorted_samples)
+            p50 = sorted_samples[n // 2]
+            p95 = sorted_samples[min(int(n * 0.95), n - 1)]
+            out["latency_pre_change_ms"] = {
+                "samples": n,
+                "p50": p50,
+                "p95": p95,
+            }
+        return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    db_path = Path(args.db).expanduser() if args.db else DEFAULT_DB_PATH
+
+    if not db_path.exists():
+        print(f"error: database not found at {db_path}", file=sys.stderr)
+        return 1
+
+    cutoff = datetime.now(UTC) - timedelta(days=args.days)
+    counters = ReplayCounters(days=args.days)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        relay_agent_id = _find_mika_relay_agent_id(conn)
+        if relay_agent_id is None:
+            print(
+                "error: no agent named 'mika-relay' in agents table — nothing to replay",
+                file=sys.stderr,
+            )
+            return 1
+
+        for event_row in _iter_relay_user_events(conn, relay_agent_id, cutoff):
+            counters.events_total += 1
+            pilot_event = _parse_pilot_event(event_row["content"])
+            if pilot_event is None:
+                counters.events_unreplayable += 1
+                continue
+
+            assistant = _find_assistant_reply(
+                conn,
+                session_id=event_row["session_id"],
+                after_id=event_row["id"],
+            )
+            relay_action = _extract_action(assistant["content"]) if assistant else None
+            if relay_action is None:
+                counters.events_unreplayable += 1
+                continue
+
+            counters.events_replayable += 1
+            local_action = _classify_locally(pilot_event)
+
+            if local_action in ("allow", "deny", "answer"):
+                counters.resolved_locally += 1
+            else:
+                counters.still_needs_relay += 1
+
+            if (
+                local_action in ("allow", "deny", "answer")
+                and local_action != relay_action
+            ):
+                counters.disagreement_vs_relay.append(
+                    {
+                        "event_id": event_row["id"],
+                        "tool": pilot_event.get("tool_name"),
+                        "input": _summarize_input(pilot_event),
+                        "local": local_action,
+                        "relay": relay_action,
+                    }
+                )
+
+            if args.emit_latency and assistant is not None:
+                latency_ms = _latency_between(event_row["created_at"], assistant["created_at"])
+                if latency_ms is not None:
+                    counters.latency_samples_ms_pre.append(latency_ms)
+
+    payload = counters.to_dict()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+    # NF3 anti-vacuous-truth hard floor.
+    if (
+        counters.events_total > 0
+        and counters.events_unreplayable / counters.events_total >= UNREPLAYABLE_HARD_FLOOR
+    ):
+        print(
+            f"\nerror: unreplayable_ratio "
+            f"{counters.events_unreplayable}/{counters.events_total} "
+            f"≥ {UNREPLAYABLE_HARD_FLOOR:.0%} — harness may be broken "
+            "(schema drift, malformed payloads, or wrong cutoff window). "
+            "Local-resolve threshold check is suspended.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    p.add_argument("--days", type=int, default=7, help="lookback window (default: 7)")
+    p.add_argument("--db", type=str, default=os.environ.get("MIKA_DB"), help="path to mika.db")
+    p.add_argument(
+        "--emit-latency",
+        action="store_true",
+        help="compute pre-change p50/p95 from messages.created_at deltas (A-AC5)",
+    )
+    return p.parse_args(argv)
+
+
+def _find_mika_relay_agent_id(conn: sqlite3.Connection) -> str | None:
+    # Match by id (the stable role slug) OR by display name as a fallback —
+    # `id='mika-relay'` is the convention for well-known agents while `name`
+    # is the human-readable display label (e.g., 'Relay').
+    row = conn.execute(
+        """
+        SELECT id FROM agents
+        WHERE id = 'mika-relay' OR LOWER(name) = 'mika-relay'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def _iter_relay_user_events(
+    conn: sqlite3.Connection,
+    agent_id: str,
+    cutoff: datetime,
+):
+    return conn.execute(
+        """
+        SELECT id, session_id, content, created_at
+        FROM messages
+        WHERE agent_id = ?
+          AND role = 'user'
+          AND created_at >= ?
+          AND content LIKE ?
+        ORDER BY created_at ASC
+        """,
+        (agent_id, cutoff.strftime("%Y-%m-%dT%H:%M:%SZ"), f"{PROMPT_PREFIX}%"),
+    )
+
+
+def _find_assistant_reply(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    after_id: int,
+) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT id, content, created_at
+        FROM messages
+        WHERE session_id = ?
+          AND role = 'assistant'
+          AND id > ?
+        ORDER BY id ASC
+        LIMIT 1
+        """,
+        (session_id, after_id),
+    ).fetchone()
+
+
+def _parse_pilot_event(content: str) -> dict[str, Any] | None:
+    if not content.startswith(PROMPT_PREFIX):
+        return None
+    payload = content[len(PROMPT_PREFIX):].strip()
+    try:
+        event = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(event, dict):
+        return None
+    if not isinstance(event.get("tool_name"), str):
+        return None
+    if not isinstance(event.get("tool_input"), dict):
+        return None
+    return event
+
+
+def _extract_action(content: str) -> str | None:
+    """The relay's assistant content is a JSON object {"action": "..."}.
+    Tolerate fenced code blocks or stray prose by scanning for the action
+    keys in order — the relay is LLM-driven and occasionally adds prose.
+    """
+    text = content.strip()
+    # Fast path — pure JSON.
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict) and parsed.get("action") in ("allow", "deny", "answer"):
+            return parsed["action"]
+    except json.JSONDecodeError:
+        pass
+
+    # Defensive parse — look for the action key inside the message body.
+    for action in ("allow", "deny", "answer"):
+        needle = f'"action": "{action}"'
+        if needle in text or f'"action":"{action}"' in text:
+            return action
+    return None
+
+
+def _classify_locally(event: dict[str, Any]) -> str | None:
+    """Return the action this tier1/tier1.5 path would produce, or None
+    (meaning: still needs the relay).
+    """
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {})
+    if not isinstance(tool_name, str) or not isinstance(tool_input, dict):
+        return None
+
+    cwd = event.get("cwd") if isinstance(event.get("cwd"), str) else os.getcwd()
+
+    if is_tier1_auto_approve(tool_name, tool_input, cwd or os.getcwd()):
+        return "allow"
+
+    auto_answer = try_tier_1_5_auto_answer(tool_name, tool_input)
+    if auto_answer is not None:
+        return "answer"
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if isinstance(command, str) and is_tier3_dangerous(command):
+            return "deny"
+
+    return None
+
+
+def _summarize_input(event: dict[str, Any]) -> str:
+    tool_input = event.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return ""
+    if event.get("tool_name") == "Bash":
+        return str(tool_input.get("command", ""))[:120]
+    return json.dumps(tool_input, default=str)[:120]
+
+
+def _latency_between(req_ts: str, resp_ts: str) -> int | None:
+    try:
+        req = datetime.fromisoformat(req_ts.replace("Z", "+00:00"))
+        resp = datetime.fromisoformat(resp_ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    delta_ms = int((resp - req).total_seconds() * 1000)
+    return delta_ms if delta_ms >= 0 else None
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/replay/replay_relay_decisions.py
+++ b/tests/replay/replay_relay_decisions.py
@@ -300,15 +300,24 @@ def _extract_action(content: str) -> str | None:
 def _classify_locally(event: dict[str, Any]) -> str | None:
     """Return the action this tier1/tier1.5 path would produce, or None
     (meaning: still needs the relay).
+
+    Write/Edit tools are intentionally skipped: ``is_within_project`` requires
+    the agent's original ``cwd`` at dispatch time, which the historical
+    PilotEvent payload does not carry (see ``types.py:63-75``). Falling back
+    to ``os.getcwd()`` would produce non-deterministic classifications and
+    silently bias the resolved-locally count, so we mark them as "still needs
+    relay" — A-AC3 measures local-resolution on the events we can correctly
+    classify.
     """
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
     if not isinstance(tool_name, str) or not isinstance(tool_input, dict):
         return None
 
-    cwd = event.get("cwd") if isinstance(event.get("cwd"), str) else os.getcwd()
+    if tool_name in ("Write", "Edit"):
+        return None
 
-    if is_tier1_auto_approve(tool_name, tool_input, cwd or os.getcwd()):
+    if is_tier1_auto_approve(tool_name, tool_input, os.getcwd()):
         return "allow"
 
     auto_answer = try_tier_1_5_auto_answer(tool_name, tool_input)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -80,3 +80,48 @@ def test_malformed_question_shape_returns_none() -> None:
         {"questions": ["compact-safe"]},
     )
     assert result is None
+
+
+def test_compact_safe_word_boundary_excludes_compact_safer() -> None:
+    # Word boundary (\bcompact-safe\b) prevents matching substrings like
+    # "compact-safer" or "compact-safety", which could otherwise hijack
+    # unrelated questions through the lexical loophole flagged in ce:review.
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": [{"question": "Is compact-safer mode preferred?"}]},
+    )
+    assert result is None
+
+
+def test_compact_safe_word_boundary_matches_punctuated_forms() -> None:
+    # Word boundary still matches "compact-safe?", "(compact-safe)", etc.
+    for question_text in (
+        "Choose: compact-safe.",
+        "Pick (compact-safe) or full compound?",
+        'Answer with "compact-safe".',
+    ):
+        result = try_tier_1_5_auto_answer(
+            "AskUserQuestion",
+            {"questions": [{"question": question_text}]},
+        )
+        assert isinstance(result, PilotResponseAnswer), question_text
+
+
+def test_non_string_question_field_returns_none() -> None:
+    # Defensive guard: PilotEvent payloads from older mika versions may have
+    # malformed question shapes. Fall through to relay rather than crash.
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": [{"question": 42}]},
+    )
+    assert result is None
+
+
+def test_missing_question_key_returns_none() -> None:
+    # Dict without a "question" key gets q.get("question", "") -> "", which
+    # has no compact-safe substring, so falls through.
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": [{"options": ["a", "b"]}]},
+    )
+    assert result is None

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,82 @@
+"""Permission handler tests covering the Tier 1.5 fast path (mika#1191 Phase A).
+
+The full `create_permission_handler` flow is exercised by the CLI/agent tests;
+this module unit-tests the deterministic short-circuits introduced for the
+mika-relay deprecation milestone, where the relay-bound LLM hop must not fire
+for events that are equivalent to TIER 1.5 in
+`mika/skills/bundled/permission-policy/system_prompt.md`.
+"""
+
+from __future__ import annotations
+
+from claude_pilot.permissions import try_tier_1_5_auto_answer
+from claude_pilot.types import PilotResponseAnswer
+
+
+def test_compact_safe_question_auto_answered() -> None:
+    question = "Choose between full compound and compact-safe compaction modes:"
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": [{"question": question, "options": []}]},
+    )
+    assert isinstance(result, PilotResponseAnswer)
+    assert result.action == "answer"
+    assert result.answers == {question: "compact-safe"}
+
+
+def test_compact_safe_keyword_match_case_insensitive() -> None:
+    question = "Run Compact-Safe mode for this session?"
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": [{"question": question}]},
+    )
+    assert isinstance(result, PilotResponseAnswer)
+    assert result.answers == {question: "compact-safe"}
+
+
+def test_non_compact_safe_question_returns_none() -> None:
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": [{"question": "What's the capital of France?"}]},
+    )
+    assert result is None
+
+
+def test_non_ask_user_question_tool_returns_none() -> None:
+    # The short-circuit is gated on tool_name; never fire for Bash/Write/etc.
+    result = try_tier_1_5_auto_answer(
+        "Bash",
+        {"command": "echo compact-safe"},
+    )
+    assert result is None
+
+
+def test_partial_match_falls_through_to_relay() -> None:
+    # Mixed AskUserQuestion: one question matches compact-safe, another does
+    # not. Returning a partial answer would leave the non-matching question
+    # unanswered and break the SDK contract — fall through instead.
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {
+            "questions": [
+                {"question": "Choose compact-safe or full compound:"},
+                {"question": "Pick a database flavor:"},
+            ],
+        },
+    )
+    assert result is None
+
+
+def test_empty_questions_returns_none() -> None:
+    assert try_tier_1_5_auto_answer("AskUserQuestion", {}) is None
+    assert try_tier_1_5_auto_answer("AskUserQuestion", {"questions": []}) is None
+    assert try_tier_1_5_auto_answer("AskUserQuestion", {"questions": "not a list"}) is None
+
+
+def test_malformed_question_shape_returns_none() -> None:
+    # A non-dict entry inside the questions list is malformed; fall through.
+    result = try_tier_1_5_auto_answer(
+        "AskUserQuestion",
+        {"questions": ["compact-safe"]},
+    )
+    assert result is None

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -378,6 +378,26 @@ def test_gh_issue_edit_compound_denied_if_unsafe_part() -> None:
 # ── mika#1191 Phase A — TIER 3 parity check vs system_prompt.md ──────────────
 
 
+# ── Newline command smuggling (ce:review adversarial finding ADV-1) ─────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Bare newline between two leaves — bash treats `\n` like `;`
+        "git status\nrm -rf /tmp",
+        "mika ask --agent mika-arch x\ncargo install backdoor-pkg",
+        "gh issue view 1\ngit push --force origin main",
+        # Carriage-return-newline pair (Windows-shaped paste)
+        "git status\r\nrm -rf /tmp",
+        # Newline inside a long compound where the tail is unsafe
+        "cd /tmp && git status\nbash -c 'rm -rf /'",
+    ],
+)
+def test_newline_smuggled_unsafe_tail_denied(command: str) -> None:
+    assert is_safe_bash_command(command) is False, command
+
+
 def test_tier3_parity_with_system_prompt() -> None:
     """Pre-implementation diff guard. system_prompt.md:39-44 enumerates the
     TIER 3 deny-list as prose. This pins each concrete command pattern from

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -14,8 +14,10 @@ from pathlib import Path
 import pytest
 
 from claude_pilot.tier1 import (
+    INTRA_PLATFORM_AGENTS,
     is_safe_bash_command,
     is_safe_git_command,
+    is_safe_mika_dispatch,
     is_safe_shell_command,
     is_tier1_auto_approve,
     is_tier3_dangerous,
@@ -265,3 +267,137 @@ def test_cd_leaf_is_safe_shell() -> None:
     assert is_safe_shell_command("cd /some/path") is True
     assert is_safe_shell_command("cd") is True
     assert is_safe_shell_command("command -v lefthook") is True
+
+
+# ── mika#1191 Phase A — intra-platform agent dispatch ────────────────────────
+
+
+def test_intra_platform_agents_frozenset() -> None:
+    # Ports the prose allow-list at mika permission-policy/system_prompt.md:21.
+    # If this set diverges from well_known_agents.rs:386-396, the cross-language
+    # sentinel should escalate to build-time codegen (mika#935 follow-up).
+    assert frozenset({"mika-arch", "mika-dev", "mika-qa"}) == INTRA_PLATFORM_AGENTS
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'mika ask --agent mika-arch "@/tmp/brief.md"',
+        'mika ask --agent mika-dev "implement mika#1191"',
+        'mika ask --agent mika-qa "review PR#456"',
+    ],
+)
+def test_intra_platform_dispatch_approved(command: str) -> None:
+    assert is_safe_mika_dispatch(command) is True, command
+    assert is_safe_bash_command(command) is True, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'mika ask --agent some-other-agent "..."',
+        'mika ask --agent mika-relay "permission check"',  # relay is target, not initiator
+        'mika ask --agent operator "..."',
+        # Wildcard rejection — never broaden the allow-list to a pattern
+        'mika ask --agent * "..."',
+    ],
+)
+def test_intra_platform_dispatch_other_agent_denied(command: str) -> None:
+    assert is_safe_mika_dispatch(command) is False, command
+    assert is_safe_bash_command(command) is False, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cd /tmp && mika ask --agent mika-arch "review this"',
+        'cd /data/workspace/mika-platform/mika && mika ask --agent mika-dev "groom #1234"',
+    ],
+)
+def test_intra_platform_dispatch_compound_with_cd_approved(command: str) -> None:
+    # Compound-safety inherits from is_safe_bash_command's segment splitter +
+    # the OR chain in _is_safe_sub_command. No additional regex needed.
+    assert is_safe_bash_command(command) is True, command
+
+
+def test_mika_dispatch_compound_denied_if_unsafe_part() -> None:
+    # NF4 negative case: TIER3 blocker on the compound trips even if the
+    # mika ask part is otherwise safe.
+    cmd = 'mika ask --agent mika-arch "do thing" && rm -rf /tmp'
+    assert is_safe_bash_command(cmd) is False
+    # Confirm via the deny-list rather than dispatch — the dispatch check
+    # itself never sees the compound; it's the split + tier3-on-raw chain.
+    assert is_tier3_dangerous(cmd) is True
+
+
+def test_bare_mika_command_not_dispatch() -> None:
+    # Plain `mika` (no `ask --agent`) is not the dispatch verb.
+    assert is_safe_mika_dispatch("mika status") is False
+    assert is_safe_mika_dispatch("mika ask --help") is False
+
+
+# ── mika#1191 Phase A — GitHub authoring (issue edit/comment) ────────────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'gh issue edit 123 --body-file /tmp/x.md',
+        'gh issue edit 1191 --add-label ready',
+        'gh issue comment 123 --body "groomed and ready"',
+        'gh issue comment 1191 --body-file /tmp/closing.md',
+    ],
+)
+def test_gh_issue_edit_comment_approved(command: str) -> None:
+    assert is_safe_bash_command(command) is True, command
+
+
+def test_gh_issue_create_not_in_tier1() -> None:
+    # `gh issue create` stays out of the allow-list — issue creation goes
+    # through the relay (auditable, intent-confirmation point).
+    assert is_safe_bash_command(
+        'gh issue create --repo senara-solutions/mika --title "x"'
+    ) is False
+
+
+def test_gh_issue_view_still_approved() -> None:
+    # Existing TIER 1 read-only — guard against accidental regression
+    # when extending the issue subcommand allow-list.
+    assert is_safe_bash_command("gh issue view 123") is True
+    assert is_safe_bash_command("gh issue list --label ready") is True
+
+
+def test_gh_issue_edit_compound_denied_if_unsafe_part() -> None:
+    # NF4 negative case: TIER3 blocker on the compound trips even if the
+    # gh issue edit part is otherwise safe.
+    cmd = 'gh issue edit 123 --body "x" && rm -rf /tmp'
+    assert is_safe_bash_command(cmd) is False
+    assert is_tier3_dangerous(cmd) is True
+
+
+# ── mika#1191 Phase A — TIER 3 parity check vs system_prompt.md ──────────────
+
+
+def test_tier3_parity_with_system_prompt() -> None:
+    """Pre-implementation diff guard. system_prompt.md:39-44 enumerates the
+    TIER 3 deny-list as prose. This pins each concrete command pattern from
+    that prose against TIER3_PATTERNS — if either side drifts, this test
+    fails and the operator updates both surfaces in lockstep.
+
+    Expected delta during Phase A: zero (current TIER3_PATTERNS already
+    mirrors the prose list).
+    """
+    prose_tier3_commands = [
+        "rm -rf /tmp/foo",            # rm -rf
+        "git push --force origin x",  # git push --force
+        "git reset --hard HEAD~1",    # git reset --hard
+        "DROP TABLE users",           # DROP TABLE
+        "cargo publish",              # cargo publish
+        "sed -i s/a/b/ file",         # sed -i
+        "gh label delete bug",        # gh label delete
+        "gh label edit bug",          # gh label edit
+        "git push origin main",       # push to main/master
+        "git push origin master",
+    ]
+    for cmd in prose_tier3_commands:
+        assert is_tier3_dangerous(cmd) is True, cmd


### PR DESCRIPTION
## Summary

Phase A of mika#1188 (milestone: Deprecate mika-relay). Ports the deterministic TIER 1 + TIER 1.5 + TIER 3 rules from `mika/skills/bundled/permission-policy/system_prompt.md` into claude-pilot's in-process classifier so the LLM-backed `mika-relay` is only invoked for residual ambiguous cases.

Plan: `docs/plans/2026-05-17-001-feat-tier1-expansion-mika1191-companion.md` (this repo, companion); canonical plan on mika at `mika/docs/plans/2026-05-17-004-feat-1191-tier1-expansion-plan.md` (architect-groomed two-pass `GROOMED`).

Companion PR: senara-solutions/mika#1194 (to be filed against the same branch; carries the plan doc and milestone bookkeeping).
Closes: senara-solutions/mika#1191 (cross-repo close — the issue's implementation is here).

## Changes

**Source:**
- `src/claude_pilot/tier1.py` — `is_safe_mika_dispatch` (intra-platform agents allow-list: `mika-arch`, `mika-dev`, `mika-qa`); `SAFE_GH_SUBCOMMANDS[\"issue\"]` extended with `\"edit\"` and `\"comment\"`. Added to `_is_safe_sub_command` OR chain. `_COMPOUND_SPLIT_RE` updated to split on `\n` (closes ce:review ADV-1 newline-smuggling regression).
- `src/claude_pilot/permissions.py` — `try_tier_1_5_auto_answer` short-circuit before relay; auto-answers AskUserQuestion events where every question matches `\bcompact-safe\b` (case-insensitive, word-bounded).

**Tests:**
- `tests/test_tier1.py` — 25 new test cases (intra-platform dispatch positive/negative, gh issue authoring, compound-safety inheritance, TIER 3 parity guard, newline-smuggling regression).
- `tests/test_permissions.py` (NEW) — 11 tests for the TIER 1.5 fast path (word boundary, malformed shapes, partial matches, missing fields).
- `tests/replay/replay_relay_decisions.py` (NEW) — operator-runnable replay harness; reads `~/.mika/data/mika.db` mika-relay events, replays through tier1, reports local-resolution percentage. NF3 hard-floor: exit 2 when `unreplayable_ratio >= 0.30` to prevent vacuous-truth from a broken harness skipping most events.

Total tests: **167 passing** (was 131 pre-PR). Ruff clean. Mypy clean.

## Acceptance criteria (from plan)

- **A-AC1** ✓ All TIER 1 rules from `system_prompt.md:13-22` encoded as deterministic patterns. Cross-ref to `mika/crates/mika-agent/src/server/permission_pre_classifier.rs` (NF6): same rule shape; no divergence detected on Phase A scope.
- **A-AC2** ✓ TIER 1.5 \"compact-safe\" question auto-answered by `try_tier_1_5_auto_answer` without invoking the relay.
- **A-AC3** ◑ Replay harness implemented + smoke-tested. Local dev DB has 60% unreplayable (in-flight sessions without committed assistant replies), so NF3 fires with exit 2 — the operator runs against the production-shaped DB on the mika host to measure A-AC3 against the deployed corpus.
- **A-AC4** ✓ Existing tier1 tests unchanged in pass count; new cases: 36 (≥10 floor).
- **A-AC5** ◑ Latency instrumentation already present in `permissions.py` via `time.perf_counter` around the relay dispatch decision. The replay harness `--emit-latency` flag computes the pre-change p50/p95 baseline from `messages.created_at` deltas.

## Sentinel cross-ref

`INTRA_PLATFORM_AGENTS` in `tier1.py` is the third surface of the same allow-list — alongside `mika/crates/mika-agent/src/well_known_agents.rs:386-396` and `mika/skills/bundled/permission-policy/system_prompt.md:21`. Per the comment block at `tier1.py:283-286`, this duplication is intentional for Phase A (3 entries < 5-entry codegen threshold).

## ce:review findings — handled and deferred

**Fixed in this PR (commit 7dc859e):**
- ADV-1 newline command smuggling (P0): `_COMPOUND_SPLIT_RE` now splits on `\n`.
- Replay harness Write/Edit nondeterminism (P1): skip Write/Edit since PilotEvent never carries cwd.
- TIER 1.5 word boundary (P2): match `\bcompact-safe\b` instead of substring.

**Follow-ups to file (not bundled per scope discipline):**
- SEC-1 / SEC-2: `gh issue edit/comment` flag-level allow-list (`--body-file`, `--add-label ready`, `--repo` containment) — currently inherits the plan's coarse \"add edit/comment to SAFE_GH_SUBCOMMANDS\" granularity.
- SEC-3: `<` and `<<` input-redirect blocker in TIER 3 — pre-existing asymmetry with `>` output-redirect (already blocked).
- SEC-4 / ADV-3: TIER 1.5 should match on `options` shape rather than question text substring.
- Correctness #3 (ADV-5): replay harness `_find_assistant_reply` picks the first assistant message; multi-message replies inflate unreplayable count.
- Shared classifier helper between `permissions.create_permission_handler` and replay harness `_classify_locally` to prevent drift.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run pytest` — 167 passed
- [x] Smoke replay harness against local DB — runs cleanly, NF3 hard-floor exit 2 on environmental data
- [ ] Replay harness against production-shaped DB on mika host (post-deploy verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
