### PR TITLE
fix(permissions): veto bash 5.3 K-style funsub ${ ...; } (cpp#37)

### DIFF
--- a/docs/plans/2026-06-30-003-fix-37-k-style-funsub-marker-plan.md
+++ b/docs/plans/2026-06-30-003-fix-37-k-style-funsub-marker-plan.md
@@ -1,0 +1,195 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+origin: cpp#37
+plan_depth: lightweight
+---
+
+# fix: Veto bash 5.3 K-style funsub `${ ...; }` in the command-substitution chain-safety gate
+
+**Target repo:** claude-pilot-py
+**Issue:** senara-solutions/claude-pilot-py#37
+**Branch:** `fix/37/k-style-funsub-bash-5-3-not-in-substitution`
+
+---
+
+## Summary
+
+The chain-safety gate `_bash_allow_is_chain_safe` (`src/claude_pilot/permissions.py`) vetoes
+every command-substitution form that could smuggle execution into a policy-allowed command —
+backtick, `$'…'`, and any un-allowlisted `$(…)`. bash 5.3 added a **fourth** substitution form,
+K-style command substitution `${ command; }` / `${| command; }`, with the same injection power as
+`$(…)`. It is not vetoed, so `gh pr list --base ${ evil }` reaches the allow path. This plan adds
+one structural veto for the funsub opening token, matching the closed-world syntactic-marker shape
+the architect ratified for cpp#34/#35 (mika-arch session `783d4a04`).
+
+## Problem Frame (WHY)
+
+- **Evidence — code:** `permissions.py:220` vetoes `` ` `` and `$'`; `permissions.py:222` routes
+  `$(` to the closed-world allowlist; **nothing** handles `${`. (The cpp#37 issue body references a
+  stale `_SUBSTITUTION_MARKERS` tuple — that constant no longer exists post-cpp#34; the live checks
+  are the inline string tests at `permissions.py:220-225`.)
+- **Evidence — bash 5.3 grammar (verified on this host, GNU bash 5.3.9):** K-style funsub opens with
+  `${` immediately followed by whitespace (space / tab / newline) or `|`. Parameter expansion
+  (`${HOME}`, `${PATH}`, `${#arr[@]}`, `${VAR:-default}`) requires `${` immediately followed by an
+  identifier or special-parameter char — **never** whitespace or `|`. The two token shapes are
+  cleanly separable by the byte after `${`. Confirmed: `${ HOME}` (space after `${`) is parsed by
+  bash 5.3 as a funsub opener, not as parameter expansion — so vetoing the whitespace form is correct,
+  not a false positive.
+- **Evidence — exploit shape (cpp#37 body):** `gh pr list --base ${ evil }` has no internal `;`, so it
+  does not trip `_split_compound_command` segmentation and currently reaches the allow path. Reliance
+  on segment-splitting is incidental defense, exactly what `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`
+  warns against.
+- **Architecture lineage:** mika-arch session `783d4a04` (cpp#34 verdict) — keep syntactic crudeness via
+  literal/structural markers; never lex the substitution body. This change is a marker-set expansion of
+  the same shape (adding a deny marker, the mirror of cpp#34's allow-allowlist).
+
+## Requirements
+
+- **R1.** `_bash_allow_is_chain_safe` returns `False` for any command containing a K-style funsub opener
+  (`${` followed by whitespace or `|`). (cpp#37 AC1)
+- **R2.** `${name}`-style parameter expansion — including the braced `${HOME}` form — continues to be
+  honored where the rest of the command is allow-safe. (cpp#37 AC2)
+- **R3.** Detection is by **opening-token shape only** — no lexing or parsing of the funsub body.
+  (cpp#37 hard rule; architect `783d4a04`)
+- **R4.** Tests cover both funsub-veto and parameter-expansion-allow, including cpp#37's adversarial
+  harness rows. (cpp#37 AC3, AC4)
+
+## Key Technical Decisions
+
+- **KTD1 — Veto `${` + (whitespace | `|`), via a compiled regex.** Add a module-level
+  `_FUNSUB_OPENER_RE = re.compile(r"\$\{[\s|]")` and veto on `.search()` match, placed alongside the
+  existing backtick / `$'` veto at `permissions.py:220`. This is cpp#37's option (c) refined to the
+  exact bash 5.3 discriminator.
+  - *Why not option (a) "add `${` to a marker list":* over-blocks — kills every `${HOME}` parameter
+    expansion. Rejected.
+  - *Why not option (b) "match `${ ` literal with trailing space":* misses the tab, newline, and `|`
+    funsub forms. Rejected.
+  - *Why regex over a few `in` substring checks:* the funsub opener is a *class* of bytes after `${`
+    (space, tab, newline, `|`), not a fixed string. A single anchored regex expresses the class exactly
+    and reads as one structural marker. `\s` covers space/tab/newline/CR/FF/VT — a superset of bash's
+    funsub-delimiter set; over-matching here only ever *vetoes* (the safe direction) and never blocks a
+    legitimate `${name}` (which never has whitespace after `${`).
+- **KTD2 — Ordering: funsub veto runs in the same early block as backtick / `$'`, before the `$(`
+  allowlist redaction.** It is an unconditional veto (no allowlist), so it belongs with the other
+  unconditional substitution vetoes and must run before any `git show` redirect exception (mirroring the
+  existing comment at `permissions.py:236-238` that substitution vetoes precede the redirect rule).
+- **KTD3 — No funsub allowlist.** Unlike `$(`, there is no closed-world allowlist for `${…}` funsubs.
+  Per cpp#34 discipline and cpp#37 out-of-scope, any future safe-funsub allowance is a separate
+  evidence-gated ticket, not part of this change.
+
+## Implementation Units
+
+### U1. Add the K-style funsub veto to the chain-safety gate
+
+- **Goal:** Veto any command whose substitution surface contains a bash 5.3 funsub opener, without
+  touching parameter expansion.
+- **Requirements:** R1, R3
+- **Dependencies:** none
+- **Files:**
+  - `src/claude_pilot/permissions.py` (modify)
+- **Approach:**
+  - Add module-level `_FUNSUB_OPENER_RE = re.compile(r"\$\{[\s|]")` near the other substitution
+    constants (`_SUBSTITUTION_ALLOWLIST` block, ~`permissions.py:116`), with a comment block
+    explaining the bash 5.3 grammar discriminator (`${` + whitespace/`|` = funsub opener; `${` +
+    identifier = parameter expansion) and citing cpp#37 + architect `783d4a04`.
+  - In `_bash_allow_is_chain_safe`, extend the early veto at `permissions.py:220` so the funsub opener
+    is rejected together with backtick / `$'`: `if "`" in command or "$'" in command or _FUNSUB_OPENER_RE.search(command): return False`.
+  - Update the explanatory comment at `permissions.py:213-220` to name the funsub form alongside
+    backtick / `$'` as a never-allowlistable substitution.
+- **Patterns to follow:** the existing backtick / `$'` veto line and the `_BARE_AMP_RE` /
+  `_SANCTIONED_HEREDOC_OPENER_RE` compiled-regex-constant convention already in this file.
+- **Technical design (directional, not spec):** the discriminator is purely the byte after `${` —
+  `[\s|]` → veto; identifier/`#`/`!`/`:` etc. → leave for the normal allow path. No body parsing.
+- **Test scenarios:** covered by U2 (tests live in a separate unit/file).
+- **Verification:** `uv run ruff check` and `uv run mypy src` clean; the new constant is referenced in
+  the gate; manual `python -c` spot-check that `${ evil }` vetoes and `${HOME}` does not.
+
+### U2. Test funsub veto + parameter-expansion regression
+
+- **Goal:** Lock in R1/R2/R4 with the cpp#37 adversarial harness rows plus the braced-`${HOME}`
+  positive regression.
+- **Requirements:** R1, R2, R4
+- **Dependencies:** U1
+- **Files:**
+  - `tests/test_policy_devpilot.py` (modify)
+- **Approach:** Add tests mirroring the existing
+  `test_guard_vetoes_command_substitution_even_double_quoted` (loop over cmd strings, assert
+  `_bash_allow_is_chain_safe(...) is False`) and `test_guard_no_false_positive_on_var_expansion` styles.
+  Note the existing positive regression at `tests/test_policy_devpilot.py:106` uses the **unbraced**
+  `$HOME` form, which the new `${`-keyed check never touches — so a new **braced** `${HOME}` positive
+  case is the one that actually guards against over-blocking and must be added.
+- **Patterns to follow:** the `_bash(cmd)` helper and `_POLICY` fixture already used throughout the file;
+  the cpp#34 test cluster (`permissions.py` import block at `tests/test_policy_devpilot.py:20`).
+- **Test scenarios:**
+  - *Funsub veto (R1, R4) — new `test_guard_vetoes_kstyle_funsub`:* assert `is False` for each of —
+    - `gh pr list --head ${ git branch --show-current; }` (Covers cpp#37 AC harness row 1 — space + `;`)
+    - `gh pr list --head ${ evil\n}` (Covers cpp#37 AC harness row 2 — space + newline terminator)
+    - `gh pr list --base ${ evil }` (Covers cpp#37 AC1 / harness row 3 — no internal delimiter; the
+      one that currently slips through)
+    - `echo ${| REPLY=evil; }` (pipe form — the `${|` funsub variant)
+    - `echo ${	evil; }` (tab-after-`${` form; use an actual `\t` in the literal)
+  - *Parameter-expansion allow (R2) — new `test_guard_allows_braced_param_expansion`:* assert `is True`
+    for `export PATH="${HOME}/.local/bin:$PATH" && which npm` (braced `${HOME}`, the at-risk form). A
+    second positive row `echo ${PATH}` may be included for clarity.
+  - *Edge — `${` with no following byte / end of string:* `echo ${` should not crash the gate
+    (regex `.search` simply does not match → command proceeds to the normal path). Assert it does not
+    raise; behavior is allow-path (no funsub opener present).
+- **Verification:** `uv run pytest tests/test_policy_devpilot.py` green, including all new rows; full
+  `uv run pytest` green.
+
+### U3. Extend the substitution solution doc with the funsub marker-set expansion
+
+- **Goal:** Record the bash 5.3 funsub surface and the discriminator in the canonical solution doc so
+  the next reviewer of `permissions.py` sees it.
+- **Requirements:** none (compounding hygiene; cpp#37 file list)
+- **Dependencies:** U1
+- **Files:**
+  - `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` (modify)
+- **Approach:** Add a short subsection under the substitution discussion (and/or the "When to Apply"
+  list) noting: bash 5.3 introduced `${ command; }` / `${| command; }`; it is vetoed structurally by the
+  `${` + whitespace/`|` opener marker; parameter expansion (`${name}`) is distinguished by the byte after
+  `${`; no funsub allowlist exists (closed-world, evidence-gated). Cross-reference cpp#37 and the
+  symmetric `permission_pre_classifier.rs` paired-audit candidate already listed in "Related".
+- **Test scenarios:** Test expectation: none — documentation only.
+- **Verification:** doc renders; the new content references cpp#37 and the discriminator rule.
+
+## Scope Boundaries
+
+**In scope:** the funsub-opener veto, its tests, and the solution-doc note.
+
+### Deferred to Follow-Up Work / Out of scope
+
+- Process substitution `<(` / `>(` — already covered defense-in-depth at `tier1.py:130-131` (cpp#37
+  out-of-scope; no-op here).
+- Allowlisting any safe `${…}` funsub — closed-world; future evidence-gated ticket only (KTD3).
+- Policy-wide symlink/TOCTOU traversal containment — cpp#38, a separate ticket.
+
+## Verification Contract
+
+- `uv run ruff check` — clean.
+- `uv run mypy src` — clean.
+- `uv run pytest` — all tests green, including the new funsub-veto and braced-param-expansion rows.
+- Manual bash 5.3 evidence (already gathered on GNU bash 5.3.9): funsub forms veto; `${HOME}` /
+  `${PATH}` / `${#arr[@]}` / `${VAR:-default}` allow.
+
+## Definition of Done
+
+- R1–R4 satisfied; all four cpp#37 acceptance criteria met.
+- `_bash_allow_is_chain_safe` vetoes `gh pr list --base ${ evil }` and the full cpp#37 harness; honors
+  `${HOME}` braced parameter expansion.
+- Solution doc extended.
+- Pipeline gates (ruff, mypy, pytest) green. PR opened with `Closes #37`.
+
+## Sources & Research
+
+- cpp#37 issue body (spec + adversarial harness AC).
+- `src/claude_pilot/permissions.py:116-260` (live substitution-handling code; the stale
+  `_SUBSTITUTION_MARKERS` name in the issue body does not exist post-cpp#34).
+- `tests/test_policy_devpilot.py:101-165` (existing substitution test cluster; param-expansion
+  regression at line 106 uses unbraced `$HOME`).
+- bash 5.3 grammar verified empirically on GNU bash 5.3.9 (this host).
+- mika-arch session `783d4a04` (cpp#34 syntactic-marker verdict).
+- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`.

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -7,7 +7,7 @@ component: permission-classifier
 problem_type: security_issue
 category: security-issues
 severity: critical
-tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, make, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-43, claude-pilot-45]
+tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, make, funsub, bash-5.3, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-43, claude-pilot-45]
 applies_when: "adding or reviewing any rule that decides allow/deny on a raw shell command string"
 ---
 
@@ -328,6 +328,48 @@ end-to-end compound path is what's locked (`tests/test_tier1.py`). Architect lin
 mika-arch session 783d4a04 (closed-world per-rule allowlist expansion; sibling
 claude-pilot#34/#35).
 
+### 9. The substitution marker set is closed over *known* shell forms — re-audit it when the shell grammar grows (bash 5.3 K-style funsub)
+
+The veto in §1/§4 enumerates the command-substitution forms it rejects: `$(`,
+backtick, `$'`. That list is only as complete as the shell grammar it was written
+against. **bash 5.3 (released late 2025) added a fourth form** — K-style command
+substitution `${ command; }` / `${| command; }` — with the same injection power as
+`$(…)`. It was not in the marker set, so on a bash 5.3 host
+`gh pr list --base ${ evil }` reached the allow path (it has no internal `;`, so it
+didn't even trip the incidental `_split_compound_command` segmentation). A
+substitution form the gate has never heard of is an open hole, not a closed world.
+
+The fix is the same shape as the rest of this doc — a **structural marker on the
+opening token, no lexing of the body** (cpp#37, mika-arch session `783d4a04`):
+
+```python
+# bash 5.3 distinguishes funsub from ${name} parameter expansion purely by the
+# byte after ${ : funsub requires whitespace (space/tab/newline) or `|`;
+# parameter expansion requires an identifier/special-param char. So this marker
+# can never collide with a legitimate ${HOME} / ${#arr[@]} / ${VAR:-x}.
+_FUNSUB_OPENER_RE = re.compile(r"\$\{[\s|]")
+# vetoed alongside backtick / $' , before any $( allowlist redaction runs.
+```
+
+Key points that make this safe and minimal:
+
+- **The discriminator is a single byte after `${`.** Verified empirically on GNU
+  bash 5.3.9: `${ HOME}` (space after `${`) is parsed as a *funsub opener*, not as
+  parameter expansion — so vetoing the whitespace/`|` form has no false positives on
+  real `${name}` references. `\s` is a deliberate superset of bash's blank set; any
+  over-match only ever vetoes (the safe direction).
+- **No funsub allowlist.** Unlike `$(`, there is no closed-world allowlist for
+  `${…}` funsubs — none is needed today, and adding one is a separate
+  evidence-gated ticket, never an inline edit (§4 discipline).
+- **Pre-existing, unrelated:** the braces in `export PATH="${HOME}/…"` are already
+  vetoed by a separate tier1 check, independent of this marker — don't conflate it
+  with funsub handling.
+
+Generalization: when a marker set encodes "the dangerous forms of X", record the
+*grammar version* it was audited against, and re-audit on a major shell/runtime
+bump. The symmetric `permission_pre_classifier.rs` in mika (see Related) is the same
+class and the same re-audit candidate.
+
 ## When to Apply
 
 - Adding/reviewing any `permissions.yaml` rule, or any code deciding allow/deny on
@@ -343,6 +385,9 @@ claude-pilot#34/#35).
   by the command's own argument grammar (full-anchor when a trailing token can change
   behavior, as `make` does), inherit chain safety from the splitter, keep the target set
   closed, and pin with `is_safe_bash_command`-level tests (§8).
+- A major shell/runtime version bump: re-audit the substitution marker set against the
+  new grammar — bash 5.3's K-style funsub `${ … }` was a new injection form the
+  original `$(`/backtick/`$'` set did not cover (§9).
 - Reviewing `tier1.py` / `policy.py` / `permissions.py` in claude-pilot.
 
 ## Related
@@ -366,3 +411,10 @@ claude-pilot#34/#35).
   write target** (`/tmp` heredoc, and every structural write rule —
   `bash-cp-mv`/`bash-mkdir`/`bash-git-show-redirect`) is a runtime concern
   outside static policy scope (see #5; closing it policy-wide = cpp#38).
+- **Known-open gap (filed cpp#47):** the sanctioned `cat > /tmp/<token> <<EOF`
+  exception (§2) returns BEFORE the §1/§4/§8 substitution-marker veto and admits an
+  *unquoted* `EOF` delimiter, so `$(…)` / backtick / `${ …; }` funsub in the heredoc
+  **body** expand and auto-approve (reproduced on bash 5.3.9). Distinct from the
+  accepted in-worktree-execution residual above: the sanctioned heredoc is *designed
+  to be inert*. Fix shape (quoted-delimiter restriction vs body-scan) needs an
+  architect call — see cpp#47.

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -127,6 +127,22 @@ _SUBSTITUTION_ALLOWLIST = (
 # --show-current)`` correctly vetoes once redacted to ``git status && _SUB_``.
 _SUBSTITUTION_PLACEHOLDER = "_SUB_"
 
+# bash 5.3 K-style command substitution opener (cpp#37). ``${ command; }`` and
+# ``${| command; }`` run ``command`` and substitute its stdout — equivalent
+# injection power to ``$(...)`` — and are NOT allowlistable (same class as
+# backtick / ``$'``). This matches the OPENING TOKEN SHAPE only, never the body:
+# bash 5.3 distinguishes a funsub from ``${name}`` parameter expansion purely by
+# the byte after ``${`` — funsub requires whitespace (space / tab / newline) or
+# ``|``, whereas parameter expansion (``${HOME}``, ``${#arr[@]}``, ``${VAR:-x}``)
+# requires an identifier or special-parameter char. So ``\$\{`` followed by
+# ``[\s|]`` is an unambiguous funsub marker; it can never collide with a legitimate
+# ``${name}``. ``\s`` is a superset of bash's blank set (it also covers CR/FF/VT) —
+# over-matching here only ever vetoes (the safe direction) and cannot block a real
+# parameter expansion, which never has whitespace after ``${``. No funsub
+# allowlist exists; like ``$(``, any future safe-funsub allowance is a separate
+# evidence-gated ticket (cpp#34 closed-world discipline, mika-arch 783d4a04).
+_FUNSUB_OPENER_RE = re.compile(r"\$\{[\s|]")
+
 
 def _redact_allowlisted_substitutions(command: str) -> str | None:
     """Redact allowlisted ``$(...)`` tokens, or signal an unrecognized one.
@@ -210,14 +226,16 @@ def _bash_allow_is_chain_safe(
         # cat-heredoc (delimiter fixed to EOF). Everything else routes to relay.
         return _is_sanctioned_pure_heredoc(command)
 
-    # Command substitution. Backtick / ``$'`` forms are never allowlistable →
-    # veto outright. For ``$(`` forms, admit only the closed-world allowlist:
-    # redact each allowlisted whole-token to an inert ``_SUB_`` placeholder, then
-    # let the per-segment chain check below run on the redacted command. We do
-    # NOT short-circuit ``return True`` — the redacted command still needs full
-    # chain-safety (e.g. ``git status && $(git branch --show-current)`` becomes
-    # ``git status && _SUB_``, whose ``_SUB_`` segment fails the segment check).
-    if "`" in command or "$'" in command:
+    # Command substitution. Backtick / ``$'`` / bash 5.3 K-style funsub (``${ … }``)
+    # forms are never allowlistable → veto outright. For ``$(`` forms, admit only
+    # the closed-world allowlist: redact each allowlisted whole-token to an inert
+    # ``_SUB_`` placeholder, then let the per-segment chain check below run on the
+    # redacted command. We do NOT short-circuit ``return True`` — the redacted
+    # command still needs full chain-safety (e.g. ``git status && $(git branch
+    # --show-current)`` becomes ``git status && _SUB_``, whose ``_SUB_`` segment
+    # fails the segment check). The funsub veto is keyed on the opener token only
+    # (``_FUNSUB_OPENER_RE``); it leaves ``${name}`` parameter expansion untouched.
+    if "`" in command or "$'" in command or _FUNSUB_OPENER_RE.search(command):
         return False
     if "$(" in command:
         redacted = _redact_allowlisted_substitutions(command)

--- a/tests/test_policy_devpilot.py
+++ b/tests/test_policy_devpilot.py
@@ -108,6 +108,50 @@ def test_guard_no_false_positive_on_var_expansion() -> None:
     assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True
 
 
+# --- cpp#37: bash 5.3 K-style funsub ``${ command; }`` veto (mika-arch 783d4a04) ---
+# bash 5.3 added command substitution via ``${ … }`` / ``${| … }`` — same injection
+# power as ``$(…)``. It is vetoed structurally by the opener-token marker (``${``
+# followed by whitespace or ``|``), which never collides with ``${name}`` parameter
+# expansion (``${`` followed by an identifier/special char). No body lexing.
+
+
+def test_guard_vetoes_kstyle_funsub() -> None:
+    # cpp#37 AC1 + adversarial harness rows: every K-style funsub opener form vetoes.
+    # ``${ evil }`` (no internal delimiter) is the row that currently slips through
+    # because it doesn't trip ``_split_compound_command`` segmentation.
+    for cmd in [
+        "gh pr list --head ${ git branch --show-current; }",  # space + ``;``
+        "gh pr list --head ${ evil\n}",  # space + newline terminator
+        "gh pr list --base ${ evil }",  # no internal delimiter (AC1)
+        "echo ${| REPLY=evil; }",  # ``${|`` pipe form
+        "echo ${\tevil; }",  # tab after ``${``
+    ]:
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
+
+
+def test_guard_allows_braced_param_expansion() -> None:
+    # cpp#37 AC2 — the braced ``${HOME}`` form is the one at risk from the funsub
+    # marker (the existing $HOME regression above is unbraced). It must still allow.
+    # Witnesses are commands already on the allow path that carry ``${name}``; the
+    # funsub marker (``${`` + whitespace/``|``) must not catch the identifier form.
+    # (NB: ``export PATH="${HOME}/…"`` is NOT a witness — its ``{}`` braces are
+    # vetoed by a pre-existing tier1 check independent of this change.)
+    for cmd in [
+        "echo ${HOME}",
+        "echo ${PATH}",
+        'echo "${HOME}/bin"',
+    ]:
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True, cmd
+
+
+def test_guard_funsub_marker_handles_truncated_opener() -> None:
+    # ``${`` at end of string (no following byte) must not crash the gate; the
+    # opener marker simply doesn't match, so the command proceeds to the normal path.
+    cmd = "echo ${"
+    # Whatever the downstream verdict, the call returns a bool and does not raise.
+    assert isinstance(_bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)), bool)
+
+
 # --- cpp#34: closed-world substitution-inner allowlist (mika-arch 783d4a04) ---
 # The blanket ``$(`` veto admits a narrow closed world of whole-token literals:
 # read-only git plumbing substitutions feeding a read-only outer command. Match


### PR DESCRIPTION
## Why

bash 5.3 (released late 2025) added **K-style command substitution** — `${ command; }` / `${| command; }` — which runs `command` and substitutes its stdout, the same injection power as `$(...)`. The permission-classifier chain-safety gate `_bash_allow_is_chain_safe` vetoed backtick, `$'`, and un-allowlisted `$(`, **but not `${ ...`**. So on a bash 5.3 host `gh pr list --base ${ evil }` (no internal `;`, so it didn't even trip `_split_compound_command` segmentation) reached the allow path.

Same defense-in-depth-via-syntactic-crudeness class as cpp#34/#35 (mika-arch session `783d4a04`: keep syntactic crudeness via literal/structural markers, no lexing inside the gate). This is a marker-set expansion — adding a deny marker, the mirror of cpp#34's allow-allowlist.

> Note: the cpp#37 issue body references a stale `_SUBSTITUTION_MARKERS` tuple that no longer exists post-cpp#34. The live checks are inline at `permissions.py`; the funsub veto sits alongside the existing backtick / `$'` veto.

## What

- `src/claude_pilot/permissions.py`: add `_FUNSUB_OPENER_RE = re.compile(r"\$\{[\s|]")` and veto on match, alongside the backtick / `$'` veto — **before** the `$(` allowlist redaction and the `bash-git-show-redirect` exception.
- `tests/test_policy_devpilot.py`: funsub-veto cases (space/`;`, newline, no-delimiter, `${|` pipe, tab) + braced-`${HOME}`/`${PATH}` parameter-expansion positive regression + truncated-`${` no-crash.
- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`: §6 (re-audit the marker set on a major shell/runtime bump) + cpp#47 cross-reference.

### Decision: option (c) refined — veto `${` + (whitespace | `|`)

bash 5.3 distinguishes a funsub opener from `${name}` parameter expansion **purely by the byte after `${`**: funsub requires whitespace (space/tab/newline) or `|`; parameter expansion requires an identifier/special-param char. So `\$\{[\s|]` matches every funsub opener and **never** collides with `${HOME}` / `${#arr[@]}` / `${VAR:-x}`. Structural opener-token match only — no body lexing.

- Option (a) "add `${` to a marker list" → over-blocks every `${HOME}`. Rejected.
- Option (b) "`${ ` literal with trailing space" → misses tab/newline/`|` forms. Rejected.

### Verified empirically on this host (GNU bash 5.3.9)

- VETOes: `${ cmd; }` (space), `${| cmd; }` (pipe), `${\tcmd; }` (tab), `${\ncmd; }` (newline).
- ALLOWs: `${HOME}`, `${PATH}`, `${#arr[@]}`, `${VAR:-default}`, `${VAR/a/b}`, `${!indirect}`.
- `${ HOME}` (space after `${`) is parsed by bash 5.3 as a funsub opener, **not** parameter expansion — so vetoing it is correct.

## Acceptance criteria (cpp#37)

- [x] AC1 — `_bash_allow_is_chain_safe` returns False for `gh pr list --base ${ evil }`.
- [x] AC2 — `${name}` / `${HOME}` parameter expansion continues to allow.
- [x] AC3 — tests cover both funsub-veto and parameter-expansion-allow.
- [x] AC4 — peer-Claude's adversarial harness (3 funsub rows) green against the real function.

## Review notes

Security + correctness peer review (Opus-tier subagents):
- **Correctness:** no defects. Regex confirmed; all parameter-expansion forms enumerated and cleared; no non-whitespace funsub bypass exists on bash 5.3.9.
- **Security:** 4/5 questions SOUND (no opener bypass, no quoting bypass, correct ordering vs `$(` redaction and git-show-redirect, truncated-`${` benign). Found one **pre-existing, out-of-scope** defense-in-depth gap — the sanctioned cat-heredoc path auto-approves substitutions in the heredoc body (symmetric across `$(`/backtick/funsub; reproduced on main). Filed as **cpp#47** with full repro; not addressed here (genuinely separate mechanism in `_is_sanctioned_pure_heredoc`).

## Gates

`uv run ruff check` ✓ · `uv run mypy src` ✓ · `uv run pytest` ✓ (437 passed)

Closes #37