### PR TITLE
fix(tier1): closed-world `make verify-bundled-skills` allowlist (cpp#45)

### DIFF
--- a/docs/plans/2026-06-30-002-fix-45-make-verify-allowlist-plan.md
+++ b/docs/plans/2026-06-30-002-fix-45-make-verify-allowlist-plan.md
@@ -1,0 +1,171 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+issue: senara-solutions/claude-pilot-py#45
+branch: fix/45-make-verify-allowlist
+architect_session: 783d4a04
+---
+
+# fix: tier1 closed-world `make verify-bundled-skills` allowlist
+
+## Summary
+
+Add a closed-world `make`-target allowlist to claude-pilot's tier1 deterministic
+classifier so `make verify-bundled-skills` auto-approves, mirroring the existing
+`cargo`/`npm` build-command handling. Only that one target is enumerated; every
+other `make` target (notably `make deploy`) stays denied. This is the primary
+(claude-pilot-py) half of mika#1639.
+
+## Problem frame (WHY)
+
+`src/claude_pilot/tier1.py` auto-approves `cargo {check,test,clippy,fmt,build,…}`
+via `SAFE_CARGO_SUBCOMMANDS` / `is_safe_build_command`, but has **no `make`
+handling at all**. When a headless pilot session runs `make verify-bundled-skills`
+— the bundled-skill pre-merge gate introduced in mika#1575, which CI runs on every
+PR via `.github/workflows/ci.yml` — during the `/ce:work` verification step, tier1
+does not match it. The command falls through to the relay, which denies it, and the
+session halts in an implementation-complete-but-unverified state with the PR stuck
+in draft.
+
+`make verify-bundled-skills` is the same operation class tier1 already trusts for
+cargo/npm: read-only verification, no side effects beyond stdout and exit code.
+
+**Hard evidence:** mika-dev's autonomous callback on mika PR #1638 (~09:51Z
+2026-06-29) named the policy-deny on `make verify-bundled-skills` as a recurring
+substrate blocker that left the PR in draft. Full write-up: mika#1639 (primary
+section) and cpp#45.
+
+**Architect verdict (on file — do not re-route):** mika-arch session `783d4a04`
+(n=3 `permission-policy-errs-strict` class) ruled: keep syntactic crudeness as
+defense-in-depth; expand per-rule allowlists by **closed-world enumeration**.
+Sibling deliverables merged this morning under the same verdict — cpp#36
+(substitution-inner allowlist, PR #36) and cpp#39 (`git show <SHA>:<path>` redirect,
+PR #39). This is the third deliverable.
+
+## Scope boundaries
+
+**In scope:** a single enumerated make target (`verify-bundled-skills`) in cpp
+`tier1.py`, with tests.
+
+**Out of scope / deferred:**
+- The **secondary** half of mika#1639 — the `## Acceptance criteria` case-sensitivity
+  fix in mika's `scripts/verify-pipeline.sh` (`grep -q` → `grep -qi`). That code lives
+  in the **mika** repo and is tracked there, not here.
+- Any other `make` target (`make check`, `make lint`, etc.). Each future target needs
+  its own evidence-gated ticket per the cpp#34 closed-world discipline. Do not
+  generalize to "any read-only make target."
+
+## Key technical decisions
+
+**KTD1 — Full-string anchor, stricter than cargo.** The make matcher anchors the
+whole sub-command: `^\s*make\s+(\S+)\s*$`. Cargo's `^\s*cargo\s+(\S+)` deliberately
+allows trailing flags (`cargo build --release`), but `make` arguments can override
+variables and change behavior, so the closed-world rule forbids *any* trailing token.
+This is what makes AC4 hold.
+
+**KTD2 — Chain safety is inherited, not re-implemented.** `is_safe_bash_command`
+already splits compound commands (`_split_compound_command`) and requires
+`all(_is_safe_sub_command(sub) for sub in sub_commands)` (`tier1.py:337`). So
+`make verify-bundled-skills && rm -rf ~` denies because the `rm` sub-command is not
+safe — not because of any anchoring in the make regex. Do **not** add redundant
+single-regex chain guarding; the splitter owns chain safety (AC2).
+
+**KTD3 — Case-sensitivity is free.** The regex matches the literal lowercase token
+`make`, so `MAKE verify-bundled-skills` never matches (AC3). No extra logic.
+
+## Implementation units
+
+### U1. Add `is_safe_make_command` closed-world allowlist to tier1
+
+**Goal:** auto-approve `make verify-bundled-skills` (and only that target) at tier1.
+
+**Requirements:** AC1, AC4, AC5.
+
+**Dependencies:** none.
+
+**Files:**
+- `src/claude_pilot/tier1.py` (modify)
+
+**Approach:** In the "Safe build/test commands" region (near `SAFE_CARGO_SUBCOMMANDS`
+/ `is_safe_build_command`, ~line 385-420), add:
+- `SAFE_MAKE_TARGETS: frozenset[str] = frozenset({"verify-bundled-skills"})`
+- `_MAKE_RE = re.compile(r"^\s*make\s+(\S+)\s*$")` — full-anchored, no trailing tokens
+- `def is_safe_make_command(sub: str) -> bool:` returning
+  `bool(m := _MAKE_RE.match(sub)) and m.group(1) in SAFE_MAKE_TARGETS` (written
+  without the walrus if it reads cleaner; mirror `is_safe_build_command`'s style).
+
+Then OR it into `_is_safe_sub_command` (`tier1.py:340-347`), alongside
+`is_safe_build_command`. Add a short comment citing cpp#45 / mika#1639 / architect
+783d4a04 and the closed-world rationale, mirroring the cpp#27 comment style already
+in the file.
+
+**Patterns to follow:** `is_safe_build_command` (the immediately-adjacent sibling)
+for structure; the cpp#27 awk/sed comment block for the rationale-comment style.
+
+**Test expectation:** covered by U2 (kept as a separate unit only for narration;
+implementer may land both in one commit).
+
+**Verification:** `is_safe_bash_command("make verify-bundled-skills")` returns True;
+`make deploy` and unenumerated targets still return False.
+
+### U2. Tests for the make allowlist (AC1–AC5)
+
+**Goal:** lock the closed-world behavior against regression.
+
+**Requirements:** AC1, AC2, AC3, AC4, AC5.
+
+**Dependencies:** U1.
+
+**Files:**
+- `tests/test_tier1.py` (modify)
+
+**Approach:** Add a small `make`-specific test section mirroring the existing
+git/shell-specific blocks (e.g. `test_git_push_to_main_denied`,
+`test_find_with_exec_denied`). Assert against `is_safe_bash_command(...)` (the public
+entry) so the compound-split + all-subs-safe path is exercised end to end. Optionally
+add `make verify-bundled-skills` to the existing `test_safe_commands` parametrize list
+for the positive case.
+
+**Test scenarios:**
+- `is_safe_bash_command("make verify-bundled-skills")` is True. *(Covers AC1)*
+- `is_safe_bash_command("make verify-bundled-skills && rm -rf ~")` is False. *(Covers AC2)*
+- `is_safe_bash_command("MAKE verify-bundled-skills")` is False. *(Covers AC3)*
+- `is_safe_bash_command("make verify-bundled-skills extra-arg")` is False. *(Covers AC4)*
+- `is_safe_bash_command("make deploy")` is False. *(Covers AC5)*
+- A pre-existing cargo/npm safe command (e.g. `cargo build --release`) still returns
+  True — guards against allowlist-ordering regression. *(Covers AC5)*
+
+**Verification:** `uv run pytest tests/test_tier1.py` passes; the five new
+assertions are present and green.
+
+## Acceptance criteria
+
+- AC1 — `make verify-bundled-skills` is tier1 auto-approved (no operator confirmation).
+- AC2 — `make verify-bundled-skills && rm -rf ~` is DENIED (compound-split + all-subs-safe; the `rm` sub fails).
+- AC3 — `MAKE verify-bundled-skills` is DENIED (case-sensitive literal `make`).
+- AC4 — `make verify-bundled-skills extra-arg` is DENIED (full-string anchor rejects trailing tokens).
+- AC5 — `make deploy` remains DENIED; existing cargo/npm/shell allowlists unchanged (pure addition, no regression).
+
+## Verification contract
+
+1. `uv run ruff check`
+2. `uv run mypy src`
+3. `uv run pytest` (all green, including the five new `make` assertions)
+
+## Definition of done
+
+- `is_safe_make_command` added to `tier1.py`, OR'd into `_is_safe_sub_command`, closed-world (`verify-bundled-skills` only).
+- Five AC tests in `tests/test_tier1.py`, all green.
+- Lint + type + test gates pass.
+- PR cites architect session `783d4a04`, references mika#1639, and `Closes #45`.
+
+## Sources & research
+
+- cpp#45 — this ticket (primary half of mika#1639).
+- mika#1639 — coupled parent; secondary half (`scripts/verify-pipeline.sh`) lives in the mika repo.
+- mika#1575 — `make verify-bundled-skills` introduction.
+- cpp#36 (PR #36), cpp#39 (PR #39) — sibling closed-world allowlist expansions under architect 783d4a04.
+- `src/claude_pilot/tier1.py:337` — `all(_is_safe_sub_command(...))` chain-safety invariant.
+- `src/claude_pilot/tier1.py:404` — `is_safe_build_command` (pattern to mirror).

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -7,7 +7,7 @@ component: permission-classifier
 problem_type: security_issue
 category: security-issues
 severity: critical
-tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-43]
+tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, make, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-43, claude-pilot-45]
 applies_when: "adding or reviewing any rule that decides allow/deny on a raw shell command string"
 ---
 
@@ -287,6 +287,47 @@ This is the source-side twin of §5's destination-side corollary ("don't claim a
 stronger guarantee than the mechanism delivers"); both were caught post-merge by
 executed/adversarial review (§3), not by reading the diff.
 
+### 8. Adding a new tier1 command class: anchor strictness scales with the command's argument surface
+
+`tier1.py`'s standalone allow-list (`is_safe_build_command`, `is_safe_shell_command`,
+…) admits whole command classes by `^\s*<cmd>\s+(\S+)` + a frozenset membership
+check on the captured token. When adding a class (claude-pilot#45 added
+`make verify-bundled-skills`), two calibration choices are load-bearing:
+
+1. **Anchor as strictly as the command's argument grammar demands — not by copying
+   a sibling's regex.** `_CARGO_RE`/`_NPM_RUN_RE` are *prefix* matches (`^\s*cargo\s+(\S+)`)
+   that intentionally admit trailing flags (`cargo build --release`) — safe because
+   cargo's flags don't change the trust character of the run. `make` is different: a
+   trailing `FOO=bar` token overrides a Makefile variable and can change *what the
+   target does*. So `_MAKE_RE` is **full-anchored** (`^\s*make\s+(\S+)\s*$`) — no
+   trailing token may ride the allowed target. The right anchor is a property of the
+   command, decided per class; "mirror the adjacent rule" is the wrong default.
+
+2. **Chain safety is inherited from the splitter — do not re-implement it in the
+   matcher.** `is_safe_bash_command` already runs `contains_unquoted_metacharacter`
+   + `is_tier3_dangerous` on the raw string, then requires *every*
+   `_split_compound_command` segment to be independently safe. So
+   `make verify-bundled-skills && rm -rf ~` dies three ways over (substitution veto,
+   tier3 `rm -rf`, and the `rm` segment failing the allow-list) with **zero** make-specific
+   logic. A new class's matcher only has to decide the single-segment case correctly;
+   adding redundant in-regex chain guards invites a parser differential (the §2 lesson).
+
+3. **A closed frozenset of one is the correct shape, and over-strict denials are the
+   correct failure mode.** Only `verify-bundled-skills` is enumerated; `make deploy`
+   and every other target route to the relay. The full anchor also denies otherwise-benign
+   `make verify-bundled-skills 2>/dev/null` (the fd-redirect strip lives only in
+   `is_tier3_dangerous`, not the matcher) — a false-negative on *approval*, which is the
+   safe direction. Each new target is an evidence-gated follow-up (the same discipline as
+   §4's substitution allowlist), not a generalization to "any read-only make target."
+
+An independent adversarial pass (20 probe strings: trailing-token, `&&`/`;`/`|`/`\n`/`\r`
+chains, `$(`/backtick, case, tab/space, quote-hidden separators) broke none — the
+closed-world frozenset + full anchor + inherited splitter held on every class. Pin the
+behavior with `is_safe_bash_command`-level tests (not just the matcher), so the
+end-to-end compound path is what's locked (`tests/test_tier1.py`). Architect lineage:
+mika-arch session 783d4a04 (closed-world per-rule allowlist expansion; sibling
+claude-pilot#34/#35).
+
 ## When to Apply
 
 - Adding/reviewing any `permissions.yaml` rule, or any code deciding allow/deny on
@@ -298,6 +339,10 @@ executed/adversarial review (§3), not by reading the diff.
   exec/write flag (§6a — `rg --pre`, `ugrep --filter`, GNU vs non-GNU provider),
   and if the command has multiple actions (like `find`), confirm the guard
   enumerates its whole mutating action set and denies the unknown (§6b).
+- Adding a new standalone command class to `tier1.py`'s allow-list: choose the anchor
+  by the command's own argument grammar (full-anchor when a trailing token can change
+  behavior, as `make` does), inherit chain safety from the splitter, keep the target set
+  closed, and pin with `is_safe_bash_command`-level tests (§8).
 - Reviewing `tier1.py` / `policy.py` / `permissions.py` in claude-pilot.
 
 ## Related

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -355,6 +355,7 @@ def _is_safe_sub_command(sub: str) -> bool:
     return (
         is_safe_git_command(sub)
         or is_safe_build_command(sub)
+        or is_safe_make_command(sub)
         or is_safe_shell_command(sub)
         or is_safe_gh_command(sub)
         or is_safe_mika_dispatch(sub)
@@ -432,6 +433,31 @@ def is_safe_build_command(sub: str) -> bool:
         return True
 
     return False
+
+
+# ── Safe make targets ────────────────────────────────────────────────────────
+#
+# Closed-world allowlist (cpp#45 / mika#1639; architect session 783d4a04, n=3
+# permission-policy-errs-strict class): only explicitly-enumerated read-only
+# `make` targets auto-approve. `make verify-bundled-skills` is the bundled-skill
+# pre-merge gate (mika#1575) CI runs on every PR — read-only, no side effects
+# beyond stdout/exit code, same class as the cargo/npm verification commands.
+#
+# Stricter than _CARGO_RE: the pattern is full-anchored (`...\s*$`), so NO
+# trailing tokens are allowed. `make` arguments can override variables and
+# change behavior, so a trailing token must NOT ride the allowed prefix. Chain
+# safety (`make verify-bundled-skills && rm -rf ~`) is handled upstream by
+# _split_compound_command + the all-subs-safe check in is_safe_bash_command, not
+# here. Each new target needs its own evidence-gated ticket (cpp#34 discipline).
+
+SAFE_MAKE_TARGETS: frozenset[str] = frozenset({"verify-bundled-skills"})
+
+_MAKE_RE = re.compile(r"^\s*make\s+(\S+)\s*$")
+
+
+def is_safe_make_command(sub: str) -> bool:
+    m = _MAKE_RE.match(sub)
+    return bool(m and m.group(1) in SAFE_MAKE_TARGETS)
 
 
 # ── Safe shell commands ──────────────────────────────────────────────────────

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -20,6 +20,7 @@ from claude_pilot.tier1 import (
     contains_unquoted_metacharacter,
     is_safe_bash_command,
     is_safe_git_command,
+    is_safe_make_command,
     is_safe_mika_dispatch,
     is_safe_shell_command,
     is_tier1_auto_approve,
@@ -190,6 +191,7 @@ def test_eval_dollar_paren_still_denied() -> None:
         "cargo test",
         "cargo clippy --all-targets",
         "cargo build --release",
+        "make verify-bundled-skills",
         "npm ci",
         "npm run build",
         "npm test",
@@ -218,6 +220,40 @@ def test_git_push_to_main_denied() -> None:
 
 def test_git_unknown_subcommand_denied() -> None:
     assert is_safe_git_command("git obliterate") is False
+
+
+# ── make-specific (cpp#45 / mika#1639; architect 783d4a04) ───────────────────
+#
+# Closed-world `make` allowlist: only `make verify-bundled-skills` auto-approves.
+# Assert through is_safe_bash_command (the public entry) so the compound-split +
+# all-subs-safe path is exercised end to end.
+
+
+def test_make_verify_bundled_skills_allowed() -> None:
+    """AC1: the read-only bundled-skill pre-merge gate auto-approves."""
+    assert is_safe_bash_command("make verify-bundled-skills") is True
+
+
+def test_make_verify_bundled_skills_chained_denied() -> None:
+    """AC2: a dangerous tail in the same compound is denied (the rm sub fails)."""
+    assert is_safe_bash_command("make verify-bundled-skills && rm -rf ~") is False
+
+
+def test_make_uppercase_denied() -> None:
+    """AC3: the matcher keys on literal lowercase `make` — `MAKE` does not match."""
+    assert is_safe_bash_command("MAKE verify-bundled-skills") is False
+
+
+def test_make_verify_with_trailing_arg_denied() -> None:
+    """AC4: the full-string anchor rejects any trailing token."""
+    assert is_safe_bash_command("make verify-bundled-skills extra-arg") is False
+
+
+def test_make_deploy_denied() -> None:
+    """AC5: unenumerated targets — notably the side-effecting `make deploy` — stay denied."""
+    assert is_safe_bash_command("make deploy") is False
+    assert is_safe_make_command("make deploy") is False
+    assert is_safe_make_command("make verify-bundled-skills") is True
 
 
 # ── shell-specific ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds `make verify-bundled-skills` to claude-pilot tier1s deterministic auto-approve allow-list, so headless pilot sessions can run the bundled-skill pre-merge gate during `/ce:work` verification instead of stalling on a relay policy-deny.

This is the **primary** half of mika#1639. The secondary half (the `## Acceptance criteria` case-sensitivity fix in mika `scripts/verify-pipeline.sh`) lives in the **mika** repo and is tracked there.

## Why

tier1 (`src/claude_pilot/tier1.py`) auto-approves `cargo {build,test,clippy,fmt}` and `npm` build scripts, but had **no `make` handling**. `make verify-bundled-skills` (the bundled-skill pre-merge gate, mika#1575; CI runs it on every PR) fell through to the relay, which denied it — halting the session with the PR stuck in draft.

**Hard evidence:** mika-devs autonomous callback on mika PR #1638 (~09:51Z 2026-06-29) named this policy-deny as a recurring substrate blocker.

## What

`is_safe_make_command` with a closed-world `SAFE_MAKE_TARGETS = frozenset({"verify-bundled-skills"})`, ORd into `_is_safe_sub_command`:

- **Full-string anchor** `^\s*make\s+(\S+)\s*$` — stricter than `_CARGO_RE` (which allows trailing flags) because `make` args can override variables and change behavior. No trailing token may ride the allowed target.
- **Chain safety inherited** from the existing `_split_compound_command` + all-segments-safe check in `is_safe_bash_command` — `make verify-bundled-skills && rm -rf ~` denies with zero make-specific logic.
- **Closed-world:** only `verify-bundled-skills` enumerated; `make deploy` and every other target stay denied. Each future target is an evidence-gated follow-up (cpp#34 discipline).

## Tests (tests/test_tier1.py — all assert through the public `is_safe_bash_command`)

- AC1 `make verify-bundled-skills` → auto-approved
- AC2 `make verify-bundled-skills && rm -rf ~` → DENIED
- AC3 `MAKE verify-bundled-skills` → DENIED (case-sensitive)
- AC4 `make verify-bundled-skills extra-arg` → DENIED (anchor rejects trailing token)
- AC5 `make deploy` → DENIED; cargo/npm allowlists unchanged

`ruff` ✓, `mypy` ✓, `pytest` 440 passed.

## Review

Independently adversarially reviewed (20 probe strings: trailing-token, `&&`/`;`/`|`/`\n`/`\r` chains, `$(`/backtick, case, whitespace, quote-hidden separators) — **no bypass found**. Learning captured in `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` §6.

Architect session: 783d4a04 (closed-world per-rule allowlist expansion, n=3 permission-policy-errs-strict class; sibling PRs #36, #39).

Closes #45
Refs senara-solutions/mika#1639