### PR TITLE
fix(permissions): require quoted delimiter for sanctioned cat-heredoc (cpp#47)

### DIFF
--- a/docs/plans/2026-06-30-004-fix-47-heredoc-quoted-delimiter-plan.md
+++ b/docs/plans/2026-06-30-004-fix-47-heredoc-quoted-delimiter-plan.md
@@ -1,0 +1,172 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+origin: cpp#47
+plan_depth: lightweight
+---
+
+# fix: Restrict the sanctioned cat-heredoc to a quoted delimiter so the body can never execute substitutions
+
+**Target repo:** claude-pilot-py
+**Issue:** senara-solutions/claude-pilot-py#47
+**Branch:** `fix/47/sanctioned-cat-heredoc-body-executes`
+
+---
+
+## Summary
+
+The chain-safety gate `_bash_allow_is_chain_safe` routes a `<<` command to `_is_sanctioned_pure_heredoc`
+and returns **before** the substitution-marker veto. The sanctioned-heredoc opener regex admits an
+**unquoted** `EOF` delimiter (`<<EOF`), and with an unquoted delimiter bash **expands** the heredoc body —
+so `$(…)`, backtick, and `${ …; }` funsub in the body execute (during heredoc expansion) while the gate
+auto-approves the command. This plan tightens the opener regex to admit **only a quoted delimiter**
+(`<<'EOF'` / `<<"EOF"`), which makes the body provably inert. One regex token, its comment, and the test
+that currently blesses the vulnerable form.
+
+## Problem Frame (WHY)
+
+- **Evidence — code:** `_bash_allow_is_chain_safe` (`src/claude_pilot/permissions.py`) handles `<<` by
+  `return _is_sanctioned_pure_heredoc(command)` — an early return **before** the backtick/`$'`/`$(`
+  substitution veto. `_SANCTIONED_HEREDOC_OPENER_RE` ends in `(?:'EOF'|"EOF"|EOF)`; the bare `EOF`
+  alternative admits an unquoted delimiter.
+- **Evidence — bash 5.3.9 (verified on this host):** with `<<EOF` (unquoted) the body is expanded —
+  `cat > /tmp/x <<EOF\nval=$(echo X)\nEOF` writes `val=X` (the substitution ran). With `<<'EOF'` **or**
+  `<<"EOF"` the body stays literal (`val=$(echo X)` verbatim, no execution). Any quoting of the heredoc
+  delimiter disables all body expansion; only the bare unquoted delimiter expands.
+- **Evidence — no legitimate caller:** searched `mika-skills/` (dispatch-lib) and `claude-pilot-py/src/`
+  for the sanctioned `cat > /tmp/<token>` heredoc emitter — zero runtime callers (only an unrelated CI
+  `$GITHUB_OUTPUT` heredoc and the permissions.py comments). Writing literal `$(…)` *content* to a file
+  requires a quoted delimiter anyway, so a quoted-only restriction breaks no real use.
+- **Evidence — a test blesses the bug:** `tests/test_policy_devpilot.py::test_guard_allows_heredoc_body_with_substitution_text`
+  asserts `cat > /tmp/x.txt <<EOF\nfoo=$(date)\n…\nEOF` (unquoted) is **allowed**, on the false premise
+  "the heredoc BODY is inert data." It is not inert under an unquoted delimiter.
+- **Lineage:** this completes the cpp#34/#35 "inert sanctioned write" intent and the §2 no-lexing
+  discipline (mika-arch session `783d4a04`). Surfaced by the cpp#37 (#49) security review.
+
+## Requirements
+
+- **R1.** A sanctioned heredoc with an **unquoted** delimiter (`<<EOF` / `<<-EOF`) whose body contains
+  `$(…)`, backtick, `$'…'`, or a `${ …; }` funsub is vetoed by `_bash_allow_is_chain_safe`. (cpp#47 AC1)
+- **R2.** A sanctioned heredoc with a **quoted** delimiter (`<<'EOF'` / `<<"EOF"`) and an arbitrary literal
+  body (including substitution *text*) continues to be honored — the body is provably inert. (cpp#47 AC2)
+- **R3.** All existing heredoc tests stay green. (cpp#47 AC3)
+- **R4.** Detection adds no body lexing — the change is a tightening of the opener-token regex only.
+
+## Key Technical Decisions
+
+- **KTD1 — Drop the bare `EOF` alternative from the opener regex (option a).** Change the delimiter group
+  `(?:'EOF'|"EOF"|EOF)` → `(?:'EOF'|"EOF")` in `_SANCTIONED_HEREDOC_OPENER_RE`. A quoted delimiter makes
+  bash treat the entire body as literal text (verified on bash 5.3.9 for both `'EOF'` and `"EOF"`), so the
+  body can no longer execute any substitution — without scanning or lexing the body.
+  - *Why not option (b) "scan the heredoc body for substitution markers":* re-introduces a body lexer (the
+    exact thing §2/§4 of the solution doc says to remove) for no benefit — no caller needs the unquoted
+    form, and the quoted-delimiter restriction is strictly simpler and closes the gap completely. Rejected.
+- **KTD2 — The closing terminator stays unquoted `EOF`.** `_HEREDOC_TERMINATOR = "EOF"` and the body
+  close-line match are unchanged: bash's *closing* delimiter line is always the bare word (never quoted),
+  regardless of how the *opener* quoted it. Only the opener's delimiter quoting controls body expansion.
+
+## Implementation Units
+
+### U1. Tighten the sanctioned-heredoc opener to a quoted delimiter
+
+- **Goal:** Admit the sanctioned `cat > /tmp/<token>` heredoc only with a quoted delimiter, so the body
+  is inert.
+- **Requirements:** R1, R2, R4
+- **Dependencies:** none
+- **Files:**
+  - `src/claude_pilot/permissions.py` (modify)
+- **Approach:**
+  - In `_SANCTIONED_HEREDOC_OPENER_RE`, change the trailing delimiter alternation
+    `(?:'EOF'|"EOF"|EOF)` → `(?:'EOF'|"EOF")` (drop the bare unquoted `EOF`).
+  - Update the comment block above the regex and the `_is_sanctioned_pure_heredoc` docstring to state the
+    quoted-delimiter requirement and **why**: an unquoted delimiter makes bash expand the body (executing
+    `$(…)`/backtick/`${ …; }`), so the "inert file write" guarantee holds only for a quoted delimiter.
+    Cross-reference cpp#47 and the §2 heredoc lesson.
+  - Leave `_HEREDOC_TERMINATOR` and the body close-line logic untouched (KTD2).
+- **Patterns to follow:** the existing full-line-anchored opener regex and its comment style; the §2
+  hard-coded-`EOF` discipline already documented in the file.
+- **Test scenarios:** covered by U2.
+- **Verification:** `uv run ruff check` / `uv run mypy src` clean; manual spot-check that an unquoted-`<<EOF`
+  sanctioned heredoc with `$(date)` in the body now vetoes and a quoted-`<<'EOF'` one still allows.
+
+### U2. Re-point the heredoc-body test from "blesses the bug" to "quoted inert, unquoted vetoes"
+
+- **Goal:** Replace the test that asserts the vulnerable unquoted form is allowed with one that pins the
+  fixed contract.
+- **Requirements:** R1, R2, R3
+- **Dependencies:** U1
+- **Files:**
+  - `tests/test_policy_devpilot.py` (modify)
+- **Approach:** Rewrite `test_guard_allows_heredoc_body_with_substitution_text` (the current body asserts
+  unquoted `<<EOF` with `$(date)` is allowed — that is the bug). Split into two assertions, mirroring the
+  existing `_bash`/`_POLICY` helpers and the heredoc test cluster:
+  - **Quoted → allow (R2):** `cat > /tmp/x.txt <<'EOF'\nfoo=$(date)\nrm -rf /tmp/build\nEOF` and the
+    `<<"EOF"` variant, each `is True` — the body is literal text, provably inert.
+  - **Unquoted → veto (R1):** `cat > /tmp/x.txt <<EOF\nfoo=$(date)\nEOF`, plus body variants carrying a
+    backtick (`` `id` ``) and a `${ id; }` funsub, each `is False`.
+- **Patterns to follow:** the `_bash(cmd)` helper, `_POLICY` fixture, and the existing heredoc tests
+  (`test_guard_exempts_sole_command_heredoc` uses `<<'EOF'`).
+- **Test scenarios:**
+  - *Quoted-delimiter inert body allows (R2):* `<<'EOF'` body with `$(date)` + `rm -rf …` → True; `<<"EOF"`
+    body with `$(date)` → True.
+  - *Unquoted-delimiter body with substitution vetoes (R1):* `<<EOF` body with `$(date)` → False;
+    `<<EOF` body with `` `id` `` → False; `<<EOF` body with `${ id; }` → False.
+  - *Regression — other heredoc tests unaffected (R3):* running the full file leaves
+    `test_guard_exempts_sole_command_heredoc`, `test_guard_closes_heredoc_trailing_chain_residual`,
+    `test_guard_vetoes_heredoc_leading_edge_chain`, `test_guard_vetoes_heredoc_delimiter_desync`,
+    `test_guard_heredoc_token_cannot_smuggle_a_chain`, `test_guard_vetoes_herestring_desync` all green.
+- **Verification:** `uv run pytest tests/test_policy_devpilot.py` green; full `uv run pytest` green.
+
+### U3. Record the fix in the substitution solution doc
+
+- **Goal:** Update the canonical solution doc so the heredoc lesson reflects the quoted-delimiter
+  requirement and the cpp#47 gap is marked closed.
+- **Requirements:** none (compounding hygiene; cpp#47 file list)
+- **Dependencies:** U1
+- **Files:**
+  - `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` (modify)
+- **Approach:** In §2 (the heredoc lesson), add that the sanctioned heredoc requires a **quoted** delimiter
+  because an unquoted delimiter expands the body (executing substitutions) — the close-point fix (§2) made
+  the *terminator* safe, but body expansion is a separate axis the quoted delimiter closes. Update the
+  cpp#47 "known-open gap" bullet in **Related** to record the fix landed (quoted-delimiter restriction).
+  Add `claude-pilot-47` to the tags if not present.
+- **Test scenarios:** Test expectation: none — documentation only.
+- **Verification:** doc renders; §2 + Related reflect the landed fix.
+
+## Scope Boundaries
+
+**In scope:** the opener-regex tightening, its test re-point, and the solution-doc update.
+
+### Deferred to Follow-Up Work / Out of scope
+
+- cpp#38 — policy-wide symlink/TOCTOU traversal containment (different mechanism).
+- Any funsub / `$(` allowlist for heredoc bodies — not needed; the quoted-delimiter restriction makes the
+  body inert wholesale.
+
+## Verification Contract
+
+- `uv run ruff check` — clean.
+- `uv run mypy src` — clean.
+- `uv run pytest` — all green, including the re-pointed heredoc-body test and the unchanged heredoc cluster.
+- Manual bash 5.3.9 evidence (already gathered): `<<EOF` expands the body; `<<'EOF'`/`<<"EOF"` keep it literal.
+
+## Definition of Done
+
+- R1–R4 satisfied; all four cpp#47 acceptance criteria met.
+- `_bash_allow_is_chain_safe` vetoes an unquoted-delimiter sanctioned heredoc whose body carries a
+  substitution; honors the quoted-delimiter form with an inert literal body.
+- Solution doc updated.
+- ruff / mypy / pytest green. PR opened with `Closes #47`.
+
+## Sources & Research
+
+- cpp#47 issue body + groomed comment (resolved design, evidence).
+- `src/claude_pilot/permissions.py` — `_SANCTIONED_HEREDOC_OPENER_RE`, `_is_sanctioned_pure_heredoc`,
+  `_bash_allow_is_chain_safe` (the `<<` early-return path).
+- `tests/test_policy_devpilot.py` heredoc cluster (the `test_guard_allows_heredoc_body_with_substitution_text`
+  test currently blesses the unquoted form).
+- bash 5.3.9 delimiter-quoting expansion behavior verified empirically on this host.
+- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` §2 / Related.
+- mika-arch session `783d4a04` (cpp#34/#35 sanctioned-heredoc + no-lexing discipline).

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -7,7 +7,7 @@ component: permission-classifier
 problem_type: security_issue
 category: security-issues
 severity: critical
-tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, make, funsub, bash-5.3, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-43, claude-pilot-45]
+tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, make, funsub, bash-5.3, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-43, claude-pilot-45, claude-pilot-47]
 applies_when: "adding or reviewing any rule that decides allow/deny on a raw shell command string"
 ---
 
@@ -81,6 +81,22 @@ General principle: when a static check must agree with a shell's parse, **fix th
 variable rather than parse it** (or shell out to a real lexer), and pin it with a
 **differential test against real bash** (run the construct, assert the gate denies
 iff bash would execute something dangerous).
+
+**The close-point and body-expansion are two separate axes — fixing one does not
+fix the other (cpp#47).** The hard-coded-`EOF` fix above made the *terminator*
+safe (the gate's close-point can't diverge from bash's). But the sanctioned shape
+also originally admitted an **unquoted** delimiter (`<<EOF`), and with an unquoted
+delimiter bash **expands the heredoc body** — so `$(…)` / backtick / `${ …; }`
+funsub in the body *execute* during expansion (verified on bash 5.3.9), while the
+`<<` early-return auto-approves the command before the substitution-marker veto
+ever runs. The fix is to require a **quoted** delimiter (`<<'EOF'` / `<<"EOF"`;
+either form disables all body expansion, verified on bash 5.3.9), making the body
+provably inert — the property the "inert /tmp write" exception always assumed.
+Writing literal `$(…)` *content* to a file requires a quoted delimiter anyway, so
+no legitimate use is lost; the bare-`EOF` alternative was dropped from
+`_SANCTIONED_HEREDOC_OPENER_RE`. Lesson: when a structural exception's safety rests
+on a body being *data*, pin the syntactic property that actually makes it data
+(here, delimiter quoting) — don't infer inertness from the close-point alone.
 
 ### 3. Permission-classifier changes need executed-exploit review, not reasoning-only review
 

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -177,21 +177,37 @@ _BARE_AMP_RE = re.compile(r"(?<![>&\d])&(?!&|>)")
 # the classifier's close-point cannot diverge from bash's — there is no
 # delimiter to mis-parse. The opener must be the entire first line (``^…$``):
 # ``cat`` redirecting to a single ``/tmp/<token>`` path (no spaces, no ``..``),
-# then ``<<`` / ``<<-`` and exactly ``EOF`` / ``'EOF'`` / ``"EOF"``. Anything
-# chained or substituted before ``<<`` breaks the full-line match → veto.
+# then ``<<`` / ``<<-`` and a QUOTED delimiter — exactly ``'EOF'`` or ``"EOF"``.
+# Anything chained or substituted before ``<<`` breaks the full-line match → veto.
+#
+# The delimiter MUST be quoted (cpp#47). The close-point fix above made the
+# *terminator* safe, but body expansion is a separate axis: with a bare unquoted
+# ``<<EOF`` bash expands the heredoc body, so ``$(…)`` / backtick / ``${ …; }``
+# funsub in the body EXECUTE during heredoc expansion (verified on bash 5.3.9) —
+# while this gate, returning early before the substitution-marker veto, would
+# auto-approve the command. Quoting the delimiter (``'EOF'`` or ``"EOF"``; either
+# form disables expansion, verified on bash 5.3.9) makes the body provably inert,
+# restoring the "inert /tmp file write" guarantee this exception was designed for
+# (cpp#34/#35). Writing literal ``$(…)`` *content* to a file requires a quoted
+# delimiter anyway, so no legitimate use is lost. See the §2 heredoc lesson in
+# docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md.
 _SANCTIONED_HEREDOC_OPENER_RE = re.compile(
-    r"""^cat\s+>\s+/tmp/(?!.*\.\.)[\w./-]+\s+<<-?\s*(?:'EOF'|"EOF"|EOF)\s*$"""
+    r"""^cat\s+>\s+/tmp/(?!.*\.\.)[\w./-]+\s+<<-?\s*(?:'EOF'|"EOF")\s*$"""
 )
 _HEREDOC_TERMINATOR = "EOF"
 
 
 def _is_sanctioned_pure_heredoc(command: str) -> bool:
-    """True only for ``cat > /tmp/<token> <<EOF`` … ``EOF`` with no trailing command.
+    """True only for ``cat > /tmp/<token> <<'EOF'`` … ``EOF`` with no trailing command.
 
-    The opener is matched as a whole line so nothing rides before ``<<``; the
-    body closes on a bare ``EOF`` line (delimiter is fixed, so the close-point
-    matches bash); nothing executable may follow the terminator. Conservative on
-    any ambiguity (unterminated, trailing non-blank) → False so the caller vetoes.
+    The opener is matched as a whole line so nothing rides before ``<<``, and the
+    delimiter must be QUOTED (``'EOF'`` / ``"EOF"``) so bash performs no expansion
+    on the body — an unquoted ``<<EOF`` would expand (execute) substitutions in the
+    body, so it is not sanctioned (cpp#47). The body closes on a bare ``EOF`` line
+    (the closing delimiter is always unquoted in bash, regardless of opener
+    quoting, so the close-point is fixed and matches bash); nothing executable may
+    follow the terminator. Conservative on any ambiguity (unterminated, trailing
+    non-blank) → False so the caller vetoes.
     """
     lines = command.split("\n")
     if not _SANCTIONED_HEREDOC_OPENER_RE.match(lines[0]):

--- a/tests/test_policy_devpilot.py
+++ b/tests/test_policy_devpilot.py
@@ -248,10 +248,28 @@ def test_guard_vetoes_heredoc_leading_edge_chain() -> None:
         assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
 
 
-def test_guard_allows_heredoc_body_with_substitution_text() -> None:
-    # The heredoc BODY is inert data — `$(...)`/`rm` as literal script text is fine.
-    cmd = "cat > /tmp/x.txt <<EOF\nfoo=$(date)\nrm -rf /tmp/build\nEOF"
-    assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True
+def test_guard_allows_quoted_heredoc_body_with_substitution_text() -> None:
+    # cpp#47 — a QUOTED delimiter makes bash treat the body as literal text (no
+    # expansion, verified on bash 5.3.9 for both `'EOF'` and `"EOF"`), so `$(...)`
+    # / `rm` as script text is provably inert and the sanctioned write is honored.
+    for cmd in [
+        "cat > /tmp/x.txt <<'EOF'\nfoo=$(date)\nrm -rf /tmp/build\nEOF",
+        'cat > /tmp/x.txt <<"EOF"\nfoo=$(date)\nEOF',
+        "cat > /tmp/x.txt <<-'EOF'\nfoo=$(date)\nEOF",  # `<<-` dash variant, quoted → inert
+    ]:
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True, cmd
+
+
+def test_guard_vetoes_unquoted_heredoc_body_substitution() -> None:
+    # cpp#47 — with an UNQUOTED `<<EOF` bash EXPANDS the body, so a substitution
+    # there executes during heredoc expansion. The sanctioned exception now admits
+    # only a quoted delimiter, so every unquoted-body-substitution form vetoes.
+    for cmd in [
+        "cat > /tmp/x.txt <<EOF\nfoo=$(date)\nEOF",  # command substitution
+        "cat > /tmp/x.txt <<EOF\nfoo=`id`\nEOF",  # backtick substitution
+        "cat > /tmp/x.txt <<EOF\nfoo=${ id; }\nEOF",  # bash 5.3 K-style funsub
+    ]:
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
 
 
 def test_guard_vetoes_heredoc_delimiter_desync() -> None:


### PR DESCRIPTION
## Why

The chain-safety gate `_bash_allow_is_chain_safe` routes a `<<` command to `_is_sanctioned_pure_heredoc` and **returns early, before** the substitution-marker veto. The sanctioned-heredoc opener regex admitted an **unquoted** `EOF` delimiter (`<<EOF`), and with an unquoted delimiter **bash expands the heredoc body** — so `$(…)`, backtick, and `${ …; }` funsub in the body *execute* during heredoc expansion, while the gate auto-approves the command (bypassing relay).

Pre-existing defense-in-depth gap surfaced by the cpp#37 (#49) security review and reproduced on GNU bash 5.3.9.

## What

`src/claude_pilot/permissions.py` — drop the bare `EOF` alternative from `_SANCTIONED_HEREDOC_OPENER_RE`: `(?:'EOF'|"EOF"|EOF)` → `(?:'EOF'|"EOF")`. Only a **quoted** delimiter is now admitted. A quoted delimiter makes bash treat the entire body as literal text (no expansion) — verified on bash 5.3.9 for both `'EOF'` and `"EOF"` — so the body is provably inert, the property the "inert /tmp write" exception (cpp#34/#35) always assumed. The closing terminator stays bare `EOF` (bash's closing delimiter is always unquoted regardless of opener quoting).

`tests/test_policy_devpilot.py` — the existing test that *blessed* the unquoted form (`test_guard_allows_heredoc_body_with_substitution_text`, premise "the body is inert data" — false under an unquoted delimiter) is re-pointed into two tests: quoted body with substitution text → **allow** (inert, incl. `<<'EOF'` / `<<"EOF"` / `<<-'EOF'`); unquoted body with `$(…)` / backtick / `${ …; }` funsub → **veto**.

`docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` — §2 extended with the cross-axis lesson (the hard-coded-`EOF` close-point fix and body-expansion are *separate axes*; quoting the delimiter is what makes the body data) + `claude-pilot-47` tag.

### Design: option (a), evidence-resolved (no architect routing needed)

Two design facts settled the call before grooming:
- **Verified on bash 5.3.9:** `<<EOF` expands the body; both `<<'EOF'` and `<<"EOF"` keep it literal. Any delimiter quoting disables expansion; only the bare delimiter expands.
- **No legitimate caller:** searched mika-skills/dispatch-lib + claude-pilot-py src — zero runtime callers of the sanctioned `cat > /tmp/<token>` heredoc, and writing literal `$(…)` content to a file *requires* a quoted delimiter anyway. So the quoted-only restriction breaks no real use.

This *completes* the cpp#34/#35 inert-write intent (mika-arch 783d4a04 no-lexing discipline); the alternative — scanning the body for substitution markers — was rejected as it re-introduces the body lexer §2/§4 says to remove.

## Acceptance criteria (cpp#47)

- [x] AC1 — unquoted-delimiter sanctioned heredoc with `$(…)` / backtick / `$'…'` / `${ …; }` funsub body → vetoes.
- [x] AC2 — quoted-delimiter heredoc with arbitrary literal body → honored (inert).
- [x] AC3 — all existing heredoc tests stay green.
- [x] AC4 — ruff + mypy + pytest green.

## Review

Security peer review (Opus-tier): **SOUND, empty findings.** Independently fuzzed 23 opener forms against the live regex + bash 5.3.9 — **zero "regex-accepts AND bash-expands" rows** (the dangerous quadrant is empty); every accepted form has an inert body, every expanding form is vetoed. Verified: unquoted heredoc vetoes with no fall-through to other allow paths; close-point correct under quoted opener; `<<-'EOF'` dash variant safe; full-line anchoring rejects all smuggling attempts (trailing chain, prefix assignment, path traversal, post-delimiter `$(id)`). Two advisory notes (a pre-existing `.strip()` close-point permissiveness that only ever closes earlier→safe; a `<<-` coverage gap now closed by the added test) — neither blocking.

## Gates

`uv run ruff check` ✓ · `uv run mypy src` ✓ · `uv run pytest` ✓ (471 passed)

Closes #47