### PR TITLE
deps: bump claude-agent-sdk 0.1.59 → 0.2.110 (Stage 1: mechanical bump, cpp#52)

### DIFF
--- a/docs/plans/2026-06-30-052-deps-claude-agent-sdk-0-2-110-stage1-plan.md
+++ b/docs/plans/2026-06-30-052-deps-claude-agent-sdk-0-2-110-stage1-plan.md
@@ -1,0 +1,67 @@
+# Plan: bump claude-agent-sdk 0.1.59 → 0.2.110 (Stage 1 — mechanical)
+
+Issue: cpp#52 · Branch: `deps/52/claude-agent-sdk-0-2-110-stage1`
+
+## WHY
+
+`claude-pilot` is the Python wrapper that runs every autonomous dispatch through the
+`claude-agent-sdk`. It was pinned at `0.1.59` while latest is `0.2.110` — a major `0.1→0.2`
+boundary plus 60+ skipped minors. The unreviewed-surface backlog keeps growing and the bundled
+Claude CLI (which actually runs in headless pilot sessions) ages with it. Vincent flagged the
+v0.2.110 release as priority. A research agent produced a friction analysis (cross-referencing
+51 release bodies v0.1.60→v0.2.110) whose headline is: **the upgrade retires zero existing cpp
+workarounds outright — the SDK is orthogonal to cpp's shell-injection/permission gate** — and a
+short Stage-1 watch list of four items that need verification on the bump.
+
+**Stage 1 is mechanical-only: bump + verify + smoke. No opportunistic API adoption.** Stages 2–3
+(enrich `PilotEvent` with new `ToolPermissionContext` fields, surface `api_error_status`, typed
+`TaskUpdatedMessage`, `SessionStore`, `skills` option) are deferred follow-up tickets.
+
+### Backlog cross-reference (does anything disappear or get fixable-better?)
+
+Evidence-backed: **no open ticket is retired or fixed-better-for-free.**
+- **mika core is out of reach** — it is Rust and imports `claude_agent_sdk` in zero source files.
+- **cpp backlog is orthogonal** — every open cpp issue (#38/#40/#41/#42/#44) is tier1/permissions
+  shell-safety; the SDK has no counterpart (it sits upstream of `can_use_tool`). This is the moat.
+- **New SDK surface maps to no existing ticket** → net-new, correctly scoped Stage 2/3.
+- **One genuine net-new gap** worth a follow-up: cpp has zero Claude-API-error classification today
+  (`permissions.py` retries only relay-transport errors); v0.1.76 `api_error_status` on
+  `ResultMessage` closes that. File as Stage 2.
+
+## WHAT
+
+### Code changes
+1. `pyproject.toml` — `claude-agent-sdk==0.1.59` → `==0.2.110` (only direct dep change).
+2. `uv.lock` — regenerated via `uv sync --all-extras`. Delta: SDK 0.1.59→0.2.110, `sniffio` newly
+   declared as a direct SDK dep, `mcp` unchanged at 1.27.0.
+3. `docs/solutions/tooling-decisions/sdk-system-prompt-must-be-preset-append-not-plain-string.md` —
+   version-cite refreshed to 0.2.110 after confirming the preset→CLI mapping holds.
+
+### Four watch-list verifications (all PASS)
+| # | Item | Result |
+|---|------|--------|
+| 1 | v0.2.82 `TodoWrite`→`Task*` | No consumers in `src/`/`tests/` — nothing to port |
+| 2 | v0.2.82 background MCP (`status:"pending"`) | No test asserts MCP status; full suite green |
+| 3 | `SystemPromptPreset` preset+append (mika#1409, load-bearing) | Mapping unchanged at `subprocess_cli.py:227-238`; preset+append → `--append-system-prompt`. New additive `type:"file"` branch, unused by cpp |
+| 4 | `mcp<2.0.0` pin (v0.2.96) | `mcp` resolves to 1.27.0 — satisfies ≥1.23 (CVE-2025-66416) and <2.0.0 |
+
+### Verification
+- `uv sync --all-extras`: clean.
+- `uv run pytest`: **474 collected, 474 passed**.
+- `uv run ruff check`: clean. `uv run mypy src`: clean (14 files).
+- Smoke (isolated fake-allow relay, throwaway cwd): session boots on 0.2.110; `can_use_tool` fires
+  for Write on both branches — AUTO-approve (in-cwd) → success `ResultJson`, exit 0; policy-deny
+  (out-of-cwd) → `interrupt` → synthetic terminal `error_during_execution` `ResultJson`, exit 1.
+  Both `ResultJson` shapes (success + error) emit correctly. Bash commands auto-resolve via host
+  settings before the callback (documented SDK "fires only on ask" behavior).
+
+### Observation (NOT fixed here — Stage 1 is mechanical)
+`agent.py:_extract_session_id`/`_extract_model` read top-level `message.session_id`/`.model`, but
+`SystemMessage` exposes only `{subtype, data}` (session_id lives in `.data`). The live `[init]` log
+shows empty session_id/model. **Pre-existing** (test fixtures already put session_id in `.data`),
+cosmetic — reconnect detection is `seen_init`-keyed and `ResultJson.session_id` is captured
+correctly downstream. File as a Stage 2 follow-up.
+
+## Out of scope
+Mika core (Rust). Bundling the Claude CLI separately. Any opportunistic adoption of new SDK API
+(all Stage 2/3). No `pydantic`/`anyio`/`httpx` bumps beyond what `uv sync` resolves transitively.

--- a/docs/solutions/tooling-decisions/claude-agent-sdk-major-version-bump-is-mechanical-not-a-rewrite.md
+++ b/docs/solutions/tooling-decisions/claude-agent-sdk-major-version-bump-is-mechanical-not-a-rewrite.md
@@ -1,0 +1,86 @@
+---
+title: "A claude-agent-sdk major-version jump is a mechanical bump, not a rewrite — verify against a watch list"
+date: 2026-06-30
+module: claude_pilot
+component: dependencies
+problem_type: tooling_decision
+category: tooling-decisions
+tags: [claude-agent-sdk, dependency-upgrade, staged-upgrade, watch-list, mika-1409, cpp-52, semver]
+applies_when: "bumping claude-agent-sdk across many minors or a 0.x major boundary in claude-pilot"
+---
+
+# A claude-agent-sdk major-version jump is mechanical — verify, don't rewrite
+
+## Context
+
+cpp#52 jumped `claude-agent-sdk` 0.1.59 → 0.2.110: a `0.1→0.2` boundary plus 60+ skipped minors,
+including a v0.2.82 cluster of *breaking* changes (`TodoWrite`→`Task*`, background MCP connect, mcp
+CVE pin). The instinct on "major version, 60 releases behind, breaking changes" is to brace for a
+refactor. The reality: **one line of `pyproject.toml`, a regenerated lock, a doc cite, zero source
+edits, 474/474 tests green.** The cost of catching up was bounded and almost entirely *verification*,
+not adaptation.
+
+## Guidance
+
+### 1. The SDK surface cpp actually touches is tiny — map it before fearing the changelog
+
+claude-pilot imports exactly **6 symbols across 2 files**: `agent.py`
+(`ClaudeAgentOptions`, `ClaudeSDKClient`, `AssistantMessage`, `ResultMessage`, `SystemMessage`,
+`SystemPromptPreset`) and `permissions.py` (`PermissionResultAllow`, `PermissionResultDeny`,
+`ToolPermissionContext`). 90% of the changelog (new options, tool types, transport internals) is
+surface cpp never imports. Grep the real import set first; size the risk against *that*, not the
+release notes.
+
+### 2. Two structural facts bound what any SDK bump can affect
+
+- **mika core (Rust) does not depend on the python SDK** (`grep -rl claude_agent_sdk mika/` → zero
+  source). An SDK bump can never touch a mika-core ticket. The blast radius is cpp only.
+- **cpp's permission gate (tier1/policy) is orthogonal to the SDK.** It sits *upstream* of
+  `can_use_tool`. No SDK release competes with or retires the shell-injection/compound-safety work
+  (cpp#33/#34/#35/#37/#42/#43/#45/#47). That gate is the moat; the SDK leaves it untouched.
+
+So a backlog scan "does this upgrade moot/improve any open ticket?" answers **no** structurally — the
+only reachable backlog (cpp) is shell-safety, which the SDK doesn't address. New SDK surface is
+always *net-new* value (Stage 2/3 follow-ups), never a free fix to an existing ticket.
+
+### 3. Run a watch list, not a vibe check
+
+For each known-breaking change, write the verification *before* bumping:
+- **`TodoWrite`→`Task*`**: `grep -rn "TodoWrite\|TaskUpdatedMessage\|DeferredToolUse" src/ tests/` →
+  empty means nothing to port.
+- **Load-bearing `SystemPromptPreset`** (see the sibling doc): after `uv sync`, read the *installed*
+  SDK's `_internal/transport/subprocess_cli.py` and confirm the preset+append → `--append-system-prompt`
+  mapping still holds. It did (lines 227-238); a new additive `type:"file"` branch appeared, unused.
+- **mcp pin**: confirm `uv.lock` resolves an `mcp` satisfying the SDK's range (here 1.27.0, in
+  [1.23, 2.0.0)). It's transitive — no direct cpp constraint to fight.
+
+### 4. Smoke against an isolated relay, and know when the callback won't fire
+
+A throwaway `--relay-config` pointing at a fake `{"action":"allow"}` script + a throwaway `--cwd`
+exercises boot → `can_use_tool` → `ResultJson` without touching the live mika-dev relay. Two gotchas:
+- `prompt` is `argparse.REMAINDER` — **all flags must precede the prompt** or they're swallowed.
+- `can_use_tool` fires **only on tools the SDK resolves to "ask"**. Host `~/.claude` settings
+  (loaded via `setting_sources`) auto-allow Bash *before* the callback, so a Bash smoke won't reach
+  the relay. Use a tool set to "ask" (Write outside cwd → deny/interrupt; Write inside cwd → tier1
+  AUTO) to drive the callback. The external-relay round-trip itself is covered by unit tests.
+
+## Latent finding (pre-existing, surfaced by the smoke)
+
+`agent.py:_extract_session_id`/`_extract_model` read top-level `message.session_id`/`.model`, but
+`SystemMessage` is `{subtype, data}` — the id/model live in `.data`. The `[init]` log prints empty
+session_id/model. It's **cosmetic and pre-existing** (the unit fixtures already nest session_id in
+`.data`): reconnect detection is `seen_init`-keyed and `ResultJson.session_id` is captured correctly
+from later messages. Worth a Stage-2 fix (read `.data`), not a Stage-1 blocker.
+
+## Why This Matters
+
+- Treating a version jump as "presumed rewrite" invites scope creep — opportunistic API adoption
+  rides in on a mechanical bump and turns a 1-line PR into a risky one. Keep the bump mechanical;
+  file the adoption as its own ticket.
+- The expensive part of a 60-version catch-up is verification, and verification is cheap if you've
+  mapped the import surface and written the watch list up front. **Track latest within ~a week** so
+  you never face the v0.2.82-style cliff cold.
+
+## Related
+- `sdk-system-prompt-must-be-preset-append-not-plain-string.md` — the load-bearing preset mapping
+- cpp#52 — this upgrade · mika#1409 — the SystemPromptPreset founding incident

--- a/docs/solutions/tooling-decisions/sdk-system-prompt-must-be-preset-append-not-plain-string.md
+++ b/docs/solutions/tooling-decisions/sdk-system-prompt-must-be-preset-append-not-plain-string.md
@@ -46,10 +46,12 @@ options = ClaudeAgentOptions(
 )
 ```
 
-Verified mapping (SDK 0.1.59 `subprocess_cli.py`): `None` → `--system-prompt ""`,
+Verified mapping (re-confirmed unchanged at SDK 0.2.110 `_internal/transport/subprocess_cli.py`
+lines 227-238; originally verified at 0.1.59): `None` → `--system-prompt ""`,
 `str` → `--system-prompt <str>` (**replace**), preset+append → `--append-system-prompt
-<hint>` (**preserve**). Annotate the helper's return type as `SystemPromptPreset`
-so mypy rejects a future regression to a bare string.
+<hint>` (**preserve**). 0.2.110 adds a new `{"type": "file", "path": ...}` →
+`--system-prompt-file` branch — additive, unused by claude-pilot. Annotate the helper's
+return type as `SystemPromptPreset` so mypy rejects a future regression to a bare string.
 
 ### 2. "Co-location prevents drift" is false unless a test backs it
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Senara Solutions" }]
 dependencies = [
-  "claude-agent-sdk==0.1.59",
+  "claude-agent-sdk==0.2.110",
   "pydantic>=2.6,<3",
   "pyyaml>=6.0,<7",
   "python-dotenv>=1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -114,19 +114,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.59"
+version = "0.2.110"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/55/438f5ba33f90cc9cbf3b40f74fbedf6792332e8fe34838f4189e418a4090/claude_agent_sdk-0.1.59.tar.gz", hash = "sha256:061af12a783a3456abfd0def3602a01249b2eee1be783fb3e242392c0ebbd2e2", size = 122887, upload-time = "2026-04-13T22:07:09.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/98/8fdab35ed9e1a36bc7afab4d390cc5002094a4950996c079da9aa4541cc4/claude_agent_sdk-0.2.110.tar.gz", hash = "sha256:538b548bac07a22f65686abab063a902ac76ba35989d0f073c942f96248e9fa3", size = 255632, upload-time = "2026-06-24T22:11:52.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/6d/1fdfbcce76d7b81e89b29ad11864a48779a880f828c2541df620686693dd/claude_agent_sdk-0.1.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b8734b5d630b75ad63b29a802fff40ba087adf463c1004dae65f7a5a912ab13a", size = 59629367, upload-time = "2026-04-13T22:07:14.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c6/aa9c5b310851b74db82e0da73a836335af4ef6767982d93ac04df52ef0cb/claude_agent_sdk-0.1.59-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:b333c0685db3f6e035acd2c6efa6ae4c4d8b077fef99de829ddb2a37ca1d9183", size = 61444059, upload-time = "2026-04-13T22:07:20.677Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/47/4ba5eb8846fcb9ba544d777ff752ff20c10a508931199f9def3e724dcc8b/claude_agent_sdk-0.1.59-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8ebe1f7e6dc18c5fae6483977ff16fcabe91cbb955f9c423c05a11f013db3957", size = 72938796, upload-time = "2026-04-13T22:07:27.147Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/df/366d8ffb3399426769a08b68bdb4bf4ccb0c8e742418a27c3d369cfab07a/claude_agent_sdk-0.1.59-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:cac6c42f3c554981597a3d023bc87fe5b4bc14da987d9ef30cc2596005c3bc12", size = 73057901, upload-time = "2026-04-13T22:07:35.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/5a/f7506588831eb664c45241745d2cd21bd095b0f432ef2fa1062b824c538a/claude_agent_sdk-0.1.59-py3-none-win_amd64.whl", hash = "sha256:92d8da9ea5f0b4a7492d074d612d54b5e6ce6800312992aa48b2bcaa6bf7bf5e", size = 75161150, upload-time = "2026-04-13T22:07:43.695Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/93/29d4fdaa13e69034faf8d3503df915b07c820e2c08e3d6a7515149cde5bb/claude_agent_sdk-0.2.110-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fed0e0f4804d9f9cff80ab7d1b44142ebd1046cdd29ca74caef4c92c35fff8d8", size = 64924533, upload-time = "2026-06-24T22:11:55.612Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/03/b40bb673cd93cdc3928262c1be75fde34a7bed4bf2c2c20e04218e2005ea/claude_agent_sdk-0.2.110-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:62b23869d46cef6f6ff1d00ceaa5e846e2f1d297478421c835efb8fe99369d4f", size = 69704449, upload-time = "2026-06-24T22:11:59.149Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/18/ab67cb5ce641333385bed55ed8e9665c00f7d30d1f6ab12f8463ddb7695f/claude_agent_sdk-0.2.110-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:324e49553c6303d6b267217dc2912652b97af2bc96503efd12095ae915b46b83", size = 74879555, upload-time = "2026-06-24T22:12:03.25Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/3627d7d14310cfec66977551263e219365244a906fc7ca1209fb0c3a6cec/claude_agent_sdk-0.2.110-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:56371dd7a2c66c0bd497dc0b3cab4193a228b196f600676393d69c0ecee37cfb", size = 75924237, upload-time = "2026-06-24T22:12:07.183Z" },
+    { url = "https://files.pythonhosted.org/packages/49/79/c9066c5c387d42c19a4b675ec1ff5219f8920cfda8ff8b527119fd69b774/claude_agent_sdk-0.2.110-py3-none-win_amd64.whl", hash = "sha256:4235d4de6d685a189c12612095ab192b759280ede1f3aed0c3e784d52c3555f9", size = 75448209, upload-time = "2026-06-24T22:12:11.283Z" },
 ]
 
 [[package]]
@@ -151,7 +152,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "claude-agent-sdk", specifier = "==0.1.59" },
+    { name = "claude-agent-sdk", specifier = "==0.2.110" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pydantic", specifier = ">=2.6,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
@@ -947,6 +948,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`claude-pilot` was pinned at `claude-agent-sdk==0.1.59`; latest is `0.2.110` — a major `0.1→0.2`
boundary plus 60+ skipped minors (including the v0.2.82 breaking cluster: `TodoWrite`→`Task*`,
background MCP connect, `mcp` CVE pin). The SDK is the single most load-bearing dependency of the
autonomous loop. Vincent flagged v0.2.110 priority.

**Stage 1 = mechanical bump + verify + smoke. No opportunistic API adoption.** Stages 2–3 are
deferred follow-up tickets (see below). Source of truth: cpp#52 + a friction analysis that
cross-referenced all 51 release bodies and produced the 4-item watch list verified here.

## What changed

- `pyproject.toml`: `claude-agent-sdk ==0.1.59 → ==0.2.110` (the only direct dep change)
- `uv.lock`: regenerated via `uv sync --all-extras` — `sniffio` newly declared as a direct SDK dep;
  **`mcp` unchanged at 1.27.0**; the starlette/uvicorn/etc. lines are unchanged `mcp` transitives
- `docs/solutions/.../sdk-system-prompt-must-be-preset-append-not-plain-string.md`: version-cite
  refreshed to 0.2.110 after re-confirming the mapping (mika#1409 load-bearing)
- `docs/solutions/.../claude-agent-sdk-major-version-bump-is-mechanical-not-a-rewrite.md`: new
  compound learning
- `docs/plans/2026-06-30-052-...-plan.md`: the plan

## Verification

| Gate | Result |
|------|--------|
| `uv sync --all-extras` | clean |
| `uv run pytest` | **474 collected, 474 passed** |
| `uv run ruff check` | clean |
| `uv run mypy src` | clean (14 files) |

### Four watch-list verifications (all PASS)

1. **v0.2.82 `TodoWrite`→`Task*`** — `grep` for `TodoWrite`/`TaskUpdatedMessage`/`DeferredToolUse`
   in `src/`+`tests/` is empty; no consumer exists, nothing to port.
2. **v0.2.82 background MCP (`status:"pending"`)** — no test asserts on MCP server status; the
   `SystemMessage(subtype="init")` assertions still pass; full suite green.
3. **`SystemPromptPreset` preset+append (mika#1409, load-bearing)** — mapping unchanged in
   `_internal/transport/subprocess_cli.py:227-238`: `{"type":"preset","preset":"claude_code","append":…}`
   → `--append-system-prompt <hint>` (preset preserved, not replaced). A new additive
   `type:"file"` → `--system-prompt-file` branch appeared; unused by cpp. Doc cite refreshed.
4. **`mcp<2.0.0` pin (v0.2.96)** — `mcp` resolves to 1.27.0, satisfying ≥1.23 (CVE-2025-66416) and
   <2.0.0. Transitive only; no direct cpp constraint.

### Smoke test (isolated fake-allow relay + throwaway cwd — does not touch live mika-dev relay)

- Boots on 0.2.110. `can_use_tool` exercised on **both** branches:
  - Write inside cwd → tier1 **AUTO** → success `ResultJson` (`{"status":"success",...,"turns":2}`), exit 0
  - Write outside cwd → `policy:deny` → `interrupt=True` → synthetic terminal
    `error_during_execution` `ResultJson` with structured `ede_diagnostic`, exit 1
- Both `ResultJson` shapes (success + error) emit correctly; real `session_id` in each.
- Bash commands auto-resolve via host `~/.claude` settings *before* the callback (documented SDK
  "`can_use_tool` fires only on ask" behavior) — the external-relay round-trip is covered by the
  unit suite, not the smoke.

## Backlog cross-reference (Vincent's directive: does anything disappear / get fixable-better?)

**No.** mika core is Rust and imports `claude_agent_sdk` in zero source files — structurally out of
reach. The cpp backlog (#38/#40/#41/#42/#44) is all tier1/permissions shell-safety, orthogonal to
the SDK (the gate sits upstream of `can_use_tool`; it's the moat). New SDK surface maps to no
existing ticket — it's net-new value, correctly scoped Stage 2/3. This validates the Stage-1-only
rule: no backlog pressure forces adoption into this PR.

## Follow-ups (filed separately, NOT in this PR)

- **Stage 2 (highest value):** surface v0.1.76 `ResultMessage.api_error_status` into `ResultJson`
  for deterministic 429/500/529 classification — cpp has **zero** Claude-API-error classification
  today (`permissions.py` retries only relay-transport errors). Loop-reliability gap.
- Stage 2 (lower): `PilotEvent` enrichment with v0.1.74 `ToolPermissionContext` fields; typed
  `TaskUpdatedMessage`. Pre-existing latent: `agent.py:_extract_session_id`/`_extract_model` read a
  top-level attr but `SystemMessage` nests it in `.data` (cosmetic `[init]` log; fix to read `.data`).
- Stage 3: one-week SLO on SDK bumps to avoid re-accumulating a 60-version cliff.

Closes #52