### PR TITLE
fix(tier1): make _split_compound_command quote-aware

### DIFF
--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -188,20 +188,91 @@ auto-approved and never halt the session."""
 
 # ── Safe Bash command checking ───────────────────────────────────────────────
 
-_COMPOUND_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||[;|\n])\s*")
-
 
 def _split_compound_command(command: str) -> list[str]:
-    """Naive split on shell operators AND raw newlines. Not quote-aware —
-    unsafe splits inside quoted strings simply won't match any safe pattern
-    and fall through to relay. Safe by design.
+    """Quote-aware split on shell operators AND raw newlines.
 
-    `\\n` is included because bash treats a bare newline as a command
-    separator equivalent to `;`. Without splitting on `\\n`, a payload like
+    Splits on ``&&``, ``||``, ``;``, ``|``, and ``\\n`` only when they appear
+    OUTSIDE of single- or double-quoted regions. Quote handling mirrors POSIX
+    semantics used by ``contains_unquoted_metacharacter`` in this module:
+
+    - Inside ``"..."``, ``\\"`` is an escape pair (skipped atomically); other
+      backslash sequences pass through as-is so ``"a\\|b"`` does not close the
+      quote on ``\\``.
+    - Inside ``'...'``, backslash is literal — only a closing ``'`` ends the
+      quoted region.
+    - Unterminated quotes: remaining bytes are treated as inside the quote
+      (conservative — falls through to the LLM relay on malformed input).
+
+    ``\\n`` is included because bash treats a bare newline as a command
+    separator equivalent to ``;``. Without splitting on ``\\n``, a payload like
     ``git status\\nrm -rf /`` would be evaluated as one segment, miss the
     rm-rf regex on the second line, and auto-approve via the safe-git prefix.
+
+    Pre-fix: split was a single quote-blind regex that matched ``|`` inside
+    grep regex alternations (``grep "a\\|b\\|c"``), shredding the segment list
+    into nonsense substrings. Every "segment" then failed the safe-list checks,
+    tier1 rejected the entire research grep, and the downstream chain-safety
+    check halted the pilot with `policy-deny [bash-grep]` even though the
+    research command was inherently safe (read-only grep + cargo doc).
+    Observed wedging mika#96 and mika#623 dispatch on 2026-06-14.
     """
-    return [s for s in (part.strip() for part in _COMPOUND_SPLIT_RE.split(command)) if s]
+    segments: list[str] = []
+    n = len(command)
+    i = 0
+    seg_start = 0
+    quote_state: str | None = None  # None / "'" / '"'
+
+    while i < n:
+        ch = command[i]
+
+        if quote_state is None:
+            if ch in ("'", '"'):
+                quote_state = ch
+                i += 1
+                continue
+            if ch in (";", "\n"):
+                segments.append(command[seg_start:i].strip())
+                i += 1
+                seg_start = i
+                continue
+            if ch == "&" and i + 1 < n and command[i + 1] == "&":
+                segments.append(command[seg_start:i].strip())
+                i += 2
+                seg_start = i
+                continue
+            if ch == "|":
+                if i + 1 < n and command[i + 1] == "|":
+                    segments.append(command[seg_start:i].strip())
+                    i += 2
+                    seg_start = i
+                else:
+                    segments.append(command[seg_start:i].strip())
+                    i += 1
+                    seg_start = i
+                continue
+            i += 1
+            continue
+
+        # inside a quote
+        if quote_state == '"':
+            if ch == "\\" and i + 1 < n and command[i + 1] == '"':
+                i += 2
+                continue
+            if ch == '"':
+                quote_state = None
+            i += 1
+            continue
+
+        # quote_state == "'"
+        if ch == "'":
+            quote_state = None
+        i += 1
+
+    tail = command[seg_start:].strip()
+    if tail:
+        segments.append(tail)
+    return [s for s in segments if s]
 
 
 def contains_unquoted_metacharacter(command: str) -> bool:

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -16,6 +16,7 @@ import pytest
 from claude_pilot.tier1 import (
     DENIED_BASH_PATTERNS_HINT,
     INTRA_PLATFORM_AGENTS,
+    _split_compound_command,
     contains_unquoted_metacharacter,
     is_safe_bash_command,
     is_safe_git_command,
@@ -750,3 +751,96 @@ def test_1409_hint_claims_match_enforcement() -> None:
     ]
     for cmd in approved:
         assert is_safe_bash_command(cmd) is True, f"expected approved but DENIED: {cmd}"
+
+
+# ── Quote-aware compound split ───────────────────────────────────────────────
+# Pre-fix regression: `_split_compound_command` was a quote-blind regex that
+# matched `|`/`;`/`&&`/`||` inside quoted strings. A research grep with regex
+# alternation (`grep "a\|b\|c"`) was shredded into nonsense segments, every
+# segment failed the safe-list check, and the pilot halted with
+# `policy-deny [bash-grep]`. Observed wedging mika#96 and mika#623 dispatch
+# on 2026-06-14.
+
+
+@pytest.mark.parametrize(
+    "command,expected_segments",
+    [
+        # Operators inside double quotes do NOT split.
+        (r'grep "a\|b\|c" file', [r'grep "a\|b\|c" file']),
+        (
+            r'grep "pub fn x\|pub fn y" src',
+            [r'grep "pub fn x\|pub fn y" src'],
+        ),
+        # Operators inside single quotes do NOT split.
+        ("echo 'foo;bar||baz' done", ["echo 'foo;bar||baz' done"]),
+        # Mixed: quoted region preserved, unquoted operator splits.
+        (
+            r'grep "a\|b" file | head -5',
+            [r'grep "a\|b" file', "head -5"],
+        ),
+        (
+            r'grep "a\|b" file || cargo test',
+            [r'grep "a\|b" file', "cargo test"],
+        ),
+        # Real-world regression — the exact command that wedged mika#96.
+        (
+            r'grep -r "pub fn delete_word\|pub fn delete_line_by_head\|pub fn select_all" '
+            r"target/debug/.fingerprint/ 2>/dev/null | head -5 "
+            r"|| cargo doc -p tui-textarea --no-deps 2>&1 | tail -5",
+            [
+                r'grep -r "pub fn delete_word\|pub fn delete_line_by_head\|pub fn select_all" '
+                r"target/debug/.fingerprint/ 2>/dev/null",
+                "head -5",
+                "cargo doc -p tui-textarea --no-deps 2>&1",
+                "tail -5",
+            ],
+        ),
+        # Escaped double quote inside double quotes does NOT close.
+        (r'echo "a\"|b" tail', [r'echo "a\"|b" tail']),
+        # Newline IS a separator (parity with semicolon).
+        ("git status\nrm -rf /", ["git status", "rm -rf /"]),
+        # `&&` splits.
+        ("a && b && c", ["a", "b", "c"]),
+        # `||` splits.
+        ("a || b", ["a", "b"]),
+        # `;` splits.
+        ("a; b; c", ["a", "b", "c"]),
+    ],
+)
+def test_split_compound_command_quote_aware(
+    command: str, expected_segments: list[str]
+) -> None:
+    assert _split_compound_command(command) == expected_segments
+
+
+def test_split_compound_unwedge_mika_96_research_grep() -> None:
+    """The exact command that policy-denied the mika#96 dispatch pilot is now
+    tier1-safe end-to-end."""
+    cmd = (
+        r'grep -r "pub fn delete_word\|pub fn delete_line_by_head\|pub fn select_all" '
+        r"target/debug/.fingerprint/ 2>/dev/null | head -5 "
+        r"|| cargo doc -p tui-textarea --no-deps 2>&1 | tail -5"
+    )
+    assert is_safe_bash_command(cmd) is True
+    assert is_tier1_auto_approve("Bash", {"command": cmd}, "/data") is True
+
+
+def test_split_compound_quoted_danger_no_longer_disguised() -> None:
+    """An rm-rf chained outside a quoted region must still be caught even
+    though earlier segments contain quoted operators."""
+    cmd = r'grep "a\|b" file; rm -rf /'
+    segs = _split_compound_command(cmd)
+    assert segs == [r'grep "a\|b" file', "rm -rf /"]
+    assert is_safe_bash_command(cmd) is False
+
+
+def test_split_compound_unterminated_quote_falls_through() -> None:
+    """Unterminated quotes treat the rest of the string as quoted — safer
+    than splitting on operators that might be inside an intended string. The
+    command falls through to relay rather than being tier1-approved."""
+    cmd = 'grep "unclosed | rm -rf /'
+    # Unterminated quote means the rest is treated as inside the quote, so
+    # no splits happen and the single segment doesn't match any safe pattern.
+    segs = _split_compound_command(cmd)
+    assert len(segs) == 1
+    assert is_safe_bash_command(cmd) is False


### PR DESCRIPTION
## Summary

Tier1 substrate fix — the compound-command splitter was quote-blind, shredding any command with regex alternation in quoted strings (\`grep \"a\\|b\\|c\"\`) into nonsense segments and halting the pilot with \`policy-deny [bash-grep]\`.

## Founding incidents

Observed wedging two dispatch pilots on 2026-06-14:
- **mika#96** (Mac keyboard shortcuts) — dev-pilot tried \`grep -r \"pub fn delete_word\\|pub fn delete_line_by_head\\|pub fn select_all\" target/debug/.fingerprint/\`. Halted after 18 turns, $0.77.
- **mika#623** (Debian packaging) — same class of failure.

Both pilots were doing legitimate research grep with regex alternation. The chain-safety check vetoed the policy allow because the quote-blind splitter produced \`['grep ... \"pub fn delete_word\\\\', 'pub fn delete_line_by_head\\\\', 'pub fn select_all\" ...', ...]\` — every middle segment unparseable.

## Fix

Hand-written quote-aware tokenizer mirroring the POSIX semantics already used by \`contains_unquoted_metacharacter\` in this module:

- Splits on \`&&\`, \`||\`, \`;\`, \`|\`, \`\\n\` only when outside both \`'...'\` and \`\"...\"\`
- Inside \`\"...\"\`, \`\\\"\` is an atomic escape pair
- Inside \`'...'\`, backslash is literal; only closing \`'\` ends the region
- Unterminated quotes: rest of string treated as inside quote (conservative — falls through to relay rather than tier1)

## Tests

14 new test cases covering:
- Operators inside double and single quotes preserved as one segment
- The exact mika#96 regression command (multi-line construction in the test)
- Escape pair \`\\\"\` handling inside double quotes
- Newline parity with \`;\`
- Operator splits outside quotes (\`&&\`, \`||\`, \`;\`)
- Quoted operator + chained \`rm -rf /\` still caught
- Unterminated quote falls through safely

177/177 tier1 tests pass (163 existing + 14 new). \`uv run ruff check\` and \`uv run mypy src\` clean.

## Test plan

- [x] All existing tier1 tests pass (163/163)
- [x] 14 new quote-aware tests added and passing
- [x] Lint clean (\`uv run ruff check\`)
- [x] Typecheck clean (\`uv run mypy src\`)
- [x] Manual verification: the exact command that wedged mika#96 dispatch (\`grep -r \"a\\|b\\|c\" path | head -5 || cargo doc | tail -5\`) now returns \`is_tier1_auto_approve == True\`
- [x] Safety regression: quote-aware split still catches \`grep \"a\\|b\" file; rm -rf /\` as dangerous

🤖 Generated with [Claude Code](https://claude.com/claude-code)