### PR TITLE
fix(agent): SDK 0.2.x composite — .data extraction + api_error_status + ToolPermissionContext enrichment (cpp#55, #54, #56)

### DIFF
--- a/docs/plans/2026-06-30-005-fix-agent-composite-55-54-56-sdk-stage2-plan.md
+++ b/docs/plans/2026-06-30-005-fix-agent-composite-55-54-56-sdk-stage2-plan.md
@@ -1,0 +1,169 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "fix(agent): SDK 0.2.x composite — session/model extraction + api_error_status + ToolPermissionContext enrichment"
+date: 2026-06-30
+type: fix
+issues: [cpp#55, cpp#54, cpp#56]
+branch: fix/agent-composite-55-54-56-sdk-stage2
+---
+
+# fix(agent): SDK 0.2.x composite — cpp#55 + cpp#54 + cpp#56
+
+## Summary
+
+Three evidence-gated, backward-compatible changes to `claude-pilot-py`, all surfaced by the `claude-agent-sdk` 0.1.59 → 0.2.110 bump (cpp#52 / PR #53). They are bundled into one PR because all three touch the `agent.py` / `types.py` / `permissions.py` cluster on the same SDK lineage:
+
+- **cpp#55 (bug, regression):** `SystemMessage` nests `session_id`/`model` inside `.data` in SDK 0.2.x; the extractors read top-level attrs and log empty `[init]` ids.
+- **cpp#54 (enhancement):** SDK now exposes `ResultMessage.api_error_status` (HTTP 429/500/529); surface it into `ResultJson` for deterministic overload classification downstream.
+- **cpp#56 (enhancement):** SDK enriched `ToolPermissionContext` with `title`/`display_name`/`description` (alongside existing `decision_reason`/`blocked_path`); capture them into `PilotEvent` for richer relay telemetry.
+
+All additions are `Optional`, default `None`, and serialize as absent via `exclude_none` — no downstream parser breaks on a missing field.
+
+## Problem Frame
+
+cpp#52 (PR #53) was a **mechanical** SDK bump — version numbers only, no API adoption. It both (a) introduced a latent regression in two extractor helpers that had silently read the wrong location even before the bump, and (b) left net-new SDK capabilities unadopted. The friction analysis at the time named the Stage-2 work explicitly. This plan closes the regression and adopts the two highest-value additive capabilities, with the typed-`TaskUpdatedMessage` part of cpp#56 deliberately deferred (no consumer exists).
+
+**Why now:** cpp#55 is a real (cosmetic-severity) regression confirmed by live smoke logs (`[init] Session , model unknown`). cpp#54 closes a loop-reliability observability gap — the pilot today cannot deterministically distinguish a transient API overload (429/500/529) from a genuine failure. cpp#56 is cheap additive enrichment riding the same file cluster.
+
+## Requirements
+
+- **R1 (cpp#55):** `_extract_session_id` / `_extract_model` MUST return the real id/model from `SystemMessage.data` under SDK 0.2.x, while preserving the legacy top-level-attr path for back-compat with any mock or future SDK that reverts the nesting.
+- **R2 (cpp#54):** `ResultJson` MUST carry an `api_error_status` field populated from `ResultMessage.api_error_status` when present, absent when null/missing.
+- **R3 (cpp#56):** `PilotEvent` MUST carry `title`, `display_name`, `description` (new) plus the already-declared `decision_reason`, `blocked_path`, all populated from `ToolPermissionContext` when the SDK supplies them, `None` otherwise.
+- **R4 (cross-cutting):** Every new field is `Optional`, defaults `None`, uses the SDK's verbatim field name, and serializes absent when `None`. No scope widening beyond these three changes.
+
+## Key Technical Decisions
+
+- **KTD1 — guarded `.data` access for cpp#55.** Read `message.data.get(...)` first, then fall back to the existing top-level `getattr(...)`. `SystemMessage` in SDK 0.2.110 has fields exactly `(subtype, data)` (verified via `dataclasses.fields`), but a guarded pattern (`data = getattr(message, "data", None)`) survives a future SDK that reverts the shape and keeps the existing test mocks valid. Both paths funnel through the existing `isinstance(..., str)` type-narrowing so a non-string `data` value can't leak through.
+- **KTD2 — `getattr` for SDK reads on cpp#54/#56.** Use `getattr(message, "api_error_status", None)` and `getattr(ctx, "<field>", None)` rather than direct attribute access, so cpp keeps running against an SDK minor that hasn't yet added (or has removed) the field. This mirrors the existing defensive `getattr` style already used in `agent.py` (`getattr(message, "session_id", None)`, `getattr(message, "errors", None)`).
+- **KTD3 — verbatim SDK field names.** `api_error_status`, `title`, `display_name`, `description` match the SDK exactly. No renaming — diverging adds drift cost on every future bump (spawn-brief hard rule).
+- **KTD4 — defer typed `TaskUpdatedMessage`.** `guardrails.py` has zero `Task*` consumers today; the cpp#56 ticket marks this "only adopt if a concrete need arises." Out of scope here.
+- **KTD5 — enrich PilotEvent at its single construction site.** `permissions.py` builds `PilotEvent` in exactly one place (the relay block, reachable only under `MIKA_PILOT_POLICY_DISABLED=1`). The enrichment is purely additive there; no behavioral change to the live policy path.
+
+---
+
+## Implementation Units
+
+### U1. cpp#55 — fix `_extract_session_id` / `_extract_model` to read `SystemMessage.data`
+
+**Goal:** Return the real session id and model under SDK 0.2.x nesting, with top-level fallback.
+
+**Requirements:** R1, R4.
+
+**Dependencies:** none.
+
+**Files:**
+- `src/claude_pilot/agent.py` — rewrite `_extract_session_id` (currently lines 366-369) and `_extract_model` (370-373).
+- `tests/test_agent.py` — add focused unit tests for both helpers.
+
+**Approach:** In each helper, first attempt `data = getattr(message, "data", None)`; if it is a dict, read the relevant key (`session_id` / `model`). If that yields a string, return it. Otherwise fall back to the existing top-level `getattr(message, "<attr>", None)` path. Keep the final `isinstance(..., str)` narrowing so non-string values return `None`. The existing `_init()` fixture (`SystemMessage(subtype="init", data={"session_id": "sess_test", "model": "claude-test"})`) means several existing agent tests will now log non-empty ids — verify they still pass.
+
+**Patterns to follow:** the existing defensive `getattr(... , None)` + `isinstance(..., str)` style already in these two helpers.
+
+**Test scenarios:**
+- `_extract_session_id(SystemMessage(subtype="init", data={"session_id": "abc-123"}))` returns `"abc-123"` (nested-data path).
+- `_extract_model(SystemMessage(subtype="init", data={"model": "claude-x"}))` returns `"claude-x"`.
+- Back-compat fallback: a stub object exposing a top-level `.session_id`/`.model` str attr and no usable `.data` returns the top-level value. (Construct a lightweight stand-in so the test pins the fallback branch even though the real 0.2.110 `SystemMessage` won't populate top-level.)
+- Missing both: `SystemMessage(subtype="init", data={})` returns `None` for each helper (no crash).
+- Non-string nested value: `data={"session_id": 42}` returns `None` (type narrowing holds).
+
+**Verification:** the two helpers return the nested value; full `tests/test_agent.py` passes including the pre-existing init/reconnect tests that consume `_init()`.
+
+### U2. cpp#54 — surface `ResultMessage.api_error_status` into `ResultJson`
+
+**Goal:** Give downstream consumers (mika-dev dispatch-lib) a deterministic 429/500/529 signal.
+
+**Requirements:** R2, R4.
+
+**Dependencies:** none (independent of U1).
+
+**Files:**
+- `src/claude_pilot/types.py` — add `api_error_status: int | None = None` to `ResultJson` (after `errors` / `termination_reason`); extend the model docstring noting the field's meaning.
+- `src/claude_pilot/agent.py` — in the `ResultMessage` branch (the `result = ResultJson(...)` construction around lines 192-202), pass `api_error_status=getattr(message, "api_error_status", None)`.
+- `tests/test_agent.py` — add coverage; `tests/test_types.py` may host the serialization-absence assertion if that's the better home (implementer's call — follow existing test layout).
+
+**Approach:** `ResultMessage.api_error_status` is typed `int | None` in SDK 0.2.110 (verified). Thread it into the single `ResultJson(...)` build on the ResultMessage path. The synthetic/guardrail `ResultJson` emissions (stream-ended, guardrail-trip) leave it at its `None` default — those paths never have a ResultMessage to read from. `to_line()` already uses `model_dump_json(exclude_none=True)`, so a `None` value is omitted from the JSON line automatically (back-compat).
+
+**Patterns to follow:** the sibling `errors=` / `cost_usd=` extractions in the same `ResultJson(...)` constructor; the existing `cost_usd: float | None = None` Optional-field pattern in `types.py`.
+
+**Test scenarios:**
+- Present path: feed a fake `ResultMessage` with `api_error_status=429` through `run_agent` (via the existing `_install_fake_client` harness); the emitted stdout `ResultJson` line parses with `api_error_status == 429`.
+- Absent path: the existing `_result()` fixture (no `api_error_status`) → emitted JSON line has NO `api_error_status` key (exclude_none).
+- Model-level: `ResultJson(... , api_error_status=None).to_line()` does not contain `"api_error_status"`; `ResultJson(..., api_error_status=529).to_line()` does.
+
+**Verification:** a 429-bearing ResultMessage round-trips to `ResultJson.api_error_status == 429`; null/absent omits the field from the line.
+
+### U3. cpp#56 — enrich `PilotEvent` with `ToolPermissionContext` fields
+
+**Goal:** Capture the SDK's richer permission-context fields into the relay event payload.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** none (independent of U1/U2).
+
+**Files:**
+- `src/claude_pilot/types.py` — add `title: str | None = None`, `display_name: str | None = None`, `description: str | None = None` to `PilotEvent` (it already declares `decision_reason` and `blocked_path`).
+- `src/claude_pilot/permissions.py` — at the single `PilotEvent(...)` construction (lines 395-401), populate `decision_reason`, `blocked_path`, `title`, `display_name`, `description` via `getattr(ctx, "<field>", None)`.
+- `tests/test_permissions.py` — add coverage; extend `_mock_ctx()` usage to supply the enriched fields.
+
+**Approach:** `ToolPermissionContext` in SDK 0.2.110 carries `tool_use_id, agent_id, blocked_path, decision_reason, title, display_name, description` (all `str | None`, verified). Add the three new fields to `PilotEvent` and populate all five enriched fields at construction with `getattr(ctx, ..., None)` for resilience against an SDK minor lacking a field. `model_config = ConfigDict(extra="forbid")` on `PilotEvent` means the three new fields MUST be declared before they can be passed — declaration and population land together in this unit. Note: the relay construction site is only reached under `MIKA_PILOT_POLICY_DISABLED=1`; the enrichment is additive and changes no live policy-path behavior.
+
+**Patterns to follow:** the existing `agent_id=ctx.agent_id` / `tool_use_id=ctx.tool_use_id or ""` assignments at the same construction; the existing `decision_reason`/`blocked_path` Optional declarations in `PilotEvent`.
+
+**Test scenarios:**
+- Present path: build a `ToolPermissionContext` with `decision_reason`, `blocked_path`, `title`, `display_name`, `description` set; drive the relay path (handler with `relay=True`, `MIKA_PILOT_POLICY_DISABLED=1`, and a mocked `invoke_command` that captures the `PilotEvent`); assert all five fields are carried on the event.
+- Absent path: a `ToolPermissionContext` without the new fields (e.g. the current `_mock_ctx()` shape) yields `PilotEvent` with those fields `None` and no crash — confirms the `getattr` defaults and `extra="forbid"` declaration coexist.
+- Model-level (lighter alternative if driving the relay path is heavy): construct `PilotEvent(...)` directly with and without the new fields and assert the schema accepts them and `exclude_none` omits the `None` ones — pick the level that gives clean coverage without over-mocking the relay machinery.
+
+**Verification:** an enriched `ToolPermissionContext` produces a `PilotEvent` carrying the five fields; an unenriched one produces `None`s without error.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the three field/extractor changes above and their tests.
+
+### Deferred to Follow-Up Work
+- Typed `TaskUpdatedMessage` adoption (cpp#56 part 2) — no `Task*` consumer exists in `guardrails.py` today.
+- Retry/backoff policy keyed on the new `api_error_status` signal — cpp#54 explicitly scopes this to a separate behavioral ticket once the signal exists.
+- `SessionStore` adapter integration and `skills` option migration — cpp#52 Stage 3, separately tracked.
+- Filing an upstream SDK issue about the `SystemMessage` shape change — optional, not required (spawn-brief out-of-scope note).
+
+**Out of scope (do not touch):** `tier1.py` / policy logic (cpp#38/#42 territory). No refactors of unrelated code in the touched files.
+
+---
+
+## System-Wide Impact
+
+- **mika-dev dispatch-lib** parses the stdout `ResultJson` line. The new `api_error_status` is additive and absent-when-null; existing parsing is unaffected. No dispatch-lib change is required by this PR (consuming the new signal is a separate ticket).
+- **mika-dev relay** consumes `PilotEvent`. New fields are additive optional; the relay need not consume them. The relay construction path is dormant in production (policy-enabled by default), so this is telemetry-readiness, not a live behavior change.
+- **No cross-repo companion PR** is required — all changes are internal to claude-pilot-py and backward-compatible at every external contract.
+
+---
+
+## Risks & Dependencies
+
+- **Low risk overall** — all additive/optional, guarded reads, no live-path behavior change.
+- **Pre-existing test interaction (U1):** the `_init()` fixture already nests ids in `data=`, so any existing assertion that depended on the *empty* logged id (unlikely, but check) would flip. Mitigation: run the full `test_agent.py` suite and read any failure.
+- **`extra="forbid"` ordering (U3):** the new `PilotEvent` fields must be declared in `types.py` before they're passed in `permissions.py`, or Pydantic rejects them. Mitigation: both land in U3 together.
+
+---
+
+## Verification Contract
+
+- `uv run ruff check` clean.
+- `uv run mypy src` clean (new fields are properly typed `int | None` / `str | None`).
+- `uv run pytest` — all tests pass; test count maintained or grown (baseline ~516 post-PR #57).
+- Each unit's enumerated test scenarios are implemented (present-field AND absent-field paths for U2 and U3 per the spawn-brief hard rule).
+- **cpp#55 regression closure (deterministic):** the new U1 unit tests assert non-empty extraction from nested `data`. The full live smoke (relay-mode `/mika` dispatch confirming `[init]` logs a non-empty session_id/model) is operator-host-time; the unit test is the in-pipeline regression confirmation, with the live smoke surfaced to the operator as a runtime check.
+
+## Definition of Done
+
+- All three units implemented with passing tests covering present + absent paths.
+- `ResultJson` and `PilotEvent` schema changes are additive/optional and serialize absent when `None`.
+- Quality gates (ruff, mypy, pytest) green.
+- PR opened on `senara-solutions/claude-pilot-py` from `fix/agent-composite-55-54-56-sdk-stage2`, body closing cpp#55, cpp#54, cpp#56, citing each part.
+- Operator surface: PR URL, test count, cpp#55 regression note, any new substrate tickets.

--- a/docs/solutions/tooling-decisions/claude-agent-sdk-major-version-bump-is-mechanical-not-a-rewrite.md
+++ b/docs/solutions/tooling-decisions/claude-agent-sdk-major-version-bump-is-mechanical-not-a-rewrite.md
@@ -1,11 +1,12 @@
 ---
 title: "A claude-agent-sdk major-version jump is a mechanical bump, not a rewrite — verify against a watch list"
 date: 2026-06-30
+last_updated: 2026-06-30
 module: claude_pilot
 component: dependencies
 problem_type: tooling_decision
 category: tooling-decisions
-tags: [claude-agent-sdk, dependency-upgrade, staged-upgrade, watch-list, mika-1409, cpp-52, semver]
+tags: [claude-agent-sdk, dependency-upgrade, staged-upgrade, watch-list, mika-1409, cpp-52, cpp-54, cpp-55, cpp-56, semver]
 applies_when: "bumping claude-agent-sdk across many minors or a 0.x major boundary in claude-pilot"
 ---
 
@@ -64,13 +65,46 @@ exercises boot → `can_use_tool` → `ResultJson` without touching the live mik
   the relay. Use a tool set to "ask" (Write outside cwd → deny/interrupt; Write inside cwd → tier1
   AUTO) to drive the callback. The external-relay round-trip itself is covered by unit tests.
 
-## Latent finding (pre-existing, surfaced by the smoke)
+## Latent finding (pre-existing, surfaced by the smoke) — RESOLVED cpp#55
 
 `agent.py:_extract_session_id`/`_extract_model` read top-level `message.session_id`/`.model`, but
 `SystemMessage` is `{subtype, data}` — the id/model live in `.data`. The `[init]` log prints empty
 session_id/model. It's **cosmetic and pre-existing** (the unit fixtures already nest session_id in
 `.data`): reconnect detection is `seen_init`-keyed and `ResultJson.session_id` is captured correctly
 from later messages. Worth a Stage-2 fix (read `.data`), not a Stage-1 blocker.
+
+**Fixed in cpp#55** (PR for branch `fix/agent-composite-55-54-56-sdk-stage2`): both helpers now
+read `message.data.get("session_id")`/`.get("model")` first, falling back to the top-level `getattr`
+so a mock or a future SDK that un-nests still resolves. The prediction held exactly — a `.data` read,
+no other change.
+
+## Stage 2 adoption pattern — predicted small/additive work lands small/additive (cpp#54, cpp#56)
+
+The same PR adopted the two net-new SDK surfaces the friction analysis deferred out of the mechanical
+bump. Both confirm the general shape: **a mechanical SDK bump's predicted Stage-2 work is small,
+additive, and `getattr`-guarded — never a refactor.**
+
+- **cpp#54** — `ResultMessage.api_error_status` (SDK 0.2.x, `int | None`) surfaced into `ResultJson`.
+  One new `Optional` field defaulting `None`, read via `getattr(message, "api_error_status", None)`,
+  plumbed at the single `ResultMessage` construction site. Gives mika-dev dispatch-lib a deterministic
+  429/500/529 signal vs. parsing prose `errors`.
+- **cpp#56** — `ToolPermissionContext` enrichment (`decision_reason`, `blocked_path`, `title`,
+  `display_name`, `description`) captured onto `PilotEvent`. Three new `Optional` fields, populated via
+  `getattr(ctx, ..., None)` at the lone relay construction site.
+
+Two reusable rules for adopting moved or net-new SDK surface on a wire-format schema:
+
+1. **Moved field → nested-first + top-level fallback** (cpp#55). When a field relocates (here into a
+   `.data` dict), read the new location first and fall back to the old `getattr`. The dual path costs
+   two lines and survives both directions of a future shape change.
+2. **Net-new field → `Optional` default `None` + `exclude_none`** (cpp#54/#56). `ResultJson` and
+   `PilotEvent` serialize with `model_dump_json(exclude_none=True)`, so an additive nullable field is
+   absent on the wire when unset — downstream parsers (dispatch-lib, mika-dev relay) never break on a
+   missing key. Use the SDK's verbatim field names so the next bump has zero rename drift.
+
+Both adoptions were independently confirmed against the installed 0.2.110 (`api_error_status` typed
+`int | None`; all five `ToolPermissionContext` fields present) before relying on them — the same
+"verify against the installed SDK, don't trust the changelog" discipline as the bump itself.
 
 ## Why This Matters
 
@@ -83,4 +117,5 @@ from later messages. Worth a Stage-2 fix (read `.data`), not a Stage-1 blocker.
 
 ## Related
 - `sdk-system-prompt-must-be-preset-append-not-plain-string.md` — the load-bearing preset mapping
-- cpp#52 — this upgrade · mika#1409 — the SystemPromptPreset founding incident
+- cpp#52 — this upgrade (Stage 1, mechanical bump) · mika#1409 — the SystemPromptPreset founding incident
+- cpp#55 — the predicted `.data` extraction fix · cpp#54 / cpp#56 — the Stage-2 additive adoptions (one PR)

--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -199,6 +199,10 @@ async def run_agent(
                         duration_ms=message.duration_ms,
                         errors=errors,
                         termination_reason=termination_reason,
+                        # cpp#54: deterministic 429/500/529 signal for
+                        # downstream classification. getattr-guarded so an SDK
+                        # minor lacking the field degrades to None, not a crash.
+                        api_error_status=getattr(message, "api_error_status", None),
                     )
                     _emit_result(result)
                     emitted_terminal = True  # cpp#20 joint 2 mutual-exclusion guard (Site 2)
@@ -364,11 +368,26 @@ def _text_of(block: Any) -> str | None:
 
 
 def _extract_session_id(message: SystemMessage) -> str | None:
+    # SDK 0.2.x nests session_id under SystemMessage.data (cpp#55). Read the
+    # nested location first, then fall back to a top-level attr so mocks and a
+    # future SDK that reverts the nesting both keep working.
+    data = getattr(message, "data", None)
+    if isinstance(data, dict):
+        sid = data.get("session_id")
+        if isinstance(sid, str):
+            return sid
     sid = getattr(message, "session_id", None)
     return sid if isinstance(sid, str) else None
 
 
 def _extract_model(message: SystemMessage) -> str | None:
+    # SDK 0.2.x nests model under SystemMessage.data (cpp#55); see
+    # _extract_session_id for the guarded-access rationale.
+    data = getattr(message, "data", None)
+    if isinstance(data, dict):
+        model = data.get("model")
+        if isinstance(model, str):
+            return model
     model = getattr(message, "model", None)
     return model if isinstance(model, str) else None
 

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -398,6 +398,13 @@ def create_permission_handler(
             tool_input=tool_input,
             tool_use_id=ctx.tool_use_id or "",
             agent_id=ctx.agent_id,
+            # cpp#56: additive ToolPermissionContext enrichment. getattr-guarded
+            # so an SDK minor lacking a field yields None instead of crashing.
+            decision_reason=getattr(ctx, "decision_reason", None),
+            blocked_path=getattr(ctx, "blocked_path", None),
+            title=getattr(ctx, "title", None),
+            display_name=getattr(ctx, "display_name", None),
+            description=getattr(ctx, "description", None),
         )
 
         log_relay_send(tool_name)

--- a/src/claude_pilot/types.py
+++ b/src/claude_pilot/types.py
@@ -72,6 +72,12 @@ class PilotEvent(BaseModel):
     agent_id: str | None = None
     decision_reason: str | None = None
     blocked_path: str | None = None
+    # cpp#56: additive ToolPermissionContext enrichment (SDK 0.2.x; these fields
+    # landed upstream in v0.1.74). Optional so older relay payloads and SDK
+    # minors lacking these fields stay valid; serialized absent via exclude_none.
+    title: str | None = None
+    display_name: str | None = None
+    description: str | None = None
     error: str | None = None
 
 
@@ -127,6 +133,12 @@ class ResultJson(BaseModel):
     duration_ms: int
     errors: list[str] | None = None
     termination_reason: str | None = None
+    # cpp#54: HTTP status of a Claude-API error (429/500/529) surfaced by SDK
+    # 0.2.x `ResultMessage.api_error_status`, letting downstream (mika-dev
+    # dispatch-lib) classify a transient overload deterministically vs. a
+    # genuine failure. None when the session ended without an API error or the
+    # SDK did not populate it; serialized absent via exclude_none.
+    api_error_status: int | None = None
 
     def to_line(self) -> str:
         """Serialize to a single JSON line (no trailing newline)."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -474,3 +474,110 @@ async def test_1409_run_agent_passes_system_prompt_into_options(
     assert isinstance(sp, dict)
     assert sp["type"] == "preset" and sp["preset"] == "claude_code"
     assert "-exec" in sp["append"] and "Grep" in sp["append"]
+
+
+# ── cpp#55: _extract_session_id / _extract_model read SystemMessage.data ──────
+
+
+def test_extract_session_id_reads_nested_data() -> None:
+    """SDK 0.2.x nests session_id under .data — the extractor must read it."""
+    msg = SystemMessage(subtype="init", data={"session_id": "abc-123"})
+    assert agent_module._extract_session_id(msg) == "abc-123"
+
+
+def test_extract_model_reads_nested_data() -> None:
+    msg = SystemMessage(subtype="init", data={"model": "claude-x"})
+    assert agent_module._extract_model(msg) == "claude-x"
+
+
+def test_extract_falls_back_to_top_level_attr() -> None:
+    """Back-compat: an object exposing top-level session_id/model attrs and no
+    usable .data still resolves (guards a future SDK that reverts the nesting,
+    and any mock built on the pre-0.2 shape)."""
+    from types import SimpleNamespace
+
+    stub = SimpleNamespace(session_id="top-sess", model="top-model")
+    assert agent_module._extract_session_id(stub) == "top-sess"  # type: ignore[arg-type]
+    assert agent_module._extract_model(stub) == "top-model"  # type: ignore[arg-type]
+
+
+def test_extract_missing_both_returns_none() -> None:
+    msg = SystemMessage(subtype="init", data={})
+    assert agent_module._extract_session_id(msg) is None
+    assert agent_module._extract_model(msg) is None
+
+
+def test_extract_non_string_nested_value_returns_none() -> None:
+    """Type narrowing holds: a non-string nested value yields None, not the int."""
+    msg = SystemMessage(subtype="init", data={"session_id": 42, "model": 7})
+    assert agent_module._extract_session_id(msg) is None
+    assert agent_module._extract_model(msg) is None
+
+
+# ── cpp#54: ResultMessage.api_error_status flows into ResultJson ──────────────
+
+
+def _result_with_api_error(status: int) -> ResultMessage:
+    return ResultMessage(
+        subtype="error",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=True,
+        num_turns=1,
+        session_id="sess_test",
+        total_cost_usd=0.0,
+        api_error_status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_error_status_flows_to_result_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cpp#54: a ResultMessage carrying api_error_status=429 must surface that
+    value on the emitted ResultJson line for deterministic downstream
+    classification."""
+    import json
+
+    _install_fake_client(monkeypatch, [_init(), _result_with_api_error(429)])
+
+    await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id="task_api_err",
+        permission_handler=_noop_permission,
+        guardrails=SessionGuardrails(_config()),
+    )
+
+    captured = capsys.readouterr()
+    json_lines = [line for line in captured.out.splitlines() if line.startswith("{")]
+    payload = json.loads(json_lines[0])
+    assert payload["api_error_status"] == 429, payload
+
+
+@pytest.mark.asyncio
+async def test_api_error_status_absent_omits_field(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Absent path: the default _result() fixture has no api_error_status, so
+    the field is omitted from the JSON line (exclude_none back-compat)."""
+    import json
+
+    _install_fake_client(monkeypatch, [_init(), _result()])
+
+    await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id="task_no_api_err",
+        permission_handler=_noop_permission,
+        guardrails=SessionGuardrails(_config()),
+    )
+
+    captured = capsys.readouterr()
+    json_lines = [line for line in captured.out.splitlines() if line.startswith("{")]
+    payload = json.loads(json_lines[0])
+    assert "api_error_status" not in payload, payload

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -12,11 +12,18 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
 from claude_agent_sdk import PermissionResultDeny
 from claude_agent_sdk.types import ToolPermissionContext
 
+from claude_pilot import permissions as permissions_module
 from claude_pilot.permissions import create_permission_handler, try_tier_1_5_auto_answer
-from claude_pilot.types import PilotResponseAnswer
+from claude_pilot.types import (
+    PilotConfig,
+    PilotEvent,
+    PilotResponseAllow,
+    PilotResponseAnswer,
+)
 
 
 def test_compact_safe_question_auto_answered() -> None:
@@ -250,3 +257,76 @@ def test_handler_returns_interrupt_true_on_escalate_decision(tmp_path: Path) -> 
     assert result.message == "rule-based test escalate"
     # Notify fired exactly once on this path.
     assert len(fired) == 1
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# cpp#56: PilotEvent enriched from ToolPermissionContext
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _enriched_ctx() -> ToolPermissionContext:
+    return ToolPermissionContext(
+        signal=None,
+        suggestions=[],
+        tool_use_id="tool_test",
+        agent_id="agent_x",
+        decision_reason="needs review",
+        blocked_path="/etc/passwd",
+        title="Read sensitive file",
+        display_name="Read",
+        description="reads a file outside the workspace",
+    )
+
+
+def _capture_relay_event(
+    monkeypatch: pytest.MonkeyPatch, ctx: ToolPermissionContext
+) -> PilotEvent:
+    """Drive the relay path (policy disabled) and capture the PilotEvent that
+    permissions.py constructs from ``ctx``."""
+    monkeypatch.setenv("MIKA_PILOT_POLICY_DISABLED", "1")
+    captured: dict[str, PilotEvent] = {}
+
+    async def _fake_invoke(_config: PilotConfig, event: PilotEvent, *_a: object) -> PilotResponseAllow:
+        captured["event"] = event
+        return PilotResponseAllow(action="allow")
+
+    monkeypatch.setattr(permissions_module, "invoke_command", _fake_invoke)
+
+    handler = create_permission_handler(
+        config=PilotConfig(command="true"),
+        relay=True,
+        verbose=False,
+        cwd="/tmp",
+    )
+    # "rm -rf /" misses Tier 1 / Tier 1.5; with policy disabled it reaches relay.
+    asyncio.run(handler("Bash", {"command": "rm -rf /"}, ctx))
+    return captured["event"]
+
+
+def test_pilot_event_carries_enriched_context_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cpp#56 present path: all five enriched ToolPermissionContext fields are
+    captured onto the relay PilotEvent."""
+    event = _capture_relay_event(monkeypatch, _enriched_ctx())
+    assert event.decision_reason == "needs review"
+    assert event.blocked_path == "/etc/passwd"
+    assert event.title == "Read sensitive file"
+    assert event.display_name == "Read"
+    assert event.description == "reads a file outside the workspace"
+
+
+def test_pilot_event_absent_context_fields_are_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cpp#56 absent path: a ctx without the enriched fields yields None on the
+    PilotEvent (getattr defaults) and does not crash. `_mock_ctx()` is exactly
+    such a bare context (only tool_use_id + agent_id set)."""
+    event = _capture_relay_event(monkeypatch, _mock_ctx())
+    assert event.decision_reason is None
+    assert event.blocked_path is None
+    assert event.title is None
+    assert event.display_name is None
+    assert event.description is None
+    # exclude_none keeps the absent fields out of the serialized payload.
+    assert "title" not in event.model_dump_json(exclude_none=True)


### PR DESCRIPTION
## Why

Three evidence-gated, backward-compatible changes surfaced by the `claude-agent-sdk` 0.1.59 → 0.2.110 bump (cpp#52 / PR #53). Bundled into one PR because all three touch the `agent.py` / `types.py` / `permissions.py` cluster on the same SDK lineage. All verified against the installed SDK 0.2.110.

## What

### cpp#55 — regression fix (`SystemMessage.data` nesting)
SDK 0.2.x `SystemMessage` is `{subtype, data}`; `session_id`/`model` live in `.data`, but `_extract_session_id`/`_extract_model` read top-level attrs, so `[init]` logged empty ids. Both helpers now read `message.data.get("session_id")`/`.get("model")` first, falling back to the top-level `getattr` so mocks and a future un-nesting SDK still resolve. The predicted fix from the SDK-bump solution doc's "Latent finding" — landed exactly as scoped.

### cpp#54 — `api_error_status` into `ResultJson`
SDK exposes `ResultMessage.api_error_status` (`int | None`) for HTTP 429/500/529. Surfaced as a new `Optional` field on `ResultJson`, populated via `getattr` at the `ResultMessage` site, so mika-dev dispatch-lib can classify a transient overload deterministically instead of parsing prose `errors`.

### cpp#56 — `ToolPermissionContext` enrichment into `PilotEvent`
Captures the SDK's enriched permission-context fields (`decision_reason`, `blocked_path`, `title`, `display_name`, `description`) onto `PilotEvent` for richer relay telemetry. Typed `TaskUpdatedMessage` (cpp#56 part 2) deferred — `guardrails.py` has zero `Task*` consumers today.

## Backward compatibility
Every new field is `Optional`, defaults `None`, uses the SDK's verbatim name, and serializes absent via `exclude_none` — no downstream `ResultJson` / `PilotEvent` parser breaks on a missing key. No live-path behavior change (the `PilotEvent` enrichment site is the relay block, reachable only under `MIKA_PILOT_POLICY_DISABLED=1`).

## Testing
- New tests cover **both present-field and absent-field paths** for cpp#54 and cpp#56, and nested / top-level-fallback / missing-both / non-string paths for cpp#55.
- `uv run pytest`: **525 passed** (baseline ~516, +9).
- `uv run ruff check`: clean. `uv run mypy src`: clean.
- Two independent code-review passes (correctness + standards/maintainability): no blocking findings; both P3 nits applied (comment provenance, test DRY).

## cpp#55 regression closure
The new `_extract_*` unit tests are the in-pipeline regression confirmation (assert non-empty extraction from nested `data`). The full live smoke — relay-mode `/mika` dispatch confirming `[init]` logs a non-empty session_id/model — is operator-host-time.

## Compounding
Extended `docs/solutions/tooling-decisions/claude-agent-sdk-major-version-bump-is-mechanical-not-a-rewrite.md`: marked the predicted cpp#55 "Latent finding" RESOLVED and added a Stage-2 adoption pattern (moved field → nested-first+fallback; net-new field → Optional + exclude_none).

Closes #55
Closes #54
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)