### PR TITLE
fix(agent): _text_of handles SDK dataclass TextBlock (cpp#12)

### DIFF
--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -284,9 +284,8 @@ def _text_of(block: Any) -> str | None:
             return text if isinstance(text, str) else None
         return None
     t = getattr(block, "type", None)
-    if not isinstance(t, str):
-        if type(block).__name__ == "TextBlock":
-            t = "text"
+    if not isinstance(t, str) and type(block).__name__ == "TextBlock":
+        t = "text"
     if t == "text":
         text = getattr(block, "text", None)
         return text if isinstance(text, str) else None

--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -271,12 +271,23 @@ def _content_blocks(message: AssistantMessage) -> list[Any]:
 
 
 def _text_of(block: Any) -> str | None:
+    """Extract text from a content block.
+
+    Mirrors `guardrails._block_type` dual-shape handling: SDK dataclass
+    instances (TextBlock, etc.) do NOT carry a `type` attribute — the
+    wire-format `type` field is consumed by the SDK parser. Fall back on
+    class name for dataclass-shaped blocks (cpp#12).
+    """
     if isinstance(block, dict):
         if block.get("type") == "text":
             text = block.get("text")
             return text if isinstance(text, str) else None
         return None
-    if getattr(block, "type", None) == "text":
+    t = getattr(block, "type", None)
+    if not isinstance(t, str):
+        if type(block).__name__ == "TextBlock":
+            t = "text"
+    if t == "text":
         text = getattr(block, "text", None)
         return text if isinstance(text, str) else None
     return None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -263,3 +263,28 @@ async def test_text_only_final_turn_emits_no_marker(
     assert "[turn 1]" not in err
     assert "no observable output" not in err
     assert "thinking-only" not in err
+
+
+# ---- cpp#12: _text_of must handle SDK dataclass TextBlock (no `type` attr) ----
+
+
+def test_text_of_returns_text_for_sdk_dataclass_textblock() -> None:
+    """SDK dataclass `TextBlock` instances do not carry a `type` attribute —
+    the wire-format `type` is consumed by the parser. `_text_of` must fall
+    back on class name so `log_text` fires for production text-emitting turns.
+    Regression for cpp#12 (production pilot logs emitting zero [text] lines).
+    """
+    block = TextBlock(text="hello world")
+    assert agent_module._text_of(block) == "hello world"
+
+
+def test_text_of_returns_text_for_dict_shaped_block() -> None:
+    """Dict-shaped blocks (legacy wire-format) must continue to work."""
+    block = {"type": "text", "text": "hello world"}
+    assert agent_module._text_of(block) == "hello world"
+
+
+def test_text_of_returns_none_for_non_text_block() -> None:
+    """Non-text blocks (ThinkingBlock, ToolUseBlock) must return None."""
+    assert agent_module._text_of(ThinkingBlock(thinking="x", signature="sig")) is None
+    assert agent_module._text_of(ToolUseBlock(id="t1", name="Bash", input={})) is None


### PR DESCRIPTION
## Summary

`_text_of` previously only matched dict-shaped blocks or objects with a `type == "text"` attribute. The claude-agent-sdk's dataclass `TextBlock` carries no `type` attribute (the wire-format field is consumed by the SDK parser), so every dataclass `TextBlock` fell through returning `None` — production pilot logs emitted zero `[text]` lines for any text-emitting turn.

Fix mirrors the dual-shape handling already used by `guardrails._block_type` (via `_SDK_BLOCK_CLASS_TO_TYPE`): fall back on class name when the `type` attribute is missing. Inline fallback rather than a shared helper — minimal surface area.

## Test plan

- [x] New unit tests in `tests/test_agent.py`:
  - SDK dataclass `TextBlock(text="...")` → returns text
  - dict-shaped `{"type": "text", "text": "..."}` → returns text (no regression)
  - non-text blocks (`ThinkingBlock`, `ToolUseBlock`) → returns `None`
- [x] `uv run --with pytest --with pytest-asyncio pytest tests/test_agent.py -k text_of` passes
- [ ] Operator-observable: next pilot run emits `[text]` lines for text-emitting turns

## Background

Latent bug surfaced during cpp#10 implementation review (PR #11). Explicitly noted in `test_agent.py`'s `test_text_and_tool_turn_emits_no_marker` docstring as out-of-scope for cpp#10 and left for follow-up — this is that follow-up. cpp#10 closed one half of the visibility gap (silent thinking-only turns); this closes the other half (silent text-emitting turns).

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)