### PR TITLE
feat(policy): ship complete permissions.yaml + make denials visible to the pilot (cpp#20)

### DIFF
--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -63,6 +63,14 @@ async def run_agent(
     )
 
     exit_code = 0
+    # cpp#20 joint 2 synthetic-emit guard: flips True after any in-loop
+    # terminal _emit_result call (guardrail trip or ResultMessage). Post-loop
+    # check below uses this to decide whether to emit a synthetic terminal
+    # ResultJson when the SDK stream ends without a ResultMessage -- the
+    # Case-B failure mode introduced by PermissionResultDeny(interrupt=True)
+    # at the can_use_tool boundary. Mutual exclusion proof + architect
+    # verdict: cpp#20 body, "Friend-Claude review convergence" section.
+    emitted_terminal = False
 
     async with ClaudeSDKClient(options=options) as client:
         await client.query(prompt)
@@ -86,6 +94,7 @@ async def run_agent(
                             termination_reason=reason.detail,
                         )
                     )
+                    emitted_terminal = True  # cpp#20 joint 2 mutual-exclusion guard (Site 1)
                     log_guardrail(reason.guardrail, reason.detail)
                     try:
                         await client.interrupt()
@@ -185,6 +194,7 @@ async def run_agent(
                         termination_reason=termination_reason,
                     )
                     _emit_result(result)
+                    emitted_terminal = True  # cpp#20 joint 2 mutual-exclusion guard (Site 2)
 
                     # mika#1189: side-channel handoff to the gateway
                     # orchestrator inbox, alongside the existing
@@ -209,6 +219,38 @@ async def run_agent(
         finally:
             guardrail_watcher.cancel()
             guardrails.dispose()
+
+    # cpp#20 joint 2 synthetic terminal emit. Fires only when the SDK message
+    # stream ended cleanly without yielding either a guardrail trip (Site 1)
+    # or a ResultMessage (Site 2). Triggered by:
+    #   * `PermissionResultDeny(interrupt=True)` at the can_use_tool boundary
+    #     causing the Claude Code CLI to close its stdio pipe without a
+    #     terminal ResultMessage (the Case-B failure mode the friend-Claude
+    #     review converged on; architect verdict READY).
+    #   * Transport drop / clean upstream close for any other reason.
+    # Without this guard cpp would exit silently with empty stdout, and
+    # dispatch-lib's `jq -r '.status // empty'` extraction would yield an
+    # empty string. With it, downstream parsers always see a `^{` JSON line
+    # with status="error" and a non-success subtype.
+    if not emitted_terminal:
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        _emit_result(
+            ResultJson(
+                status="error",
+                subtype="stream_ended_without_result",
+                task_id=task_id,
+                session_id=session_id,
+                turns=guardrails.turns,
+                cost_usd=None,
+                duration_ms=duration_ms,
+                termination_reason=(
+                    "SDK message stream ended without a terminal ResultMessage. "
+                    "Likely caused by permission denial with interrupt=True or "
+                    "transport close upstream."
+                ),
+            )
+        )
+        exit_code = 1
 
     return exit_code
 

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -40,7 +40,7 @@ from .ui import (
     log_fallback,
     log_policy_allow,
     log_policy_deny,
-    log_policy_escalate,
+    log_policy_deny_with_notify,
     log_question,
     log_question_escalate,
     log_relay_recv,
@@ -60,7 +60,13 @@ CanUseTool = Callable[
 
 
 def _fire_notify(tool_name: str, detail: str, reason: str) -> None:
-    """Best-effort operator notification on escalation via ``mika notify``."""
+    """Best-effort operator notification on deny-with-notify via ``mika notify``.
+
+    Wire-format keeps the legacy ``escalate`` decision string for back-compat
+    with existing operator-authored permissions.yaml overlays; the runtime
+    semantics post-cpp#20 joint 2 are deny-with-notify (no relay roundtrip,
+    pilot loop halts via ``interrupt=True``).
+    """
     from .notify import notify_escalation
 
     notify_escalation(f"{tool_name}: {detail}: {reason}")
@@ -98,7 +104,13 @@ def create_permission_handler(
             log_tool(tool_name, _summarize_input(tool_name, tool_input), "AUTO")
             return _map_response(tool_name, tool_input, auto_answer)
 
-        # Tier 2: deterministic policy-file lookup (mika#1192)
+        # Tier 2: deterministic policy-file lookup (mika#1192).
+        # cpp#20 joint 2: denial paths return PermissionResultDeny(interrupt=True)
+        # so the SDK aborts the agent loop instead of surfacing the denial as a
+        # tool_result error the LLM can fabricate around. The pilot exits
+        # honestly; downstream parsers (mika dispatch-lib `_run_claude_pilot`)
+        # see a clean terminal ResultJson with status != "success" via the
+        # synthetic-emit guard in agent.py.
         if policy_enabled:
             pd = evaluate(policy, tool_name, tool_input)
             detail = _summarize_input(tool_name, tool_input)
@@ -107,13 +119,17 @@ def create_permission_handler(
                 return PermissionResultAllow(updated_input=tool_input)
             if pd.decision == "deny":
                 log_policy_deny(tool_name, detail, pd.rule_id)
-                return PermissionResultDeny(message=pd.reason, interrupt=False)
-            # escalate: best-effort notify, then deny
-            log_policy_escalate(tool_name, detail, pd.rule_id)
+                return PermissionResultDeny(message=pd.reason, interrupt=True)
+            # Wire-format `escalate` = deny-with-notify: best-effort operator
+            # notify + halt the pilot loop. Wire keyword preserved for
+            # back-compat with existing operator overlays; runtime semantics
+            # post-cpp#20 joint 2 are identical to `deny` plus the notify
+            # side-effect (cpp#21 rename is source-only).
+            log_policy_deny_with_notify(tool_name, detail, pd.rule_id)
             _fire_notify(tool_name, detail, pd.reason)
-            return PermissionResultDeny(message=pd.reason, interrupt=False)
+            return PermissionResultDeny(message=pd.reason, interrupt=True)
 
-        # TODO(mika#1193 Phase C): remove relay block below once policy has soaked ≥7 days.
+        # TODO(mika#1193 Phase C): remove relay block below once policy has soaked >= 7 days.
         # The relay path is only reachable when MIKA_PILOT_POLICY_DISABLED=1 (emergency rollback).
 
         # No relay → interactive fallback

--- a/src/claude_pilot/policies/permissions.yaml
+++ b/src/claude_pilot/policies/permissions.yaml
@@ -11,6 +11,8 @@
 #                     Skill -> skill name
 #                     Other -> str(tool_input)
 #       decision:   "allow" | "deny" | "escalate"
+#                     "escalate" returns deny + best-effort operator notify
+#                     (deny-with-notify; see permissions.py handler dispatch).
 #       reason:     Human-readable explanation (shown in logs, notify payload)
 #
 #   default:        Fallback when no rule matches.
@@ -18,25 +20,111 @@
 #     reason:       Human-readable explanation
 #
 # Notes:
-#   - Extra fields are allowed for forward-compatibility (ignored by current
-#     evaluator).
-#   - Real rules will be derived from audit data (Change 4). These two
-#     are schema-illustrative placeholders.
+#   - Tier 1 fast-path (read-only file ops, safe binaries) is consulted before
+#     this file via permissions.py::is_tier1_auto_approve. Anything that takes
+#     that path is auto-allowed without entering the rules list.
+#   - Operator override: set MIKA_PILOT_POLICY_PATH=<path> to point at a
+#     different file. Used for temporary overlays (e.g. widened groom-phase
+#     allowlists) without rebuilding cpp. The override remains as escape
+#     hatch; this bundled file is the production default.
+#   - Rule set below was derived from groom-phase pilot evidence (mika
+#     dispatch-lib `_run_claude_pilot` calls captured 2026-05-28). Dev-pilot
+#     phase Bash footprint (cargo/uv/npm/file-tools) is not yet enumerated --
+#     those tool calls will hit `default: deny` and halt the pilot via
+#     joint 2's interrupt=True semantics. Extend the rule set as dev-pilot
+#     evidence is captured.
 # --------------------------------------------------------------------------
 
 rules:
+  # ---- Read-only repo orientation ----
+  # Common pre-work Bash commands that pilots use to understand the codebase
+  # before making changes. Confirmed in mika#1253's pre-wedge pilot log.
+
+  - id: bash-find
+    tool: Bash
+    pattern: "^find\\s"
+    decision: allow
+    reason: "find for repo orientation"
+
+  - id: bash-grep
+    tool: Bash
+    pattern: "^grep\\s|\\sgrep\\s"
+    decision: allow
+    reason: "grep for source-code research"
+
+  - id: bash-jq
+    tool: Bash
+    pattern: "^(for\\s.*do\\s+.*\\s)?jq\\s|;\\s*jq\\s"
+    decision: allow
+    reason: "jq for skill-manifest and JSON inspection"
+
+  - id: bash-for-loop-orientation
+    tool: Bash
+    pattern: "^for\\s+\\w+\\s+in\\s.*;\\s*do\\s"
+    decision: allow
+    reason: "shell-for loops for batch orientation queries"
+
+  - id: bash-cat-heredoc-tmp
+    tool: Bash
+    pattern: "^cat\\s+>\\s+/tmp/.*<<\\s*'?EOF'?"
+    decision: allow
+    reason: "heredoc to /tmp for helper scripts (groom-phase)"
+
+  # ---- Git operations ----
+  # The slash-command-driven groom phase requires git read + plan-doc commit
+  # + push. Read-only ops are always safe; commit/push are gated by the
+  # slash command's own state machine, not by policy.
+
+  - id: bash-git-readonly
+    tool: Bash
+    pattern: "^git\\s+(status|log|diff|show|branch|rev-parse|fetch|ls-remote|worktree)"
+    decision: allow
+    reason: "git read-only operations"
+
+  - id: bash-git-stage-commit
+    tool: Bash
+    pattern: "^git\\s+(add|commit)"
+    decision: allow
+    reason: "git add + git commit (plan-authoring phase)"
+
+  - id: bash-git-push
+    tool: Bash
+    pattern: "^git\\s+push(\\s|$)"
+    decision: allow
+    reason: "git push (groom-phase plan publication)"
+
+  # ---- GitHub CLI read-only ops ----
+
+  - id: bash-gh-issue-read
+    tool: Bash
+    pattern: "^gh\\s+issue\\s+(view|list)"
+    decision: allow
+    reason: "gh issue view/list (ticket grounding)"
+
+  - id: bash-gh-pr-read
+    tool: Bash
+    pattern: "^gh\\s+pr\\s+(view|list|diff|checks)"
+    decision: allow
+    reason: "gh pr view/list/diff/checks (PR grounding)"
+
+  # ---- GitHub CLI write -- gated ----
+  # gh issue create is handled by the mika-issue skill, which routes
+  # through agent-tier authority. Direct CLI use bypasses that.
+
   - id: gh-issue-create-deny
     tool: Bash
     pattern: "gh\\s+issue\\s+create"
     decision: deny
     reason: "gh issue create is handled by mika-issue skill -- direct CLI use denied"
 
+  # ---- Skill tool -- non-platform agent escalation ----
+
   - id: mika-ask-non-platform-agent
     tool: Skill
     pattern: "^mika-ask$"
     decision: escalate
-    reason: "mika-ask targets external agents -- escalate for operator review"
+    reason: "mika-ask targets external agents -- escalate (deny + notify) for operator review"
 
 default:
-  decision: escalate
-  reason: "no matching policy rule -- escalating to operator"
+  decision: deny
+  reason: "no matching policy rule -- denied by default (production posture; widen rules to allow new tool footprints)"

--- a/src/claude_pilot/policy.py
+++ b/src/claude_pilot/policy.py
@@ -3,7 +3,9 @@
 Replaces the relay LLM call for tier2 decisions (Phase B of mika#1188).
 Rules are matched in order; first hit wins. If no rule matches, the
 policy default applies.  Graceful degradation: missing file or parse
-error -> empty rules -> default escalate.
+error -> empty rules -> default deny (fail-closed; cpp#20 joint 1
+hardens the prior default-escalate posture into default-deny on every
+fail-closed path).
 """
 
 from __future__ import annotations
@@ -59,8 +61,8 @@ class PolicyDefault(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    decision: str = "escalate"
-    reason: str = "no matching rule — escalating to operator"
+    decision: str = "deny"
+    reason: str = "no matching rule -- denied by default (fail-closed)"
 
     @field_validator("decision")
     @classmethod
@@ -143,7 +145,8 @@ def load_policy(path: Path | None = None) -> Policy:
     3. Bundled default at ``policies/permissions.yaml``
 
     On any error (missing file, parse failure, validation failure) the
-    function returns a safe fallback: empty rules with ``default: escalate``.
+    function returns a safe fallback: empty rules with ``default: deny``
+    (fail-closed; cpp#20 joint 1).
     """
     resolved: Path | None = path
 
@@ -156,32 +159,32 @@ def load_policy(path: Path | None = None) -> Policy:
         resolved = _load_bundled_policy_path()
 
     if resolved is None:
-        logger.warning("policy: no policy file found — using default escalate")
+        logger.warning("policy: no policy file found — using default deny")
         return Policy()
 
     try:
         raw = resolved.read_text(encoding="utf-8")
     except FileNotFoundError:
-        logger.warning("policy: file not found %s — using default escalate", resolved)
+        logger.warning("policy: file not found %s — using default deny", resolved)
         return Policy()
     except OSError as err:
-        logger.warning("policy: cannot read %s: %s — using default escalate", resolved, err)
+        logger.warning("policy: cannot read %s: %s — using default deny", resolved, err)
         return Policy()
 
     try:
         data = yaml.safe_load(raw)
     except yaml.YAMLError as err:
-        logger.warning("policy: malformed YAML in %s: %s — using default escalate", resolved, err)
+        logger.warning("policy: malformed YAML in %s: %s — using default deny", resolved, err)
         return Policy()
 
     if not isinstance(data, dict):
-        logger.warning("policy: expected mapping in %s — using default escalate", resolved)
+        logger.warning("policy: expected mapping in %s — using default deny", resolved)
         return Policy()
 
     try:
         return Policy.model_validate(data)
     except Exception as err:
-        logger.warning("policy: validation error in %s: %s — using default escalate", resolved, err)
+        logger.warning("policy: validation error in %s: %s — using default deny", resolved, err)
         return Policy()
 
 

--- a/src/claude_pilot/ui.py
+++ b/src/claude_pilot/ui.py
@@ -119,9 +119,17 @@ def log_policy_deny(tool_name: str, detail: str, rule_id: str | None) -> None:
     _log(f"{RED}[policy:deny]{RESET} {BOLD}{tool_name}{RESET}: {detail}{tag}")
 
 
-def log_policy_escalate(tool_name: str, detail: str, rule_id: str | None) -> None:
+def log_policy_deny_with_notify(tool_name: str, detail: str, rule_id: str | None) -> None:
+    """Log a policy decision of ``escalate`` (wire-format) = deny-with-notify.
+
+    Renamed from ``log_policy_escalate`` in cpp#20/#21: the runtime semantics
+    post-joint-2 are "halt the pilot loop + best-effort operator notify" --
+    not a relay-to-operator-for-decision escalation. The wire-format keyword
+    stays ``escalate`` for back-compat; the source symbol reads under the
+    correct name.
+    """
     tag = f" [{rule_id}]" if rule_id else ""
-    _log(f"{YELLOW}[policy:escalate]{RESET} {BOLD}{tool_name}{RESET}: {detail}{tag}")
+    _log(f"{YELLOW}[policy:deny_with_notify]{RESET} {BOLD}{tool_name}{RESET}: {detail}{tag}")
 
 
 def log_turn_summary(turn: int, summary: str) -> None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -361,3 +361,69 @@ async def test_multi_init_logs_reconnect_after_first(
     assert err.index("[init]") < err.index("[reconnect]")
     assert prompt_calls == ["test"], f"expected one log_prompt call, got: {prompt_calls}"
     assert exit_code == 0
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# cpp#20 joint 2 synthetic-emit regression test
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_emits_synthetic_terminal_on_silent_stream_end(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cpp#20 joint 2 safety contract: when the SDK message stream ends
+    without yielding a ResultMessage (the Case-B failure mode introduced
+    by ``PermissionResultDeny(interrupt=True)`` at the can_use_tool
+    boundary), ``run_agent`` MUST emit a synthetic terminal ResultJson
+    to stdout so dispatch-lib's ``grep -m1 '^{' | jq -r '.status'``
+    parsing always sees a non-success status. Without this guard the
+    pilot would exit silently with empty stdout — the seam joint 2's
+    safety story rests on.
+
+    Mock the SDK client to yield only init + assistant messages (no
+    ResultMessage), simulating the CLI closing its stdio pipe cleanly
+    after the SDK relays interrupt=True. Capture stdout, parse the
+    first ``^{`` line, assert it has status="error" and the
+    cpp#20-defined subtype.
+    """
+    import json
+
+    messages: list[Any] = [
+        _init(),
+        _assistant([TextBlock(text="going to run a denied tool now")], "msg1"),
+        # No ResultMessage — stream just ends. This is the Case-B trigger.
+    ]
+
+    _install_fake_client(monkeypatch, messages)
+    guardrails = SessionGuardrails(_config())
+
+    exit_code = await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id="task_synthetic_test",
+        permission_handler=_noop_permission,
+        guardrails=guardrails,
+    )
+
+    captured = capsys.readouterr()
+    # Exactly one terminal JSON line on stdout — no double-emit, no silent exit.
+    json_lines = [line for line in captured.out.splitlines() if line.startswith("{")]
+    assert len(json_lines) == 1, (
+        f"expected exactly one terminal JSON line, got {len(json_lines)}:\n{captured.out!r}"
+    )
+
+    payload = json.loads(json_lines[0])
+    # dispatch-lib parses .status with `jq -r '.status // empty'` — assert the
+    # value is a non-success that maps cleanly.
+    assert payload["status"] == "error", (
+        f"expected status=error for silent stream end, got {payload!r}"
+    )
+    assert payload["subtype"] == "stream_ended_without_result", (
+        f"expected subtype=stream_ended_without_result, got {payload!r}"
+    )
+    assert payload["task_id"] == "task_synthetic_test"
+    # exit code reflects the silent-stream-end as a non-success run.
+    assert exit_code == 1

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -9,7 +9,13 @@ for events that are equivalent to TIER 1.5 in
 
 from __future__ import annotations
 
-from claude_pilot.permissions import try_tier_1_5_auto_answer
+import asyncio
+from pathlib import Path
+
+from claude_agent_sdk import PermissionResultDeny
+from claude_agent_sdk.types import ToolPermissionContext
+
+from claude_pilot.permissions import create_permission_handler, try_tier_1_5_auto_answer
 from claude_pilot.types import PilotResponseAnswer
 
 
@@ -125,3 +131,122 @@ def test_missing_question_key_returns_none() -> None:
         {"questions": [{"options": ["a", "b"]}]},
     )
     assert result is None
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# cpp#20 joint 2: handler returns interrupt=True on policy denial
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _mock_ctx() -> ToolPermissionContext:
+    return ToolPermissionContext(
+        signal=None,
+        suggestions=[],
+        tool_use_id="tool_test",
+        agent_id=None,
+    )
+
+
+def test_handler_returns_interrupt_true_on_default_deny() -> None:
+    """cpp#20 joint 2 end-to-end: handler under fail-closed policy
+    (missing file → empty Policy → default-deny) returns
+    PermissionResultDeny(interrupt=True). This is the contract
+    dispatch-lib relies on for the pilot loop to halt honestly
+    instead of continuing past a silent denial.
+    """
+    handler = create_permission_handler(
+        config=None,
+        relay=False,
+        verbose=False,
+        cwd="/tmp",
+        policy_path=Path("/nonexistent/policy.yaml"),
+    )
+    result = asyncio.run(handler("Bash", {"command": "rm -rf /"}, _mock_ctx()))
+    assert isinstance(result, PermissionResultDeny), (
+        f"expected PermissionResultDeny, got {type(result)}: {result!r}"
+    )
+    assert result.interrupt is True, (
+        f"expected interrupt=True for cpp#20 joint 2 contract, got {result!r}"
+    )
+
+
+def test_handler_returns_interrupt_true_on_rule_deny(tmp_path: Path) -> None:
+    """An explicit rule-based deny must also return interrupt=True --
+    not just the default-deny path. Pins permissions.py deny branch
+    (current source line 110).
+
+    Uses ``curl`` because Tier 1 fast-path auto-approves common safe
+    binaries (echo, awk, find, etc.); we need a command that misses
+    Tier 1 so the request reaches the policy evaluator.
+    """
+    policy_file = tmp_path / "rule_deny.yaml"
+    policy_file.write_text(
+        "rules:\n"
+        "  - id: deny-curl\n"
+        "    tool: Bash\n"
+        "    pattern: '^curl\\s'\n"
+        "    decision: deny\n"
+        "    reason: rule-based test deny\n"
+        "default:\n"
+        "  decision: allow\n"
+        "  reason: default allow (test fixture)\n"
+    )
+    handler = create_permission_handler(
+        config=None,
+        relay=False,
+        verbose=False,
+        cwd="/tmp",
+        policy_path=policy_file,
+    )
+    result = asyncio.run(handler("Bash", {"command": "curl https://example.com"}, _mock_ctx()))
+    assert isinstance(result, PermissionResultDeny)
+    assert result.interrupt is True
+    assert result.message == "rule-based test deny"
+
+
+def test_handler_returns_interrupt_true_on_escalate_decision(tmp_path: Path) -> None:
+    """The wire-format ``escalate`` decision (renamed in source to
+    deny-with-notify) also returns interrupt=True. Pins
+    permissions.py:114 alongside the deny branch.
+    """
+    policy_file = tmp_path / "escalate.yaml"
+    policy_file.write_text(
+        "rules:\n"
+        "  - id: escalate-skill\n"
+        "    tool: Skill\n"
+        "    pattern: '^test-target$'\n"
+        "    decision: escalate\n"
+        "    reason: rule-based test escalate\n"
+        "default:\n"
+        "  decision: allow\n"
+        "  reason: default allow (test fixture)\n"
+    )
+    handler = create_permission_handler(
+        config=None,
+        relay=False,
+        verbose=False,
+        cwd="/tmp",
+        policy_path=policy_file,
+    )
+    # Use monkeypatched notify so the test does not actually call mika notify.
+    from claude_pilot import permissions as permissions_module
+
+    fired: list[tuple[str, str, str]] = []
+
+    def _fake_notify(tool_name: str, detail: str, reason: str) -> None:
+        fired.append((tool_name, detail, reason))
+
+    original = permissions_module._fire_notify
+    permissions_module._fire_notify = _fake_notify  # type: ignore[assignment]
+    try:
+        result = asyncio.run(handler("Skill", {"skill": "test-target"}, _mock_ctx()))
+    finally:
+        permissions_module._fire_notify = original  # type: ignore[assignment]
+
+    assert isinstance(result, PermissionResultDeny)
+    assert result.interrupt is True, (
+        "escalate (deny-with-notify) must also halt the loop"
+    )
+    assert result.message == "rule-based test escalate"
+    # Notify fired exactly once on this path.
+    assert len(fired) == 1

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -36,7 +36,10 @@ class TestRuleModel:
 
 class TestDefaultModel:
     def test_defaults(self) -> None:
-        assert PolicyDefault().decision == "escalate"
+        # cpp#20 joint 1: fail-closed default is "deny", not "escalate".
+        # Pins the safety property that a missing/malformed policy file
+        # never silently allows tool calls.
+        assert PolicyDefault().decision == "deny"
 
     def test_invalid_decision(self) -> None:
         with pytest.raises(Exception, match="decision must be one of"):
@@ -47,7 +50,8 @@ class TestDocModel:
     def test_empty(self) -> None:
         p = Policy()
         assert p.rules == []
-        assert p.default.decision == "escalate"
+        # cpp#20 joint 1: fail-closed default-deny on every empty-Policy path.
+        assert p.default.decision == "deny"
 
     def test_full(self) -> None:
         p = Policy(
@@ -71,30 +75,31 @@ class TestLoadRules:
         assert p.default.decision == "deny"
 
     def test_missing_file_graceful(self, tmp_path: Path) -> None:
+        # cpp#20 joint 1 safety: fail-closed paths default to deny, never allow.
         p = load_policy(tmp_path / "nonexistent.yaml")
         assert p.rules == []
-        assert p.default.decision == "escalate"
+        assert p.default.decision == "deny"
 
     def test_malformed_yaml_graceful(self, tmp_path: Path) -> None:
         f = tmp_path / "bad.yaml"
         f.write_text(": : : not valid yaml [[[")
         p = load_policy(f)
         assert p.rules == []
-        assert p.default.decision == "escalate"
+        assert p.default.decision == "deny"
 
     def test_non_mapping_graceful(self, tmp_path: Path) -> None:
         f = tmp_path / "list.yaml"
         f.write_text("- item1\n- item2\n")
         p = load_policy(f)
         assert p.rules == []
-        assert p.default.decision == "escalate"
+        assert p.default.decision == "deny"
 
     def test_validation_error_graceful(self, tmp_path: Path) -> None:
         f = tmp_path / "invalid.yaml"
         f.write_text("rules:\n  - id: bad\n    tool: Bash\n    pattern: \"[invalid\"\n    decision: allow\n    reason: test\n")
         p = load_policy(f)
         assert p.rules == []
-        assert p.default.decision == "escalate"
+        assert p.default.decision == "deny"
 
     def test_env_var_resolution(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         f = tmp_path / "env_rules.yaml"
@@ -105,9 +110,11 @@ class TestLoadRules:
         assert p.default.reason == "env-loaded"
 
     def test_bundled_default_loads(self) -> None:
+        # cpp#20 joint 1: bundled permissions.yaml ships with the
+        # canary-validated rule set and default-deny.
         p = load_policy()
         assert len(p.rules) >= 1
-        assert p.default.decision == "escalate"
+        assert p.default.decision == "deny"
 
 
 class TestEvaluateRules:
@@ -174,3 +181,45 @@ def test_no_relay_config_graceful() -> None:
     with tempfile.TemporaryDirectory() as d:
         result = _load_config(Path(d), None)
         assert result is None, "_load_config should return None for missing config"
+
+
+# cpp#20 joint 1 / joint 2 fail-closed regression tests.
+# Composition: load failure -> empty Policy -> default-deny -> evaluate returns
+# deny -> handler returns PermissionResultDeny(interrupt=True) -> pilot loop
+# halts. These tests pin the load -> evaluate half of the chain; the handler
+# half lives in tests/test_permissions.py.
+
+class TestFailClosedSafety:
+    """Architect-required tests (cpp#20 joint 1 safety property)."""
+
+    def test_load_failure_evaluates_to_halt(self, tmp_path: Path) -> None:
+        """Missing file -> empty Policy -> evaluate returns a halt decision."""
+        policy = load_policy(tmp_path / "nonexistent.yaml")
+        assert policy.default.decision in ("deny", "escalate")
+        result = evaluate(policy, "Bash", {"command": "echo hello"})
+        assert result.decision in ("deny", "escalate")
+
+    def test_load_malformed_yaml_evaluates_to_halt(self, tmp_path: Path) -> None:
+        """Parse error -> empty Policy -> evaluate returns a halt decision."""
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("not: valid: yaml: :::: [[[")
+        policy = load_policy(bad)
+        assert policy.default.decision in ("deny", "escalate")
+        result = evaluate(policy, "Bash", {"command": "rm -rf /"})
+        assert result.decision in ("deny", "escalate")
+
+    def test_load_validation_error_evaluates_to_halt(self, tmp_path: Path) -> None:
+        """Pydantic validation error -> empty Policy -> evaluate halts."""
+        bad = tmp_path / "invalid.yaml"
+        bad.write_text(
+            "rules:\n"
+            "  - id: bad-regex\n"
+            "    tool: Bash\n"
+            '    pattern: "[unterminated"\n'
+            "    decision: allow\n"
+            "    reason: test\n"
+        )
+        policy = load_policy(bad)
+        assert policy.default.decision in ("deny", "escalate")
+        result = evaluate(policy, "Bash", {"command": "anything"})
+        assert result.decision in ("deny", "escalate")


### PR DESCRIPTION
## Summary

Lands cpp#20 (joints 1 + 2 + synthetic emit) bundled with cpp#21 (source-only rename). Closes the cpp#15 substrate wedge surfaced on 2026-05-28: placeholder `permissions.yaml` + `PermissionResultDeny(interrupt=False)` let denied tool calls reach the LLM as ordinary tool errors, which the pilot then fabricated success around — caught by mika#1322's brake but only as a symptom, never structurally.

- **Joint 1** — bundled `permissions.yaml` now carries the 12 canary-validated rules (groom-phase coverage) and `default: deny`. Fail-closed: every error path in `load_policy` collapses to deny, never to allow.
- **Joint 2** — `permissions.py` deny + escalate branches return `PermissionResultDeny(interrupt=True)`. SDK aborts the agent loop on denial instead of surfacing it as a fabricatable tool error.
- **Synthetic emit** — `agent.py::run_agent` adds a post-loop terminal `ResultJson(status="error", subtype="stream_ended_without_result")` guarded by a mutual-exclusion flag. Closes the Case-B failure mode (SDK stream ends cleanly without ResultMessage → previously silent empty stdout; now a deterministic non-success status dispatch-lib can parse).
- **cpp#21 (source rename, bundled)** — `log_policy_escalate` → `log_policy_deny_with_notify`; log tag `[policy:escalate]` → `[policy:deny_with_notify]`; comments updated. Wire-format `decision: escalate` preserved for back-compat — only Python symbols + log strings rename.

## Review trail (the design got two passes)

1. **friend-Claude third-angle review** (after `mika-arch` first invocation returned a memory-persistence-check output without a `Disposition:` line — a `project_mika_arch_failure_modes` contract-fabrication instance). Converged on the synthetic-emit refinement (Case B is the unverified seam; closing it in-tree removes the CLI-behavior dependency joint 2's contract would otherwise inherit).
2. **mika-arch coherence review** — `Disposition: READY` (session `1eed6e27-ecb0-458b-b3ed-9afc7349998b`). Verified mutual exclusion across all four paths (Site 1 / Site 2 / Site 3 / Case B). Surfaced one pre-existing edge case (Site 2 + post-loop raise → potential double-emit) — not introduced by this patch; dispatch-lib's `grep -m1 '^{'` already handles it cleanly.

Full design context, deployment-path trace, and mutual-exclusion table live in cpp#20's body.

## Test plan

All checks pass locally (uv venv on Python 3.14.2):

- [x] `uv run pytest` — 280 passed (273 prior + 7 new)
- [x] `uv run ruff check` — All checks passed
- [x] `uv run mypy src` — Success, no issues in 14 source files
- [x] `uv build --wheel` — clean wheel build
- [ ] CI green (pending — will watch)
- [ ] Architect-noted pre-existing double-emit edge case: confirm `grep -m1` handles it on dispatch-lib side (already does; flagged for future post-loop-block changes)

**New tests:**

- `test_rules.py::TestFailClosedSafety` — load failure / malformed YAML / validation error all evaluate to deny-or-escalate (never allow)
- `test_permissions.py::test_handler_returns_interrupt_true_on_default_deny` — fail-closed end-to-end through the handler
- `test_permissions.py::test_handler_returns_interrupt_true_on_rule_deny` — rule-based deny path (`curl` chosen to bypass Tier 1)
- `test_permissions.py::test_handler_returns_interrupt_true_on_escalate_decision` — wire-format `escalate` path (deny-with-notify semantics + notify fires)
- `test_agent.py::test_agent_emits_synthetic_terminal_on_silent_stream_end` — the load-bearing test from friend's review: mock SDK client yields only init + assistant messages, no ResultMessage; asserts exactly one `^{` JSON line with `status="error"` + `subtype="stream_ended_without_result"`

**Updated tests:** 5 in `test_rules.py` updated to expect `default.decision == "deny"` (was `"escalate"`).

## Sequencing notes

- This PR is single-flight per architect verdict + friend convergence: synthetic emit closes the unverified CLI-behavior seam in-tree, so joint 1 + joint 2 ship together safely. Without the synthetic emit, sequencing (joint 1 first, soak, joint 2) was the right call — with it, the contract becomes cpp-owned and combined is the cleaner landing.
- After merge + a soak: the dispatch-lib host-local hot-patch (`MIKA_PILOT_POLICY_PATH` inject + `~/.mika/policies/groom-policy.yaml` overlay) can be removed — bundled config is now the production default.
- mika#1327 (joint 3) can land after this. Joint 2's `interrupt=True` makes its state-checking exit contract unambiguous, and mika#1322's fabrication-string brake retires as part of mika#1327's acceptance criteria (comment posted on mika#1327).

## Companion

- senara-solutions/mika#1327 — joint 3 (engine-side state-checking brake replacing mika#1322's grep)
- cpp#21 — source rename ticket (bundled here; wire-format rename — if it happens at all — is a separate future micro-PR with deprecation alias)

Closes #20
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)