### PR TITLE
feat(claude-pilot): orchestrator inbox writer for mika#1189

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ src/claude_pilot/permissions.py  → can_use_tool: tier1 short-circuit, relay, r
 src/claude_pilot/tier1.py        → Auto-approval filter: deny-list, safe command patterns, path safety
 src/claude_pilot/transport.py    → asyncio.create_subprocess_exec transport with Pydantic validation
 src/claude_pilot/guardrails.py   → Stall / empty / idle-timeout detection with pausable idle timer
+src/claude_pilot/inbox_writer.py → mika#1189 side-channel handoff to mika-gateway orchestrator inbox
 src/claude_pilot/ui.py           → Stderr log renderer (ANSI colors)
 src/claude_pilot/types.py        → Pydantic models: PilotConfig, PilotEvent, PilotResponse, ResultJson
 src/claude_pilot/logger.py       → File + stderr sink with ANSI stripping
@@ -45,6 +46,7 @@ src/claude_pilot/logger.py       → File + stderr sink with ANSI stripping
 - **Session guardrails** detect degenerate loops (stall, empty responses, idle) and terminate cleanly with structured `ResultJson` output. SDK-native `max_turns` is passed through to the SDK. Idle timer pauses during `can_use_tool` to avoid false positives from slow relay agents.
 - **Pipeline slash commands bypass relay approval.** The `Skill` tool invocations for `/mika`, `/ce:*`, `/compound-engineering:resolve_todo_parallel`, and `/mika-doc-audit` are auto-approved at Tier 1. These are the agent's own orchestration steps — routing them through the relay exposes them to LLM-driven denials that rationalize fabricated rejections. The allow-list is in `TIER1_SAFE_SKILLS` in `src/claude_pilot/tier1.py`.
 - **Relay payload prefix.** Events are written to relay stdin as `[claude-pilot] <PilotEvent JSON>`. The prefix is load-bearing — LLM-backed relay agents key on it to distinguish claude-pilot events from user prose and webhook notifications.
+- **Orchestrator inbox side-channel (mika#1189).** On the success path, after `_emit_result(result)` in `agent.py`, the session calls `inbox_writer.post_handoff(result)` — a best-effort HTTP POST to `${MIKA_GATEWAY_URL}/orchestrator/inbox/{MIKA_ORCHESTRATOR_ID}/message`. Dual-write with the mika-platform#100 filesystem inbox; filesystem write remains canonical. Gated by `MIKA_ORCHESTRATOR_INBOX_ENABLED=1` AND a valid `MIKA_ORCHESTRATOR_ID`. Failures are logged to stderr but never change the exit code. The function returns `False` (silent no-op) when env is incomplete OR the gateway responds 404 (its own feature flag off). See `inbox_writer.py` constants and the gateway plan: `mika/docs/plans/2026-05-17-003-feat-1189-mika-gateway-orchestrator-inbox-v2-plan.md`.
 
 ## Environment Variables
 
@@ -53,6 +55,17 @@ Place a `.env` file in the package root (alongside `pyproject.toml`). Values do 
 The `.env` file is gitignored and not copied to worktrees. Autonomous sessions inherit env vars from the parent process.
 
 **Note:** Variables matching sensitive patterns (`TOKEN`, `KEY`, `SECRET`, `AUTH`, etc.) are scrubbed from the relay child process by `scrub_env()` in `transport.py`, but remain visible to the Claude Code SDK subprocess — by design. Claude Code needs tokens like `GH_TOKEN` to operate; the relay agent should not see them.
+
+### Orchestrator inbox (mika#1189)
+
+The inbox writer reads four env vars at call time — all four must be set for the side-channel post to fire:
+
+- `MIKA_ORCHESTRATOR_INBOX_ENABLED` — `1` / `true` (case-insensitive) enables; `0`, `2`, `false`, empty, or unset disables. The `2` (gateway-only cutover) value is reserved for a future ticket and currently treated as disabled to avoid silent partial cutover.
+- `MIKA_ORCHESTRATOR_ID` — orchestrator session id (1-128 chars, `[A-Za-z0-9_-]`). Exported by `scripts/mika-platform-spawn` from a cached id at `~/.mika/orchestrator/id`.
+- `MIKA_GATEWAY_URL` — base URL of the mika-gateway (e.g. `https://gateway.example`). Trailing slash is normalised away.
+- `MIKA_INTERNAL_TOKEN` — bearer token shared with the gateway (already known to claude-pilot for other paths).
+
+`MIKA_SPAWN_ID` is read opportunistically to populate the `spawn_id` correlation field; absent → null in the envelope.
 
 ## Key SDK Types
 

--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -18,6 +18,7 @@ from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 from claude_agent_sdk.types import AssistantMessage, ResultMessage, SystemMessage
 
 from .guardrails import SessionGuardrails, TurnBoundaryEvent
+from .inbox_writer import post_handoff
 from .permissions import CanUseTool
 from .types import ResultJson
 from .ui import (
@@ -178,6 +179,15 @@ async def run_agent(
                         termination_reason=termination_reason,
                     )
                     _emit_result(result)
+
+                    # mika#1189: side-channel handoff to the gateway
+                    # orchestrator inbox, alongside the existing
+                    # mika-platform#100 filesystem-inbox write. Both no-op
+                    # silently when their respective env vars are unset.
+                    # Failures here MUST NOT change exit code — _emit_result
+                    # is the canonical signal.
+                    if status == "success":
+                        post_handoff(result)
 
                     if status == "success":
                         log_done(message.num_turns, result.cost_usd, message.duration_ms)

--- a/src/claude_pilot/inbox_writer.py
+++ b/src/claude_pilot/inbox_writer.py
@@ -1,0 +1,188 @@
+"""Orchestrator inbox writer (mika#1189).
+
+Posts session-end handoff messages to the mika-gateway orchestrator inbox
+endpoint, supplementing the existing filesystem-inbox protocol from
+mika-platform#100. Dual-write semantics during the migration window — the
+filesystem write is the canonical path; the HTTP post is a side channel that
+fails open.
+
+Gated by two env vars (both must be set):
+
+- ``MIKA_ORCHESTRATOR_INBOX_ENABLED`` — case-insensitive `1`/`true` enables
+  the writer. `2` (gateway-only cutover) is reserved for a future ticket and
+  currently treated as disabled to prevent silent partial cutover.
+- ``MIKA_ORCHESTRATOR_ID`` — orchestrator session id passed through by
+  ``scripts/mika-platform-spawn``. Must be 1-128 chars matching the gateway's
+  ``[A-Za-z0-9_-]`` regex.
+
+Transport reads ``MIKA_GATEWAY_URL`` and ``MIKA_INTERNAL_TOKEN`` (same env
+vars the agent SDK already consumes). Failures are logged via stderr and never
+change the agent's exit code — canonical output remains the stdout
+``ResultJson`` line.
+
+See the plan for the full rationale:
+``mika/docs/plans/2026-05-17-003-feat-1189-mika-gateway-orchestrator-inbox-v2-plan.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .types import ResultJson
+
+# Module-level constants (tuneable by code edit) — match the gateway side so
+# either edit is enough to discover the other.
+
+# Per-request timeout for the inbox write. Side-channel; we never want to slow
+# the agent's shutdown waiting on a slow gateway.
+INBOX_POST_TIMEOUT_SECS: float = 5.0
+
+# Max body size we'll send. Belt-and-braces against accidental payload growth;
+# the gateway enforces 256KB with a 413 anyway.
+INBOX_BODY_LIMIT_BYTES: int = 200 * 1024
+
+
+def is_orchestrator_inbox_enabled(raw: str | None) -> bool:
+    """Mirror of the gateway's ``orchestrator_inbox_is_enabled`` rule.
+
+    ``1`` and ``true`` (case-insensitive, surrounding whitespace stripped) are
+    on. Anything else — including ``0``, ``false``, empty, ``2`` — is off.
+    """
+    if raw is None:
+        return False
+    lower = raw.strip().lower()
+    return lower in ("1", "true")
+
+
+def _is_valid_orchestrator_id(value: str) -> bool:
+    """Match the gateway's ``is_valid_orchestrator_id`` so we never POST an id
+    the gateway will reject with 400. ASCII-alphanumeric plus hyphen /
+    underscore, 1-128 chars.
+    """
+    if not value or len(value) > 128:
+        return False
+    return all(c.isalnum() or c in "-_" for c in value)
+
+
+def post_handoff(
+    result: ResultJson,
+    *,
+    spawn_id: str | None = None,
+    extra_body: dict[str, Any] | None = None,
+) -> bool:
+    """Post a handoff message to the orchestrator inbox.
+
+    Returns ``True`` on a 201 from the gateway, ``False`` on any skip /
+    failure. Never raises.
+
+    The function reads env vars at call time so the caller doesn't need to
+    cache them. Disabling the writer is a single env-var flip with no code
+    change.
+
+    ``spawn_id`` defaults to ``$MIKA_SPAWN_ID`` for consistency with
+    mika-platform#100's filesystem-inbox protocol; pass explicitly to override.
+    """
+    enabled_raw = os.environ.get("MIKA_ORCHESTRATOR_INBOX_ENABLED")
+    if not is_orchestrator_inbox_enabled(enabled_raw):
+        return False
+
+    orchestrator_id = os.environ.get("MIKA_ORCHESTRATOR_ID")
+    if not orchestrator_id or not _is_valid_orchestrator_id(orchestrator_id):
+        if orchestrator_id:
+            _warn(
+                "MIKA_ORCHESTRATOR_ID does not match the gateway's id rule "
+                f"(1-128 chars [A-Za-z0-9_-]); got {orchestrator_id!r} — skipping inbox post."
+            )
+        return False
+
+    gateway_url = os.environ.get("MIKA_GATEWAY_URL")
+    if not gateway_url:
+        _warn("MIKA_GATEWAY_URL unset; skipping orchestrator inbox post.")
+        return False
+
+    internal_token = os.environ.get("MIKA_INTERNAL_TOKEN")
+    if not internal_token:
+        _warn("MIKA_INTERNAL_TOKEN unset; skipping orchestrator inbox post.")
+        return False
+
+    if spawn_id is None:
+        spawn_id = os.environ.get("MIKA_SPAWN_ID") or None
+
+    body: dict[str, Any] = {
+        "result": json.loads(result.to_line()),
+    }
+    if extra_body:
+        body.update(extra_body)
+
+    envelope: dict[str, Any] = {
+        "spawn_id": spawn_id,
+        "kind": "handoff",
+        "body": body,
+    }
+    payload = json.dumps(envelope).encode("utf-8")
+    if len(payload) > INBOX_BODY_LIMIT_BYTES:
+        _warn(
+            f"orchestrator inbox payload {len(payload)} bytes exceeds "
+            f"INBOX_BODY_LIMIT_BYTES={INBOX_BODY_LIMIT_BYTES}; skipping post."
+        )
+        return False
+
+    url = _build_url(gateway_url, orchestrator_id)
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        method="POST",
+        headers={
+            "authorization": f"Bearer {internal_token}",
+            "content-type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=INBOX_POST_TIMEOUT_SECS) as resp:
+            status = resp.status
+            if status == 201:
+                return True
+            if status == 404:
+                # Gateway has the feature flag off — caller is dual-writing
+                # ahead of cutover. Silent skip; filesystem inbox carries the
+                # canonical message.
+                return False
+            _warn(
+                f"orchestrator inbox post returned unexpected status {status}; "
+                "filesystem inbox remains the canonical path."
+            )
+            return False
+    except urllib.error.HTTPError as e:
+        _warn(
+            f"orchestrator inbox post got HTTP {e.code}: {e.reason}; "
+            "filesystem inbox remains the canonical path."
+        )
+        return False
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        _warn(
+            f"orchestrator inbox post failed to reach {url}: {e}; "
+            "filesystem inbox remains the canonical path."
+        )
+        return False
+
+
+def _build_url(gateway_url: str, orchestrator_id: str) -> str:
+    """Join the gateway base URL with the inbox path, normalizing trailing /."""
+    base = gateway_url.rstrip("/")
+    return f"{base}/orchestrator/inbox/{orchestrator_id}/message"
+
+
+def _warn(msg: str) -> None:
+    """Best-effort stderr write; never raises. Mirrors ``ui.log_*`` style
+    without the ANSI deps so this module stays import-cheap."""
+    try:
+        sys.stderr.write(f"[claude-pilot inbox] {msg}\n")
+        sys.stderr.flush()
+    except OSError:
+        pass

--- a/tests/test_inbox_writer.py
+++ b/tests/test_inbox_writer.py
@@ -1,0 +1,307 @@
+"""Tests for the orchestrator inbox writer (mika#1189)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_pilot.inbox_writer import (
+    _build_url,
+    _is_valid_orchestrator_id,
+    is_orchestrator_inbox_enabled,
+    post_handoff,
+)
+from claude_pilot.types import ResultJson
+
+# -- Pure helpers --
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("2", False),  # reserved future value — currently disabled
+        ("anything-else", False),
+        ("1", True),
+        (" 1 ", True),
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("\ttrue\n", True),
+    ],
+)
+def test_is_orchestrator_inbox_enabled(raw: str | None, expected: bool) -> None:
+    assert is_orchestrator_inbox_enabled(raw) is expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("", False),
+        ("a", True),
+        ("550e8400-e29b-41d4-a716-446655440000", True),
+        ("20260517T204027Z-12345", True),
+        ("vincent_desktop_orch_1", True),
+        ("a" * 128, True),
+        ("a" * 129, False),
+        ("../etc/passwd", False),
+        ("foo/bar", False),
+        ("foo bar", False),
+        ("foo@bar", False),
+        ("foo$bar", False),
+    ],
+)
+def test_is_valid_orchestrator_id(value: str, expected: bool) -> None:
+    assert _is_valid_orchestrator_id(value) is expected
+
+
+def test_build_url_normalises_trailing_slash() -> None:
+    assert (
+        _build_url("https://gw.example/", "orch-1")
+        == "https://gw.example/orchestrator/inbox/orch-1/message"
+    )
+    assert (
+        _build_url("https://gw.example", "orch-1")
+        == "https://gw.example/orchestrator/inbox/orch-1/message"
+    )
+    assert (
+        _build_url("https://gw.example//", "orch-1")
+        == "https://gw.example/orchestrator/inbox/orch-1/message"
+    )
+
+
+# -- post_handoff env-gating --
+
+
+def _result(**overrides: Any) -> ResultJson:
+    base = {
+        "status": "success",
+        "subtype": "success",
+        "task_id": "t-1",
+        "session_id": "sess-1",
+        "turns": 12,
+        "cost_usd": 0.42,
+        "duration_ms": 12345,
+    }
+    base.update(overrides)
+    return ResultJson(**base)
+
+
+def test_post_handoff_skips_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", raising=False)
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+    assert post_handoff(_result()) is False
+
+
+def test_post_handoff_skips_when_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "0")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+    assert post_handoff(_result()) is False
+
+
+def test_post_handoff_skips_when_orchestrator_id_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.delenv("MIKA_ORCHESTRATOR_ID", raising=False)
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+    assert post_handoff(_result()) is False
+
+
+def test_post_handoff_skips_when_orchestrator_id_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "../etc/passwd")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+    assert post_handoff(_result()) is False
+
+
+def test_post_handoff_skips_when_gateway_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.delenv("MIKA_GATEWAY_URL", raising=False)
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+    assert post_handoff(_result()) is False
+
+
+def test_post_handoff_skips_when_internal_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.delenv("MIKA_INTERNAL_TOKEN", raising=False)
+    assert post_handoff(_result()) is False
+
+
+# -- post_handoff success path --
+
+
+def test_post_handoff_posts_envelope_to_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-abc")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok-xyz")
+    monkeypatch.setenv("MIKA_SPAWN_ID", "spawn-xyz")
+
+    response = MagicMock()
+    response.status = 201
+    response.__enter__ = lambda self: response
+    response.__exit__ = lambda self, exc_type, exc_val, exc_tb: None
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: float) -> Any:
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.headers)
+        captured["body"] = req.data
+        captured["timeout"] = timeout
+        return response
+
+    with patch("claude_pilot.inbox_writer.urllib.request.urlopen", side_effect=fake_urlopen):
+        assert post_handoff(_result()) is True
+
+    assert captured["url"] == "https://gw.example/orchestrator/inbox/orch-abc/message"
+    assert captured["method"] == "POST"
+    assert captured["headers"]["Authorization"] == "Bearer tok-xyz"
+    assert captured["headers"]["Content-type"] == "application/json"
+    assert captured["timeout"] > 0
+
+    parsed = json.loads(captured["body"])
+    assert parsed["spawn_id"] == "spawn-xyz"
+    assert parsed["kind"] == "handoff"
+    assert parsed["body"]["result"]["status"] == "success"
+    assert parsed["body"]["result"]["turns"] == 12
+
+
+def test_post_handoff_uses_explicit_spawn_id_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+    monkeypatch.setenv("MIKA_SPAWN_ID", "env-spawn")
+
+    response = MagicMock()
+    response.status = 201
+    response.__enter__ = lambda self: response
+    response.__exit__ = lambda self, exc_type, exc_val, exc_tb: None
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: float) -> Any:
+        captured["body"] = req.data
+        return response
+
+    with patch("claude_pilot.inbox_writer.urllib.request.urlopen", side_effect=fake_urlopen):
+        assert post_handoff(_result(), spawn_id="explicit-spawn") is True
+
+    parsed = json.loads(captured["body"])
+    assert parsed["spawn_id"] == "explicit-spawn"
+
+
+def test_post_handoff_skips_when_payload_oversized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+
+    huge_payload = {"giant": "x" * (300 * 1024)}
+
+    with patch("claude_pilot.inbox_writer.urllib.request.urlopen") as urlopen_mock:
+        assert post_handoff(_result(), extra_body=huge_payload) is False
+        urlopen_mock.assert_not_called()
+
+
+def test_post_handoff_returns_false_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gateway has the feature flag off — caller must keep filesystem inbox as
+    canonical (silent no-op semantics)."""
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+
+    response = MagicMock()
+    response.status = 404
+    response.__enter__ = lambda self: response
+    response.__exit__ = lambda self, exc_type, exc_val, exc_tb: None
+
+    with patch("claude_pilot.inbox_writer.urllib.request.urlopen", return_value=response):
+        assert post_handoff(_result()) is False
+
+
+def test_post_handoff_returns_false_on_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+
+    import urllib.error
+
+    with patch(
+        "claude_pilot.inbox_writer.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        # Must not raise; must return False.
+        assert post_handoff(_result()) is False
+
+
+def test_post_handoff_returns_false_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+
+    import urllib.error
+
+    with patch(
+        "claude_pilot.inbox_writer.urllib.request.urlopen",
+        side_effect=urllib.error.HTTPError(
+            "https://gw.example",
+            500,
+            "boom",
+            {},
+            None,  # type: ignore[arg-type]
+        ),
+    ):
+        assert post_handoff(_result()) is False
+
+
+def test_post_handoff_returns_false_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_INBOX_ENABLED", "1")
+    monkeypatch.setenv("MIKA_ORCHESTRATOR_ID", "orch-1")
+    monkeypatch.setenv("MIKA_GATEWAY_URL", "https://gw.example")
+    monkeypatch.setenv("MIKA_INTERNAL_TOKEN", "tok")
+
+    with patch(
+        "claude_pilot.inbox_writer.urllib.request.urlopen",
+        side_effect=TimeoutError("slow gateway"),
+    ):
+        assert post_handoff(_result()) is False


### PR DESCRIPTION
## Summary

Phase 2 of the mika#1189 orchestrator inbox v2 implementation — adds a best-effort HTTP side-channel that posts session-end handoff messages to the mika-gateway orchestrator inbox endpoint, alongside the existing mika-platform#100 filesystem-inbox protocol.

**Companion PRs:**
- senara-solutions/mika#1198 — gateway endpoints (primary)
- senara-solutions/mika-platform#130 — orchestrator-id helper + spawn-side export + operator poll client

## What's new

- `src/claude_pilot/inbox_writer.py` — single `post_handoff(result)` function. Reads `MIKA_ORCHESTRATOR_INBOX_ENABLED`, `MIKA_ORCHESTRATOR_ID`, `MIKA_GATEWAY_URL`, `MIKA_INTERNAL_TOKEN`, and `MIKA_SPAWN_ID` at call time. POSTs the `ResultJson` envelope to `/orchestrator/inbox/{id}/message`. Returns `False` on any skip/failure; never raises.
- `src/claude_pilot/agent.py` — invoked from `run_agent()` after `_emit_result(result)` on the success path. Failure of the inbox post does NOT change the agent's exit code — `_emit_result` remains canonical.
- `CLAUDE.md` — module description, env-var contract, dual-write semantics.

## Design

- **Dual-write with mika-platform#100.** Filesystem inbox at `~/.mika/orchestrator/inbox/<spawn_id>.json` continues to receive every handoff; the HTTP post is purely additive. Disabling the feature flag removes the HTTP path; filesystem path is unchanged.
- **Feature-flag rule mirrors the gateway.** `1`/`true` (case-insensitive, whitespace-stripped) → on. `0`/`2`/`false`/empty/unset → off. `2` (gateway-only cutover) is reserved for a future ticket; currently treated as disabled on both sides to prevent silent partial cutover.
- **ID validation mirrors the gateway.** `_is_valid_orchestrator_id()` enforces the same 1-128 chars, `[A-Za-z0-9_-]` rule used by `is_valid_id_token()` in `crates/mika-gateway/src/orchestrator_inbox.rs`. Skips silently with a stderr note if `MIKA_ORCHESTRATOR_ID` is unset or malformed.
- **Fails open.** HTTPError / URLError / TimeoutError / OSError on the POST → log to stderr, return False. The agent's stdout `ResultJson` is the canonical signal; the inbox post is a side channel.
- **Payload cap.** 200KB Python-side cap before send (gateway enforces 256KB with a 413 anyway).

## Tests

- 40 new tests in `tests/test_inbox_writer.py`:
  - 14 parametric cases for `is_orchestrator_inbox_enabled` (case-insensitivity, `2` reserved, whitespace).
  - 12 parametric cases for `_is_valid_orchestrator_id` (length boundary, path-traversal, special chars).
  - URL trailing-slash normalization.
  - Env-gating skips (disabled, `=0`, id missing, id invalid, gateway URL missing, token missing).
  - Success-path envelope shape (mocked urlopen captures URL, method, headers, body).
  - Explicit `spawn_id` overrides `MIKA_SPAWN_ID` env.
  - Oversized payload rejected without HTTP call.
  - 404 from gateway → silent skip.
  - URLError / HTTPError / TimeoutError fallbacks all return False without raising.

`uv run pytest` 207 passed. `uv run ruff check` and `uv run mypy src` clean.

## Test plan

- [ ] Set `MIKA_ORCHESTRATOR_INBOX_ENABLED=1` + valid `MIKA_ORCHESTRATOR_ID`, run claude-pilot to completion against a local gateway with the feature flag also enabled. Confirm a row appears in `orchestrator_inbox_messages` via `SELECT * FROM orchestrator_inbox_messages ORDER BY id DESC LIMIT 1`.
- [ ] With the gateway feature flag off (`MIKA_ORCHESTRATOR_INBOX_ENABLED` unset), confirm the writer logs the 404 quietly and exit code is unchanged.
- [ ] With `MIKA_ORCHESTRATOR_INBOX_ENABLED` unset on the claude-pilot side, confirm zero network traffic to the gateway endpoint.

Plan: `mika/docs/plans/2026-05-17-003-feat-1189-mika-gateway-orchestrator-inbox-v2-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)