### PR TITLE
fix(permissions): destination validator — worktree containment + control-plane denylist (cpp#38 + cpp#42)

### DIFF
--- a/docs/plans/2026-06-30-053-fix-dest-validator-containment-control-plane-plan.md
+++ b/docs/plans/2026-06-30-053-fix-dest-validator-containment-control-plane-plan.md
@@ -1,0 +1,387 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "fix(permissions): destination-validator — worktree containment + control-plane denylist (cpp#38 + cpp#42)"
+date: 2026-06-30
+type: fix
+issues: [38, 42]
+branch: fix/dest-validator-38-42-containment-and-control-plane
+origin: /tmp/spawn-brief-cpp-destination-validator.md
+---
+
+# fix(permissions): destination-validator — worktree containment + control-plane denylist
+
+> **Target repo:** claude-pilot-py
+> Closes cpp#38 and cpp#42 in one PR — both close residuals on the *same* set of
+> write-capable structural permission rules and share one destination-validation
+> code path. Splitting them would duplicate the operand-extraction plumbing.
+
+---
+
+## Summary
+
+claude-pilot's deterministic permission policy admits three write-capable Bash
+rules — `bash-git-show-redirect`, `bash-cp-mv`, `bash-mkdir` — purely by
+**command-string shape**. The string check has no view of the filesystem, so two
+empirically-confirmed bypasses survive it:
+
+1. **cpp#38 — symlink traversal (out-of-worktree write).** A committed symlink
+   `esc -> ../OUTSIDE` turns `git show <SHA>:payload > esc/passwd` (and the
+   `cp`/`mv`/`mkdir` variants) into a write *outside* the worktree. The static
+   regex rejects literal `../` but is blind to a symlinked intermediate
+   component.
+2. **cpp#42 — control-plane overwrite (in-worktree, higher severity).**
+   `git show <SHA>:payload > .git/hooks/post-checkout` resolves to a *genuinely
+   in-worktree* path, so even a containment check passes it — yet writing there
+   executes code on next checkout / in CI / rewrites the agent's own slash
+   commands and bundled skills. No symlink pre-plant required.
+
+This plan adds a single **destination validator** invoked at the one chokepoint
+every write-capable allow already flows through — `_bash_allow_is_chain_safe` in
+`src/claude_pilot/permissions.py`. The validator runs two ordered checks on the
+destination operand(s) of each write-capable rule: **(1) worktree containment
+first** (load-bearing safety, closes cpp#38), **(2) control-plane denylist
+second** (layered policy, closes cpp#42). Either failure vetoes the allow and
+the pilot halts honestly via the existing `interrupt=True` path.
+
+The plan does **not** harden against TOCTOU (symlink swapped between check and
+exec). `pathlib.Path.resolve()` carries the same TOCTOU residual the Write tool's
+`is_within_project` already accepts; that residual is documented, not closed
+(out of scope, per architect verdict).
+
+---
+
+## Problem Frame
+
+### Why the chokepoint is singular
+
+`cp`/`mv`/`mkdir` are **not** in `SAFE_SHELL_COMMANDS` (`tier1.py`), and
+`git show … > dest` is rejected by the Tier-1 metacharacter/danger scan because
+of the `>`. So none of the three rules can be auto-approved at Tier 1. They reach
+an `allow` **only** through the Tier-2 policy path:
+`create_permission_handler.handler` → `evaluate(...) == allow` →
+`_bash_allow_is_chain_safe(...)` (permissions.py:366). Inside that guard:
+
+- `bash-git-show-redirect` short-circuits to `return True` via its `rule_id`
+  (permissions.py:290).
+- `bash-cp-mv` / `bash-mkdir` are honored in the per-segment loop
+  (permissions.py:293–303): each segment is a clean policy allow and not
+  tier3-dangerous, so the loop `continue`s.
+
+This is confirmed by the existing learning doc: *"policy.evaluate … no compound
+splitting, no danger scan (those live only in tier1.py, already bypassed by the
+time the policy evaluator runs)."* Putting the destination validator inside
+`_bash_allow_is_chain_safe` therefore gates **all three rules in one place** —
+no per-rule duplication, and no second entry point to miss.
+
+### What "destination" means per rule
+
+| Rule | Command shape | Destination operand(s) to validate |
+|------|---------------|-------------------------------------|
+| `bash-git-show-redirect` | `git show <SHA>:<src> > <dest>` | the single redirect target after `>` |
+| `bash-cp-mv` | `cp [flags] <src>… <dest>` / `mv …` | the **last** operand (and `-t <dir>` target if present) |
+| `bash-mkdir` | `mkdir [-p] <dir>…` | **every** directory operand (mkdir takes N targets) |
+
+Operand extraction is the fiddly core of this work: multi-source `cp`, multi-dir
+`mkdir`, the `cp -t <dir> <src>…` target-flag form, and `>` whitespace variants
+(`>x`, `> x`, `>  x`) all have to land on the right token(s).
+
+---
+
+## Scope Boundaries
+
+### In scope
+- Worktree-containment check on the destination operand of all three
+  write-capable structural rules (cpp#38).
+- Control-plane denylist check on the same operands (cpp#42).
+- One shared validator code path; AC test matrices for both tickets.
+- Extending the existing security learning doc with the static-shape-vs-runtime
+  -containment crystallization.
+
+### Out of scope (do not pull in)
+- `tier1.py` `FIND_EXEC_SAFE_COMMANDS` — already shipped (cpp#57).
+- Refactoring the native Write tool's `is_within_project` — this work *mirrors*
+  its semantics for shell rules; it does not touch Write.
+- Adding control-plane paths beyond the 6 enumerated — evidence-gated future
+  tickets only.
+- `O_NOFOLLOW` / `openat` TOCTOU hardening — `Path.resolve()` residual is
+  accepted (architect verdict; Write tool accepts the identical residual).
+- `bash-cat-heredoc-tmp` — already `/tmp`-pinned by its anchored rule; not a
+  worktree-relative destination. (Note it in the doc as audited-and-excluded.)
+
+---
+
+## Key Technical Decisions
+
+### KTD-1 — Single validator at `_bash_allow_is_chain_safe`, not per-rule call sites
+The chokepoint argument above. One insertion point gates all three rules and any
+future write-capable rule that flows through the same allow-honoring guard.
+Rationale: the brief's "one helper, four call sites" intent is best served by
+*one* guard function at the *one* place allows are honored, rather than literally
+sprinkling calls at each `rule_id` branch.
+
+### KTD-2 — Thread `cwd` (worktree root) into the validation
+Both checks are filesystem-relative and need the worktree root. `cwd` lives in
+`create_permission_handler`'s closure but `_bash_allow_is_chain_safe` does not
+currently receive it. Decision: pass `cwd` into the destination-validation path
+(extend `_bash_allow_is_chain_safe`'s signature, or factor the destination check
+into a sibling guard called from the handler with `cwd` in scope — implementer's
+call at `ce-work` time; both keep `cwd` flowing from the handler). The containment
+helper reuses `tier1.is_within_project`'s resolution semantics
+(`Path.resolve(strict=False)`).
+
+### KTD-3 — Containment FIRST, control-plane SECOND
+Containment is the load-bearing safety boundary; control-plane is layered policy
+on an already-contained path. Order is observable: an out-of-worktree symlinked
+control-plane-looking path must be denied as *containment* failure (cpp#38), not
+mislabeled. Implement as: resolve → assert within worktree (else deny) → compute
+canonical worktree-relative path → literal-prefix match against denylist (else
+deny) → allow.
+
+### KTD-4 — Control-plane denylist: anchored literal-prefix on the *resolved*
+worktree-relative path
+Match the canonical relative path (post-resolve, via `.relative_to(worktree_root)`),
+not the raw string — this makes the denylist robust to `./` prefixes and to a
+symlink that lands inside the worktree but inside the control plane. Patterns
+(each with inline rationale in code):
+
+```
+^\.git/                                       # hooks/config exec on checkout
+^\.github/workflows/                          # runs in CI, broad token access
+^\.claude/                                    # agent's own slash commands
+^skills/bundled/                              # bundled skills the pilot trusts
+^crates/mika-agent/src/well_known_agents\.rs$ # mika agent identities
+^\.mika/                                       # runtime config
+```
+
+`.gitignore` (top-level) must NOT match — anchor `^\.git/` with the trailing
+slash so a sibling dotfile passes. Use a symbolic constant tuple so audits are
+one-stop.
+
+### KTD-5 — No regex on inner content; structural shape only
+Canonicalization is `Path.resolve()`; denylist is literal-prefix. No parsing of
+file contents, no source-side inspection. Consistent with the whole-file
+learning doc: the gate is a pre-exec shape filter, not a runtime sandbox.
+
+### KTD-6 — Fail closed
+If operand extraction is ambiguous/unparseable for a write-capable rule, deny
+(do not allow an un-validated destination). Mirrors the existing rule_id
+fail-closed coupling: when in doubt, route to deny, the safe direction.
+
+---
+
+## High-Level Technical Design
+
+Decision flow for a write-capable rule's policy `allow`, inside the chain-safety
+guard:
+
+```mermaid
+flowchart TD
+    A[policy evaluate == allow<br/>rule is write-capable] --> B[extract destination operand(s)]
+    B -->|extraction ambiguous| DENY[veto allow → interrupt=True halt]
+    B --> C{for each dest:<br/>resolve + within worktree?}
+    C -->|no — escapes worktree| DENY
+    C -->|yes| D{resolved rel-path<br/>matches control-plane denylist?}
+    D -->|yes| DENY
+    D -->|no| E[next dest]
+    E -->|all dests clean| ALLOW[honor allow]
+```
+
+Non-write-capable rules and non-Bash tools bypass the validator unchanged
+(current `_bash_allow_is_chain_safe` behavior preserved).
+
+---
+
+## Implementation Units
+
+### U1. Destination-operand extraction helpers
+**Goal:** Pure functions that pull the destination operand(s) out of each
+write-capable command shape, fail-closed on ambiguity.
+**Requirements:** cpp#38 AC38.1–38.4, cpp#42 AC42.1–42.6 all depend on correct
+operand extraction.
+**Dependencies:** none.
+**Files:**
+- `src/claude_pilot/permissions.py` (new private helpers, e.g.
+  `_extract_write_destinations(rule_id, command) -> list[str] | None`)
+- `tests/test_policy_devpilot.py` (extraction unit tests)
+**Approach:** One extractor keyed on `rule_id`. For `bash-git-show-redirect`,
+split on the redirect operator and take the post-`>` token (reuse the anchored
+YAML pattern's structure for the target group rather than re-lexing). For
+`bash-cp-mv`, return the last positional operand; also handle `-t <dir>` /
+`--target-directory=<dir>`. For `bash-mkdir`, return all non-flag operands.
+Return `None` on anything that doesn't cleanly parse → caller denies.
+**Patterns to follow:** existing anchored-regex rule shapes in
+`permissions.yaml`; fail-closed `rule_id` coupling at permissions.py:290.
+**Test scenarios:**
+- `git show abc123:payload > esc/passwd` → `["esc/passwd"]`.
+- `git show abc123:legit > docs/plans/X-plan.md` → `["docs/plans/X-plan.md"]`.
+- `>x`, `> x`, `>  x` whitespace variants all extract `x`.
+- `cp a b` → `["b"]`; `cp a b c dest/` → `["dest/"]`; `cp -t out/ a b` →
+  `["out/"]`.
+- `mv src esc/passwd` → `["esc/passwd"]`.
+- `mkdir esc/newdir` → `["esc/newdir"]`; `mkdir -p a/b c/d` → `["a/b", "c/d"]`.
+- Unparseable/empty destination → `None` (fail closed).
+- Edge: `cp` with only one operand (no dest) → `None`.
+
+### U2. Worktree-containment check (cpp#38)
+**Goal:** Reject any destination that resolves outside the worktree root,
+including via committed symlink.
+**Requirements:** cpp#38 AC38.1–38.6.
+**Dependencies:** U1.
+**Files:**
+- `src/claude_pilot/permissions.py` (e.g.
+  `_check_destination_within_worktree(dest, cwd) -> bool`)
+- `tests/test_policy_devpilot.py`
+**Approach:** Mirror `tier1.is_within_project` semantics —
+`Path.resolve(strict=False)` resolves symlinks on existing components and leaves
+the non-existent tail as-is; then `.relative_to(resolved_cwd)`; `ValueError` →
+outside → deny. Import/reuse `is_within_project` directly if its signature fits,
+rather than reimplementing.
+**Patterns to follow:** `tier1.py:825 is_within_project`.
+**Test scenarios (build a real worktree via `tmp_path`, plant a symlink
+`esc -> ../OUTSIDE`):**
+- Covers AC38.1: resolved `esc/passwd` (symlink → outside) → not within → False.
+- Covers AC38.5/38.6: `docs/plans/X-plan.md`, `docs/plans/copy.md` (real
+  in-worktree paths) → within → True.
+- Absolute path `/etc/passwd` → False.
+- Non-existent-but-in-worktree tail `docs/plans/new.md` → True (tail left as-is).
+- `cwd` does not resolve (bad root) → False (mirror `is_within_project` OSError
+  guard).
+
+### U3. Control-plane denylist check (cpp#42)
+**Goal:** Reject an in-worktree destination that lands on the agent's control
+plane.
+**Requirements:** cpp#42 AC42.1–42.7.
+**Dependencies:** U1, U2 (operates on the post-containment resolved rel-path).
+**Files:**
+- `src/claude_pilot/permissions.py` (denylist constant +
+  `_is_control_plane_path(dest, cwd) -> bool`)
+- `tests/test_policy_devpilot.py`
+**Approach:** Compute the canonical worktree-relative path (resolve, then
+`relative_to(worktree_root)`), normalize to POSIX, literal-prefix match against
+the symbolic denylist tuple. Each entry carries an inline rationale comment.
+**Patterns to follow:** anchored-pattern + per-entry rationale style already used
+across `permissions.yaml` rules.
+**Test scenarios:**
+- Covers AC42.1: `.git/hooks/post-checkout` → True (deny).
+- Covers AC42.2: `.github/workflows/ci.yml` → True.
+- Covers AC42.3: `.claude/commands/mika.md` → True.
+- Covers AC42.4: `skills/bundled/_shared/dispatch-lib.sh` → True.
+- Covers AC42.7: `.gitignore` (top-level) → False (allow).
+- `well_known_agents.rs` at the exact path → True; a same-named file elsewhere →
+  False (anchored `$`).
+- `.mika/config` → True.
+- `docs/.claude-test/x` → False (not the real control plane — prefix is
+  `docs/`, not `^\.claude/`).
+
+### U4. Wire the validator into the allow-honoring guard
+**Goal:** Invoke extraction → containment → control-plane for every
+write-capable rule allow, before the guard returns `True` / `continue`s.
+**Requirements:** all ACs (integration seam).
+**Dependencies:** U1, U2, U3.
+**Files:**
+- `src/claude_pilot/permissions.py` (`_bash_allow_is_chain_safe` and/or the
+  handler call site; thread `cwd` per KTD-2)
+- `tests/test_policy_devpilot.py` (end-to-end through the handler / guard)
+**Approach:** At the `bash-git-show-redirect` short-circuit (permissions.py:290)
+and the cp/mv/mkdir segment-loop `continue` (293–303), gate on
+`_destination_is_safe(rule_id, command, cwd)` = extract (deny on `None`) →
+containment (deny on escape) → control-plane (deny on match). A veto returns the
+same `PermissionResultDeny(interrupt=True)` shape the chain-danger guard already
+uses, with a clear reason string. Preserve all existing positive paths.
+**Patterns to follow:** the existing chained-danger veto at permissions.py:366–373.
+**Test scenarios (full AC matrices, exercised through the public guard/handler):**
+- Covers AC38.1–38.4: symlink-escape `git show / cp / mv / mkdir` variants →
+  DENY (`interrupt=True`).
+- Covers AC38.5–38.6: legit in-worktree `git show` redirect + `cp` → ALLOW.
+- Covers AC42.1–42.6: each control-plane destination across `git show` and `cp`
+  → DENY.
+- Covers AC42.7: `.gitignore` write → ALLOW.
+- Regression: the existing `test_bundled_allows_git_show_redirect_trigger` and
+  `test_bundled_allows_dev_pilot_footprint` cases stay green.
+- Order check: an out-of-worktree symlink that *also* looks control-plane is
+  denied — assert the deny fires (containment-first means it's caught before the
+  denylist would even see a rel-path).
+
+### U5. Extend the security learning doc + YAML rule comments
+**Goal:** Crystallize the static-shape-vs-runtime-containment learning where the
+next implementer will find it.
+**Requirements:** brief's "Files" item; doc-audit gate.
+**Dependencies:** U1–U4 (document what shipped).
+**Files:**
+- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`
+  (extend; bump `last_updated`, add `claude-pilot-38`, `claude-pilot-42` tags)
+- `src/claude_pilot/policies/permissions.yaml` (comment block on the three
+  write-capable rules citing the new validator; rule logic stays in
+  permissions.py)
+**Approach:** Add a section: the policy is a pre-exec **shape filter**, not a
+runtime sandbox; worktree containment + control-plane denial are the runtime-
+adjacent checks that the shape filter structurally cannot do, now layered at the
+allow-honoring chokepoint. Record the accepted TOCTOU residual and the
+`bash-cat-heredoc-tmp` audited-and-excluded note.
+**Test expectation:** none — documentation + comments only.
+
+---
+
+## Verification Contract
+
+- `uv run pytest` — all pass; new AC tests present (count grows from 516 toward
+  530+).
+- `uv run ruff check` — clean.
+- `uv run mypy src` — clean.
+- Every write-capable structural rule (`bash-git-show-redirect`, `bash-cp-mv`,
+  `bash-mkdir`) demonstrably routes through the validator — asserted by the U4
+  matrix, and stated explicitly in the PR body.
+- Both AC matrices (cpp#38 AC38.1–38.6, cpp#42 AC42.1–42.7) pass.
+
+---
+
+## Definition of Done
+
+- One PR on branch `fix/dest-validator-38-42-containment-and-control-plane`,
+  `Closes #38` and `Closes #42`.
+- Containment-first / control-plane-second ordering implemented and asserted.
+- Single validator chokepoint; no per-rule duplication; fail-closed on ambiguous
+  extraction.
+- Learning doc + YAML comments updated.
+- All quality gates green.
+- **Not author-self-merged** — security boundary; adversarial / executed-exploit
+  review required before merge (handled at merge time, outside this plan).
+- PR body lists every write-capable rule and confirms each routes through the
+  validator; surfaces both AC matrices; notes the accepted `Path.resolve` TOCTOU
+  residual and any substrate tickets for residual gaps.
+
+---
+
+## Risks & Residuals
+
+- **TOCTOU (accepted).** `Path.resolve()` resolves symlinks at check time; a
+  concurrent attacker could swap a symlink between check and exec. Theoretical
+  under the single-sequential-model execution model; identical to the residual
+  the Write tool already accepts. Documented, not closed.
+- **Operand-extraction completeness.** `cp`/`mkdir` have many flag forms. The
+  fail-closed default (deny on unparseable) bounds the blast radius: a missed
+  form denies (safe), it does not silently allow. New legitimate forms that get
+  denied are evidence-gated follow-ups.
+- **Denylist completeness.** Six entries by design; broadening is evidence-gated.
+  A control-plane path not yet listed remains writable if it passes containment —
+  call this out in the doc so the boundary is loud.
+
+---
+
+## Sources & Research
+
+- Spawn brief: `/tmp/spawn-brief-cpp-destination-validator.md` (architectural
+  lineage, hard rules, AC matrices).
+- cpp#38 body (symlink-traversal PoC, accepted-residual classification).
+- cpp#42 body (control-plane PoC, peer-Claude harness on cpp#PR39).
+- `src/claude_pilot/permissions.py:223–303` (`_bash_allow_is_chain_safe`,
+  rule_id short-circuit, segment loop), `:358–386` (Tier-2 handler).
+- `src/claude_pilot/tier1.py:825` (`is_within_project` reference semantics),
+  `:392–413` (Tier-1 allowlist confirms cp/mv/mkdir excluded).
+- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`
+  (the "no danger scan at policy layer" statement that proves the chokepoint).
+- mika-arch sessions `fe891012` (cpp#35 symlink-residual ratification at parity),
+  `783d4a04` (no-realpath constraint context).

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -503,22 +503,51 @@ Design points worth keeping:
    metacharacter scan). So the validator runs once, in the handler, right after
    `_bash_allow_is_chain_safe`, where every write-capable allow is honored and
    nowhere else. A future write-capable rule inherits the check for free.
-2. **Order is load-bearing: containment FIRST, control-plane SECOND.** Containment
+2. **Classify write-capability STRUCTURALLY (leading command word), NEVER by the
+   matched `rule_id`.** This is the subtle one — the first cut keyed on
+   `evaluate(seg).rule_id ∈ {cp-mv, mkdir, …}`, and a cross-model adversarial pass
+   broke it: `policy.evaluate` is first-match-wins `re.search`, and a benign
+   earlier rule **shadows** the write rule while bash still performs the write.
+   `bash-grep`'s `\sgrep\s` matches ` grep ` *anywhere*, so
+   `cp "payload grep x" .git/hooks/post-checkout` evaluates to `rule_id=bash-grep`
+   → a rule-id gate skips the segment → the control-plane write is allowed (no
+   symlink, no pre-plant). The matched rule is **not** what bash executes; the
+   literal leading command word is. The whole command is already established
+   allow + chain-safe by the handler, so classification only has to answer "what
+   does bash write here," and that is a property of the command shape, not the
+   policy's first-match. (`git show … >` is immune — its `>` forces chain-safety
+   to demand the `bash-git-show-redirect` rule_id specifically and any shadow
+   makes the `>` tier3-dangerous — but the no-redirect writers cp/mv/mkdir were
+   wide open.) Generalizes §1's "denylist is incomplete by nature": a *first-match
+   allowlist* is just as unsound a basis for a security *classification*.
+3. **Tokenize operands with `shlex`, not `str.split`.** The same ` grep ` shadow
+   trick puts spaces in an operand, and a naive split fragments a quoted path
+   (`cp src "esc/a grep b"` → `"esc/a`, `b"`) so the symlink/control-plane
+   component is never resolved. POSIX `shlex.split` recovers the operand bash
+   actually sees; a tokenization error (unbalanced quotes) fails closed.
+4. **Order is load-bearing: containment FIRST, control-plane SECOND.** Containment
    is the safety boundary; the denylist is layered policy on an *already-contained*
    path. A symlink that escapes the worktree AND looks control-plane must be
    reported as a containment failure, not mislabeled.
-3. **The validator needs `cwd`; the YAML rule cannot resolve the filesystem.**
+5. **The validator needs `cwd`; the YAML rule cannot resolve the filesystem.**
    This is why the guarantee lives in code at the honoring point, not in the
    pattern. The rule stays a shape filter; the comment points at the code.
-4. **Match the canonical worktree-relative path, not the raw string.** Resolve,
+6. **Match the canonical worktree-relative path, not the raw string.** Resolve,
    then `relative_to(worktree_root)`, then literal-prefix match — so a symlink
-   resolving *into* `.git/` is still denied, and top-level `.gitignore` is *not*
-   (anchor `^\.git/` with the trailing slash).
-5. **Fail closed on unparseable destinations**, and keep the control-plane
+   resolving *into* `.git/` is still denied. Anchor each entry with `(/|$)`, not a
+   bare trailing `/`: a trailing-slash-only `^\.git/` misses the **bare** target
+   (`cp source .git`, `cp -t .claude x`, `git show … > .git`) — which overwrites
+   the gitdir pointer or writes *into* the control-plane dir — while `(/|$)` still
+   lets top-level `.gitignore` through (the char after `.git` is `i`, not `/`/end).
+   The `cp -t DIR` / bare-destination form is the evasion this closes.
+7. **Fail closed on unparseable destinations**, and keep the control-plane
    denylist a small symbolic constant with per-entry rationale — broaden only
    with evidence. The accepted residual is `Path.resolve` TOCTOU (a symlink
    swapped between check and exec), identical to what the Write tool's
-   `is_within_project` already accepts; documented, not closed.
+   `is_within_project` already accepts; documented, not closed. Known residual
+   denylist gaps to evidence-gate next: `.github/actions/` (composite/JS actions
+   run in CI with the same org-token blast radius as workflows), `.github/CODEOWNERS`,
+   `.github/dependabot.yml`.
 
 ## When to Apply
 

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -7,7 +7,7 @@ component: permission-classifier
 problem_type: security_issue
 category: security-issues
 severity: critical
-tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, xargs, ugrep, double-quote, ref-resolution, make, funsub, bash-5.3, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-40, claude-pilot-41, claude-pilot-43, claude-pilot-44, claude-pilot-45, claude-pilot-47]
+tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, xargs, ugrep, double-quote, ref-resolution, make, funsub, bash-5.3, worktree-containment, control-plane, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-38, claude-pilot-40, claude-pilot-41, claude-pilot-42, claude-pilot-43, claude-pilot-44, claude-pilot-45, claude-pilot-47]
 applies_when: "adding or reviewing any rule that decides allow/deny on a raw shell command string"
 ---
 
@@ -203,8 +203,10 @@ state, name the layer that actually enforces it.** Here, true worktree
 containment is a *runtime* concern: the Write native tool (the documented
 substitute for `>` redirects) already enforces it via `is_within_project`
 (`Path.resolve(strict=False)` + containment), so shell redirects are strictly
-weaker than the tool they substitute for. Closing it policy-wide (resolve-and-
-contain on every write rule's destination) is tracked in cpp#38.
+weaker than the tool they substitute for. This was closed policy-wide in cpp#38
+by porting that same resolve-and-contain to every write rule's destination — see
+§11 for the runtime validator and the higher-severity control-plane class it also
+closes (cpp#42).
 
 Corollary: don't write a comment that claims a stronger guarantee than the
 mechanism delivers. An overstated "closes B2" in a security rule is worse than no
@@ -477,7 +479,53 @@ must auto-approve should single-quote the payload. The Rust mirror
 (`permission_pre_classifier.rs`) has the same gap and is the paired-audit follow-up;
 the Python side intentionally diverges (hardened) until the Rust side mirrors.
 
+### 11. Filesystem-dependent guarantees go in code at the honoring point, not the YAML — one validator, two ordered checks
+
+§5 named the rule: when a security guarantee depends on filesystem state, name —
+and build — the layer that enforces it. cpp#38 + cpp#42 are that layer for the
+three write-capable structural rules (`bash-git-show-redirect`, `bash-cp-mv`,
+`bash-mkdir`). Two distinct residuals, both invisible to a string filter, both
+closed by **one** validator (`permissions.py` `_destination_veto_reason`):
+
+- **cpp#38 — out-of-worktree write via committed symlink.** A relative,
+  `..`-free target through `esc -> ../OUTSIDE` resolves outside the worktree.
+- **cpp#42 — in-worktree control-plane write (higher severity, no pre-plant).**
+  `git show <SHA>:x > .git/hooks/post-checkout` resolves *genuinely inside* the
+  worktree, so a containment check passes it — yet the write executes on next
+  checkout / in CI / rewrites the agent's own slash commands and bundled skills.
+  Reachable with just a path string; a containment-only fix does **not** catch it.
+
+Design points worth keeping:
+
+1. **One chokepoint, not per-rule call sites.** All three rules can only reach an
+   `allow` through the Tier-2 policy path (`cp`/`mv`/`mkdir` are absent from
+   tier1's `SAFE_SHELL_COMMANDS`; `git show … >` is rejected by tier1's
+   metacharacter scan). So the validator runs once, in the handler, right after
+   `_bash_allow_is_chain_safe`, where every write-capable allow is honored and
+   nowhere else. A future write-capable rule inherits the check for free.
+2. **Order is load-bearing: containment FIRST, control-plane SECOND.** Containment
+   is the safety boundary; the denylist is layered policy on an *already-contained*
+   path. A symlink that escapes the worktree AND looks control-plane must be
+   reported as a containment failure, not mislabeled.
+3. **The validator needs `cwd`; the YAML rule cannot resolve the filesystem.**
+   This is why the guarantee lives in code at the honoring point, not in the
+   pattern. The rule stays a shape filter; the comment points at the code.
+4. **Match the canonical worktree-relative path, not the raw string.** Resolve,
+   then `relative_to(worktree_root)`, then literal-prefix match — so a symlink
+   resolving *into* `.git/` is still denied, and top-level `.gitignore` is *not*
+   (anchor `^\.git/` with the trailing slash).
+5. **Fail closed on unparseable destinations**, and keep the control-plane
+   denylist a small symbolic constant with per-entry rationale — broaden only
+   with evidence. The accepted residual is `Path.resolve` TOCTOU (a symlink
+   swapped between check and exec), identical to what the Write tool's
+   `is_within_project` already accepts; documented, not closed.
+
 ## When to Apply
+
+- Admitting any new write-capable command (a rule whose `allow` writes to a
+  destination operand): route its destination through `_destination_veto_reason`
+  at the honoring point — do not rely on the YAML pattern for containment, which
+  cannot resolve symlinks or detect control-plane paths (§5, §11).
 
 - Adding/reviewing any `permissions.yaml` rule, or any code deciding allow/deny on
   a raw shell command string.

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import sys
 import time
 from collections.abc import Awaitable, Callable
@@ -321,31 +322,77 @@ def _bash_allow_is_chain_safe(
 # metacharacter/danger scan — so all three can only be approved through the
 # Tier-2 policy path. One chokepoint, no per-rule duplication.
 
-# Rules whose policy `allow` writes to a destination operand that must be
-# contained + control-plane-checked. Keep in sync with the YAML rule ids.
-_WRITE_CAPABLE_RULE_IDS: frozenset[str] = frozenset({
-    "bash-git-show-redirect",
-    "bash-cp-mv",
-    "bash-mkdir",
-})
+# Write-capability is classified STRUCTURALLY, by the segment's leading command
+# word — NEVER by the policy `rule_id`. `policy.evaluate` is first-match-wins
+# `re.search`, so a benign earlier rule shadows the write rule while bash still
+# executes the write: `bash-grep`'s `\sgrep\s` matches ` grep ` ANYWHERE, so
+# `cp "payload grep x" .git/hooks/post-checkout` evaluates to `rule_id=bash-grep`
+# — a rule-id gate would skip it and miss the control-plane write. The whole
+# command was already established as allow + chain-safe by the handler; the
+# literal command shape, not the matched rule, is the source of truth for what
+# bash writes (cpp#42 adversarial review).
+_LEADING_CMD_RE = re.compile(r"^\s*(\S+)")
+_GIT_SHOW_RE = re.compile(r"^\s*git\s+show\b")
 
 # `git show <SHA>:<src> > <dest>` — the redirect target is the write destination.
-# Mirrors the anchored `bash-git-show-redirect` YAML pattern's target group.
+# Mirrors the anchored `bash-git-show-redirect` YAML pattern's target group; its
+# `[\w./-]+` class excludes spaces/quotes, so a quoted/spaced redirect target
+# can't match the rule at all (it would be denied) — regex-on-raw-segment is safe
+# here, unlike cp/mv/mkdir whose operands are shell-quoted (tokenized via shlex).
 _GIT_SHOW_REDIRECT_DEST_RE = re.compile(r">\s*([\w./-]+)\s*$")
+
+# A `cp`/`mv` short-flag cluster whose last (arg-taking) flag is `-t`
+# (target-directory): `-t`, `-rt`, `-vt`, `-rpt`, … The NEXT token is the target
+# directory. The attached form (`-tDIR`) is NOT matched here — it has no separate
+# next token, so it falls through to the fail-closed `None` (safe over-deny).
+_CP_MV_TARGET_FLAG_RE = re.compile(r"-[A-Za-z]*t")
 
 # Control-plane denylist (cpp#42): in-worktree destinations that, if written,
 # compromise the surface that constrains the agent. Matched against the canonical
 # worktree-RELATIVE resolved path (so a symlink that lands inside `.git/` etc. is
-# still caught). Anchored so a sibling like top-level `.gitignore` does NOT match.
+# still caught). Each entry is anchored with `(/|$)` so it matches BOTH the bare
+# directory/file (`cp source .git`, `cp -t .claude x` — which write the gitdir
+# pointer / into the dir) AND any path beneath it, while a sibling like top-level
+# `.gitignore` still does NOT match (the char after `.git` is `i`, not `/`/end).
 # Each entry carries its blast-radius rationale; broadening is evidence-gated.
 _CONTROL_PLANE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^\.git/"),                       # hooks/config — execute on next checkout
-    re.compile(r"^\.github/workflows/"),          # run in CI with broad org-token access
-    re.compile(r"^\.claude/"),                    # agent's own slash commands (self-modify)
-    re.compile(r"^skills/bundled/"),              # bundled skills every pilot session trusts
+    re.compile(r"^\.git(/|$)"),                   # hooks/config/gitdir — execute on next checkout
+    re.compile(r"^\.github/workflows(/|$)"),      # run in CI with broad org-token access
+    re.compile(r"^\.claude(/|$)"),                # agent's own slash commands (self-modify)
+    re.compile(r"^skills/bundled(/|$)"),          # bundled skills every pilot session trusts
     re.compile(r"^crates/mika-agent/src/well_known_agents\.rs$"),  # mika agent identities
-    re.compile(r"^\.mika/"),                       # ~/.mika runtime config
+    re.compile(r"^\.mika(/|$)"),                  # ~/.mika runtime config
 )
+
+
+def _segment_write_kind(seg: str) -> str | None:
+    """Classify a command segment by the file-write it performs, from its leading
+    command word only (rule-order-independent). Returns the write-kind key, or
+    ``None`` for a non-write segment."""
+    m = _LEADING_CMD_RE.match(seg)
+    if not m:
+        return None
+    cmd = m.group(1)
+    if cmd in ("cp", "mv"):
+        return "bash-cp-mv"
+    if cmd == "mkdir":
+        return "bash-mkdir"
+    if cmd == "git" and _GIT_SHOW_RE.match(seg) and ">" in seg:
+        return "bash-git-show-redirect"
+    return None
+
+
+def _shlex_operands(seg: str) -> list[str] | None:
+    """POSIX shell word-split of a segment (quotes removed the way bash would),
+    or ``None`` on a tokenization error (unbalanced quotes) so the caller fails
+    closed. Using shlex — not ``str.split`` — is load-bearing: a quoted operand
+    with spaces (`cp src "esc/a grep b"`) must yield the real path `esc/a grep b`,
+    not the fragments `"esc/a` / `b"`, or the symlink/control-plane component is
+    never seen."""
+    try:
+        return shlex.split(seg)
+    except ValueError:
+        return None
 
 
 def _extract_cp_mv_destination(seg: str) -> list[str] | None:
@@ -356,12 +403,18 @@ def _extract_cp_mv_destination(seg: str) -> list[str] | None:
     `-t`/`--target-directory` value when present, else the last positional
     operand. Returns ``None`` (fail-closed) when no destination is parseable.
     """
-    tokens = seg.split()
-    if len(tokens) < 3:  # need command + >= 1 source + destination
+    tokens = _shlex_operands(seg)
+    if tokens is None or len(tokens) < 3:  # need command + >= 1 source + dest
         return None
     rest = tokens[1:]
     for i, tok in enumerate(rest):
-        if tok in ("-t", "--target-directory") and i + 1 < len(rest):
+        # `-t DIR` and the GNU combined short-flag forms (`-rt DIR`, `-vt DIR`,
+        # …) put the TARGET DIRECTORY in the next token and make every positional
+        # a source — so the real write destination is `<DIR>/<src>`, NOT the last
+        # positional. Missing this validates a benign source operand while bytes
+        # land in an unchecked (possibly escaping or control-plane) directory.
+        # A short cluster ending in `t` means `-t` is its last, arg-taking flag.
+        if (tok == "--target-directory" or _CP_MV_TARGET_FLAG_RE.fullmatch(tok)) and i + 1 < len(rest):
             return [rest[i + 1]]
         if tok.startswith("--target-directory="):
             return [tok.split("=", 1)[1]]
@@ -378,22 +431,23 @@ def _extract_mkdir_destinations(seg: str) -> list[str] | None:
     which is harmless: it resolves in-worktree and is not control-plane, so it
     never produces a false deny while the real target(s) are still validated.
     """
-    tokens = seg.split()
-    if len(tokens) < 2:
+    tokens = _shlex_operands(seg)
+    if tokens is None or len(tokens) < 2:
         return None
     dests = [t for t in tokens[1:] if not t.startswith("-")]
     return dests or None
 
 
-def _extract_write_destinations(rule_id: str, seg: str) -> list[str] | None:
-    """Destination operand(s) for a write-capable rule segment, or ``None`` to
-    fail closed when the destination cannot be parsed."""
-    if rule_id == "bash-git-show-redirect":
+def _extract_write_destinations(kind: str, seg: str) -> list[str] | None:
+    """Destination operand(s) for a write-capable segment, or ``None`` to fail
+    closed when the destination cannot be parsed. ``kind`` is the structural
+    write-kind from ``_segment_write_kind``, never a policy rule_id."""
+    if kind == "bash-git-show-redirect":
         m = _GIT_SHOW_REDIRECT_DEST_RE.search(seg)
         return [m.group(1)] if m else None
-    if rule_id == "bash-cp-mv":
+    if kind == "bash-cp-mv":
         return _extract_cp_mv_destination(seg)
-    if rule_id == "bash-mkdir":
+    if kind == "bash-mkdir":
         return _extract_mkdir_destinations(seg)
     return None
 
@@ -419,27 +473,28 @@ def _is_control_plane_path(dest: str, cwd: str) -> bool:
     return any(pat.match(rel) for pat in _CONTROL_PLANE_PATTERNS)
 
 
-def _destination_veto_reason(
-    policy: Policy, command: str, cwd: str
-) -> str | None:
+def _destination_veto_reason(command: str, cwd: str) -> str | None:
     """Veto reason if any write-capable segment's destination escapes the
     worktree (cpp#38) or lands on the agent control plane (cpp#42); else ``None``.
 
     Per-segment so a compound like ``mkdir a && cp s esc/x`` validates each write
-    target independently. Order is load-bearing: CONTAINMENT first (the safety
-    boundary), CONTROL-PLANE second (layered policy on an already-contained path).
-    Unparseable destinations fail closed (vetoed).
+    target independently. Each segment is classified STRUCTURALLY by its leading
+    command word (``_segment_write_kind``) — never by a shadowable policy rule_id.
+    Order is load-bearing: CONTAINMENT first (the safety boundary), CONTROL-PLANE
+    second (layered policy on an already-contained path). Unparseable destinations
+    fail closed (vetoed). The caller has already established the whole command as
+    allow + chain-safe, so this only decides where the write lands.
     """
     if not isinstance(command, str) or not command:
         return None
     for seg in _split_compound_command(command):
-        pd = evaluate(policy, "Bash", {"command": seg})
-        if pd.decision != "allow" or pd.rule_id not in _WRITE_CAPABLE_RULE_IDS:
+        kind = _segment_write_kind(seg)
+        if kind is None:
             continue
-        dests = _extract_write_destinations(pd.rule_id, seg)
+        dests = _extract_write_destinations(kind, seg)
         if not dests:
             return (
-                f"write-capable rule {pd.rule_id} destination could not be "
+                f"write-capable segment ({kind}) destination could not be "
                 "parsed — denied fail-closed"
             )
         for dest in dests:
@@ -531,7 +586,7 @@ def create_permission_handler(
                 # every other policy denial (cpp#20 joint 2).
                 if tool_name == "Bash":
                     dest_veto = _destination_veto_reason(
-                        policy, tool_input.get("command", ""), cwd
+                        tool_input.get("command", ""), cwd
                     )
                     if dest_veto is not None:
                         log_policy_deny(tool_name, detail, pd.rule_id)

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -28,6 +28,7 @@ from .tier1 import (
     is_safe_bash_command,
     is_tier1_auto_approve,
     is_tier3_dangerous,
+    is_within_project,
 )
 from .transport import invoke_command
 from .types import (
@@ -303,6 +304,158 @@ def _bash_allow_is_chain_safe(
     return True
 
 
+# ── Destination validation for write-capable structural rules (cpp#38, cpp#42) ─
+#
+# `_bash_allow_is_chain_safe` (above) proves a command is shape-safe and that no
+# dangerous tail rides an allowed prefix. It is still a PRE-EXEC STRING FILTER:
+# it cannot see the filesystem, so it cannot tell that a relative redirect/copy/
+# mkdir target traverses a committed symlink out of the worktree (cpp#38), nor
+# that an in-worktree target lands on the agent's own control plane (cpp#42).
+#
+# Those two checks are runtime-adjacent — they need the worktree root (`cwd`),
+# which the policy guard does not carry. They run in the handler, at the single
+# point where a Bash policy `allow` is honored (see `create_permission_handler`),
+# AFTER chain-safety passes. Every write-capable structural rule reaches that
+# point and nowhere else: `cp`/`mv`/`mkdir` are absent from tier1's
+# `SAFE_SHELL_COMMANDS`, and `git show … > dest` is rejected by tier1's
+# metacharacter/danger scan — so all three can only be approved through the
+# Tier-2 policy path. One chokepoint, no per-rule duplication.
+
+# Rules whose policy `allow` writes to a destination operand that must be
+# contained + control-plane-checked. Keep in sync with the YAML rule ids.
+_WRITE_CAPABLE_RULE_IDS: frozenset[str] = frozenset({
+    "bash-git-show-redirect",
+    "bash-cp-mv",
+    "bash-mkdir",
+})
+
+# `git show <SHA>:<src> > <dest>` — the redirect target is the write destination.
+# Mirrors the anchored `bash-git-show-redirect` YAML pattern's target group.
+_GIT_SHOW_REDIRECT_DEST_RE = re.compile(r">\s*([\w./-]+)\s*$")
+
+# Control-plane denylist (cpp#42): in-worktree destinations that, if written,
+# compromise the surface that constrains the agent. Matched against the canonical
+# worktree-RELATIVE resolved path (so a symlink that lands inside `.git/` etc. is
+# still caught). Anchored so a sibling like top-level `.gitignore` does NOT match.
+# Each entry carries its blast-radius rationale; broadening is evidence-gated.
+_CONTROL_PLANE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\.git/"),                       # hooks/config — execute on next checkout
+    re.compile(r"^\.github/workflows/"),          # run in CI with broad org-token access
+    re.compile(r"^\.claude/"),                    # agent's own slash commands (self-modify)
+    re.compile(r"^skills/bundled/"),              # bundled skills every pilot session trusts
+    re.compile(r"^crates/mika-agent/src/well_known_agents\.rs$"),  # mika agent identities
+    re.compile(r"^\.mika/"),                       # ~/.mika runtime config
+)
+
+
+def _extract_cp_mv_destination(seg: str) -> list[str] | None:
+    """Destination operand of a `cp`/`mv` segment (the write target).
+
+    The `bash-cp-mv` YAML rule already rejects any `..`/absolute/`~`/`$` operand,
+    so an allowed segment has only relative operands. The destination is the
+    `-t`/`--target-directory` value when present, else the last positional
+    operand. Returns ``None`` (fail-closed) when no destination is parseable.
+    """
+    tokens = seg.split()
+    if len(tokens) < 3:  # need command + >= 1 source + destination
+        return None
+    rest = tokens[1:]
+    for i, tok in enumerate(rest):
+        if tok in ("-t", "--target-directory") and i + 1 < len(rest):
+            return [rest[i + 1]]
+        if tok.startswith("--target-directory="):
+            return [tok.split("=", 1)[1]]
+    non_flags = [t for t in rest if not t.startswith("-")]
+    if len(non_flags) < 2:  # need >= 1 source + destination
+        return None
+    return [non_flags[-1]]
+
+
+def _extract_mkdir_destinations(seg: str) -> list[str] | None:
+    """Every directory operand of a `mkdir` segment (each is created).
+
+    A space-separated option value (e.g. ``-m 755``) survives as a pseudo-operand,
+    which is harmless: it resolves in-worktree and is not control-plane, so it
+    never produces a false deny while the real target(s) are still validated.
+    """
+    tokens = seg.split()
+    if len(tokens) < 2:
+        return None
+    dests = [t for t in tokens[1:] if not t.startswith("-")]
+    return dests or None
+
+
+def _extract_write_destinations(rule_id: str, seg: str) -> list[str] | None:
+    """Destination operand(s) for a write-capable rule segment, or ``None`` to
+    fail closed when the destination cannot be parsed."""
+    if rule_id == "bash-git-show-redirect":
+        m = _GIT_SHOW_REDIRECT_DEST_RE.search(seg)
+        return [m.group(1)] if m else None
+    if rule_id == "bash-cp-mv":
+        return _extract_cp_mv_destination(seg)
+    if rule_id == "bash-mkdir":
+        return _extract_mkdir_destinations(seg)
+    return None
+
+
+def _is_control_plane_path(dest: str, cwd: str) -> bool:
+    """Whether ``dest`` (resolved against the worktree ``cwd``) lands on the
+    agent's control plane (cpp#42). Operates on the canonical worktree-relative
+    path so a symlink resolving INTO the control plane is still caught. Returns
+    ``False`` for paths outside the worktree — containment owns that verdict."""
+    try:
+        resolved_cwd = Path(cwd).resolve(strict=True)
+    except OSError:
+        return False
+    abs_path = (
+        Path(dest).resolve(strict=False)
+        if Path(dest).is_absolute()
+        else (resolved_cwd / dest).resolve(strict=False)
+    )
+    try:
+        rel = abs_path.relative_to(resolved_cwd).as_posix()
+    except ValueError:
+        return False
+    return any(pat.match(rel) for pat in _CONTROL_PLANE_PATTERNS)
+
+
+def _destination_veto_reason(
+    policy: Policy, command: str, cwd: str
+) -> str | None:
+    """Veto reason if any write-capable segment's destination escapes the
+    worktree (cpp#38) or lands on the agent control plane (cpp#42); else ``None``.
+
+    Per-segment so a compound like ``mkdir a && cp s esc/x`` validates each write
+    target independently. Order is load-bearing: CONTAINMENT first (the safety
+    boundary), CONTROL-PLANE second (layered policy on an already-contained path).
+    Unparseable destinations fail closed (vetoed).
+    """
+    if not isinstance(command, str) or not command:
+        return None
+    for seg in _split_compound_command(command):
+        pd = evaluate(policy, "Bash", {"command": seg})
+        if pd.decision != "allow" or pd.rule_id not in _WRITE_CAPABLE_RULE_IDS:
+            continue
+        dests = _extract_write_destinations(pd.rule_id, seg)
+        if not dests:
+            return (
+                f"write-capable rule {pd.rule_id} destination could not be "
+                "parsed — denied fail-closed"
+            )
+        for dest in dests:
+            if not is_within_project(dest, cwd):
+                return (
+                    f"destination {dest!r} resolves outside the worktree "
+                    "(cpp#38 symlink-traversal containment)"
+                )
+            if _is_control_plane_path(dest, cwd):
+                return (
+                    f"destination {dest!r} is on the agent control plane "
+                    "(cpp#42 denylist)"
+                )
+    return None
+
+
 def _fire_notify(tool_name: str, detail: str, reason: str) -> None:
     """Best-effort operator notification on deny-with-notify via ``mika notify``.
 
@@ -371,6 +524,18 @@ def create_permission_handler(
                     )
                     log_policy_deny(tool_name, detail, pd.rule_id)
                     return PermissionResultDeny(message=veto_reason, interrupt=True)
+                # Destination validation for write-capable structural rules:
+                # worktree containment (cpp#38) + control-plane denylist (cpp#42).
+                # Runs here because it needs the worktree root (`cwd`), which the
+                # string-only policy guard does not carry. Halts honestly like
+                # every other policy denial (cpp#20 joint 2).
+                if tool_name == "Bash":
+                    dest_veto = _destination_veto_reason(
+                        policy, tool_input.get("command", ""), cwd
+                    )
+                    if dest_veto is not None:
+                        log_policy_deny(tool_name, detail, pd.rule_id)
+                        return PermissionResultDeny(message=dest_veto, interrupt=True)
                 log_policy_allow(tool_name, detail, pd.rule_id)
                 return PermissionResultAllow(updated_input=tool_input)
             if pd.decision == "deny":

--- a/src/claude_pilot/policies/permissions.yaml
+++ b/src/claude_pilot/policies/permissions.yaml
@@ -97,17 +97,19 @@ rules:
   #     `[\w./-]+` char class excludes `$`, backtick, `(`, space and `>`, so no
   #     shell expansion / substitution / chaining can ride the target.
   #   - the SOURCE path char class `[\w./-]+` likewise excludes `$(`/backtick.
-  # RESIDUAL (accepted, mika-arch session fe891012): this static check rejects
-  # literal `../` traversal but CANNOT detect SYMLINK traversal — `> esc/passwd`
-  # where `esc` is a committed symlink to `../OUTSIDE` writes outside the
-  # worktree. Symlinks are a runtime filesystem property invisible to string
-  # matching; this rule does NOT close path-traversal-via-symlink (B2). This is
-  # the SAME residual already carried by the deployed `bash-cp-mv` and
-  # `bash-mkdir` rules (all pure-structural, all symlink-blind) and is classed
-  # out-of-static-policy-scope in docs/solutions/security-issues/command-string-
-  # policy-allow-rules-are-compound-unsafe.md. True worktree containment is a
-  # runtime concern (the Write tool's `is_within_project`/`Path.resolve`);
-  # closing B2 policy-wide is tracked separately (cpp#38).
+  # STATIC RESIDUAL (cpp#38) — now closed one layer up at runtime: this string
+  # pattern still rejects only literal `../` and CANNOT detect SYMLINK traversal
+  # (`> esc/passwd` where `esc` is a committed symlink to `../OUTSIDE`). Symlinks
+  # are a runtime filesystem property invisible to string matching, so the regex
+  # is intentionally NOT tightened (that would break the legitimate multi-
+  # component target `docs/plans/X.md`). Worktree containment is enforced at the
+  # honoring point instead: permissions.py `_destination_veto_reason` resolves
+  # the redirect target against the worktree root and vetoes any escape (cpp#38)
+  # and any control-plane landing (cpp#42), AFTER `_bash_allow_is_chain_safe`.
+  # The same validator gates the `bash-cp-mv` / `bash-mkdir` destinations. See
+  # docs/solutions/security-issues/command-string-policy-allow-rules-are-
+  # compound-unsafe.md §5 / §11. TOCTOU residual of `Path.resolve` is accepted
+  # (same as the Write tool's `is_within_project`).
   # Anchored `^...$` is load-bearing: policy.evaluate uses re.search with NO
   # re.MULTILINE, so `$` honors only a single trailing newline — a multi-line
   # injection (`> foo\nrm -rf /`) cannot match here and falls through to the
@@ -183,6 +185,13 @@ rules:
   # and the safe npx subset are already tier1-auto-approved standalone; the
   # rules here cover them inside a PATH-bootstrap compound and as defense-in-
   # depth.
+  #
+  # WRITE DESTINATIONS (cpp#38 + cpp#42): the `bash-cp-mv` and `bash-mkdir` rules
+  # below are string-only and symlink-blind — like `bash-git-show-redirect`. The
+  # destination operand(s) of all three are validated at runtime in permissions.py
+  # `_destination_veto_reason` (worktree containment FIRST, control-plane denylist
+  # SECOND) at the single point a Bash `allow` is honored. Rule logic stays here;
+  # destination containment lives in code (the YAML cannot resolve the filesystem).
 
   - id: bash-mkdir
     tool: Bash

--- a/tests/test_policy_devpilot.py
+++ b/tests/test_policy_devpilot.py
@@ -19,6 +19,7 @@ from claude_agent_sdk.types import ToolPermissionContext
 from claude_pilot.permissions import (
     _SUBSTITUTION_ALLOWLIST,
     _bash_allow_is_chain_safe,
+    _destination_veto_reason,
     create_permission_handler,
 )
 from claude_pilot.policy import Policy, evaluate, load_policy
@@ -476,19 +477,165 @@ def test_guard_substitution_in_source_vetoed_before_git_show_exception() -> None
     assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False
 
 
-def test_git_show_redirect_symlink_traversal_is_accepted_static_residual() -> None:
-    # DOCUMENTS an accepted residual (mika-arch session fe891012, cpp#35 / cpp#38):
-    # a relative, ..-free target through a *committed symlink* (`esc -> ../OUTSIDE`)
-    # passes the static rule and would write outside the worktree AT RUNTIME. Static
-    # policy is a pre-exec shape filter, not a runtime sandbox — it cannot detect
-    # symlinks. This is the SAME residual the deployed cp/mv/mkdir rules carry
-    # (asserted below for parity). Do NOT "fix" by tightening this regex (that would
-    # break the legitimate multi-component target `docs/plans/X.md`); true
-    # containment is runtime resolve-and-contain, tracked policy-wide in cpp#38.
+def test_git_show_redirect_symlink_traversal_string_layer_still_allows() -> None:
+    # The STRING-FILTER layer (policy + chain guard) intentionally still allows a
+    # relative, ..-free target through a committed symlink — a pre-exec shape
+    # filter cannot detect symlinks, and tightening the regex would break the
+    # legitimate multi-component target `docs/plans/X.md`. Containment is now
+    # closed one layer up, at runtime resolve-and-contain in the handler (cpp#38);
+    # see test_dest_validator_* below. This test pins that the string layer was
+    # NOT changed to do containment.
     assert _effective("git show e95a9d8f:payload > esc/passwd") == "allow"
-    # Parity: the pre-existing structural write rules share the identical residual.
     assert _effective("cp payload esc/passwd") == "allow"
     assert _effective("mkdir esc/newdir") == "allow"
+
+
+# ── cpp#38 + cpp#42: destination validator (containment + control-plane) ──────
+#
+# The string layer above stays lenient; the handler's destination validator
+# closes both residuals at runtime. Containment (cpp#38) is checked FIRST, the
+# control-plane denylist (cpp#42) SECOND. These tests build a real worktree on
+# disk with a committed symlink `esc -> ../OUTSIDE` so resolve-and-contain has
+# something to resolve.
+
+
+def _make_worktree(tmp_path: Path) -> str:
+    """A worktree dir with `docs/plans/` and a symlink `esc -> ../OUTSIDE` that
+    escapes it. Returns the worktree path (use as `cwd`)."""
+    worktree = tmp_path / "wt"
+    (worktree / "docs" / "plans").mkdir(parents=True)
+    (tmp_path / "OUTSIDE").mkdir()
+    (worktree / "esc").symlink_to("../OUTSIDE")
+    return str(worktree)
+
+
+def _dest_effective(cmd: str, cwd: str, policy: Policy = _POLICY) -> str:
+    """Effective decision of the FULL honoring path: policy + chain guard +
+    destination validator (the production order in the handler)."""
+    d = evaluate(policy, "Bash", _bash(cmd))
+    if d.decision != "allow":
+        return d.decision
+    if not _bash_allow_is_chain_safe(policy, "Bash", _bash(cmd)):
+        return "deny"
+    if _destination_veto_reason(policy, cmd, cwd) is not None:
+        return "deny"
+    return "allow"
+
+
+# cpp#38 — symlink-traversal containment
+
+
+def test_dest_validator_ac38_1_git_show_symlink_escape_denied(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("git show e95a9d8f:payload > esc/passwd", cwd) == "deny"
+
+
+def test_dest_validator_ac38_2_cp_symlink_escape_denied(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("cp source esc/passwd", cwd) == "deny"
+
+
+def test_dest_validator_ac38_3_mv_symlink_escape_denied(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("mv source esc/passwd", cwd) == "deny"
+
+
+def test_dest_validator_ac38_4_mkdir_symlink_escape_denied(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("mkdir esc/newdir", cwd) == "deny"
+
+
+def test_dest_validator_ac38_5_git_show_legit_plan_allowed(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    # cpp#35 founding trigger — must STAY allowed (positive regression).
+    assert (
+        _dest_effective("git show e95a9d8f:legit > docs/plans/X-plan.md", cwd)
+        == "allow"
+    )
+
+
+def test_dest_validator_ac38_6_cp_in_worktree_allowed(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("cp source docs/plans/copy.md", cwd) == "allow"
+
+
+# cpp#42 — control-plane denylist (in-worktree but compromises the agent)
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git show e95a9d8f:payload > .git/hooks/post-checkout",          # AC42.1
+        "git show e95a9d8f:payload > .github/workflows/ci.yml",         # AC42.2
+        "git show e95a9d8f:payload > .claude/commands/mika.md",         # AC42.3
+        "git show e95a9d8f:payload > skills/bundled/dispatch-lib.sh",   # AC42.4
+        "cp source .git/config",                                        # AC42.5
+        "cp source .mika/runtime.json",                                 # .mika denylist
+    ],
+)
+def test_dest_validator_ac42_control_plane_denied(cmd: str, tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective(cmd, cwd) == "deny"
+
+
+def test_dest_validator_ac42_7_gitignore_allowed(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    # Top-level dotfile — NOT control plane; `^\.git/` requires the trailing slash.
+    assert _dest_effective("git show e95a9d8f:payload > .gitignore", cwd) == "allow"
+
+
+def test_dest_validator_well_known_agents_anchored_exact(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    # The mika-identities entry is exact-path-anchored ($): the real path denies,
+    # a same-named file elsewhere passes containment + control-plane.
+    assert (
+        _dest_effective(
+            "git show e95a9d8f:x > crates/mika-agent/src/well_known_agents.rs", cwd
+        )
+        == "deny"
+    )
+    assert (
+        _dest_effective("git show e95a9d8f:x > docs/well_known_agents.rs", cwd)
+        == "allow"
+    )
+
+
+def test_dest_validator_containment_precedes_control_plane(tmp_path: Path) -> None:
+    # Order is load-bearing: a symlink that escapes the worktree AND looks
+    # control-plane must be denied as a CONTAINMENT failure (cpp#38), reported
+    # before the denylist would ever see an in-worktree relative path.
+    cwd = _make_worktree(tmp_path)
+    reason = _destination_veto_reason(
+        _POLICY, "git show e95a9d8f:payload > esc/.git/hooks/x", cwd
+    )
+    assert reason is not None
+    assert "outside the worktree" in reason
+
+
+# cpp#38 + cpp#42 — full handler integration (interrupt semantics preserved)
+
+
+def test_dest_validator_handler_denies_with_interrupt(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    handler = create_permission_handler(
+        config=None, relay=False, verbose=False, cwd=cwd, policy_path=_BUNDLED
+    )
+    result = asyncio.run(
+        handler("Bash", _bash("git show e95a9d8f:payload > .git/hooks/post-checkout"), _mock_ctx())
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert result.interrupt is True
+
+
+def test_dest_validator_handler_allows_legit_in_worktree(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    handler = create_permission_handler(
+        config=None, relay=False, verbose=False, cwd=cwd, policy_path=_BUNDLED
+    )
+    result = asyncio.run(
+        handler("Bash", _bash("git show e95a9d8f:legit > docs/plans/X-plan.md"), _mock_ctx())
+    )
+    assert isinstance(result, PermissionResultAllow)
 
 
 # ── Handler end-to-end: interrupt semantics (cpp#20 joint 2) ─────────────────

--- a/tests/test_policy_devpilot.py
+++ b/tests/test_policy_devpilot.py
@@ -517,7 +517,7 @@ def _dest_effective(cmd: str, cwd: str, policy: Policy = _POLICY) -> str:
         return d.decision
     if not _bash_allow_is_chain_safe(policy, "Bash", _bash(cmd)):
         return "deny"
-    if _destination_veto_reason(policy, cmd, cwd) is not None:
+    if _destination_veto_reason(cmd, cwd) is not None:
         return "deny"
     return "allow"
 
@@ -580,8 +580,29 @@ def test_dest_validator_ac42_control_plane_denied(cmd: str, tmp_path: Path) -> N
 
 def test_dest_validator_ac42_7_gitignore_allowed(tmp_path: Path) -> None:
     cwd = _make_worktree(tmp_path)
-    # Top-level dotfile — NOT control plane; `^\.git/` requires the trailing slash.
+    # Top-level dotfile — NOT control plane; the `(/|$)` anchor stops at `.git`
+    # only when followed by `/` or end, so `.gitignore` (next char `i`) passes.
     assert _dest_effective("git show e95a9d8f:payload > .gitignore", cwd) == "allow"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # Bare control-plane directory/file targets: the write lands ON or INSIDE
+        # the control plane even though the operand has no trailing path. The
+        # `(/|$)` anchor closes this — a bare-slash `^\.git/` would have let these
+        # through (regression guard for the `-t` and bare-dest evasion class).
+        "cp source .git",                 # overwrites the worktree gitdir pointer file
+        "git show e95a9d8f:payload > .git",
+        "cp -t .git source",              # writes .git/source
+        "cp -t .claude evil.md",          # writes .claude/evil.md
+        "cp -t .mika source",             # writes .mika/source
+        "mkdir .claude",                  # re-creates / targets the control-plane dir
+    ],
+)
+def test_dest_validator_bare_control_plane_target_denied(cmd: str, tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective(cmd, cwd) == "deny"
 
 
 def test_dest_validator_well_known_agents_anchored_exact(tmp_path: Path) -> None:
@@ -606,7 +627,7 @@ def test_dest_validator_containment_precedes_control_plane(tmp_path: Path) -> No
     # before the denylist would ever see an in-worktree relative path.
     cwd = _make_worktree(tmp_path)
     reason = _destination_veto_reason(
-        _POLICY, "git show e95a9d8f:payload > esc/.git/hooks/x", cwd
+        "git show e95a9d8f:payload > esc/.git/hooks/x", cwd
     )
     assert reason is not None
     assert "outside the worktree" in reason
@@ -636,6 +657,147 @@ def test_dest_validator_handler_allows_legit_in_worktree(tmp_path: Path) -> None
         handler("Bash", _bash("git show e95a9d8f:legit > docs/plans/X-plan.md"), _mock_ctx())
     )
     assert isinstance(result, PermissionResultAllow)
+
+
+# cp -t / --target-directory / combined short-flag target forms: the real write
+# destination is <DIR>/<src>, so DIR must be the validated operand (else a benign
+# source operand is checked while bytes land in an unchecked directory).
+
+
+@pytest.mark.parametrize(
+    "cmd, expected",
+    [
+        ("cp -t out/ a b", ["out/"]),
+        ("cp --target-directory out/ a b", ["out/"]),
+        ("cp --target-directory=out/ a b", ["out/"]),
+        ("cp -rt out/ a b", ["out/"]),            # combined short flags ending in t
+        ("cp -vt out/ a", ["out/"]),
+        ("mv -t out/ a", ["out/"]),
+        ("cp a b c dest/", ["dest/"]),            # no -t: last positional is dest
+        ("cp a b", ["b"]),
+        ("cp a", None),                            # no destination -> fail closed
+    ],
+)
+def test_extract_cp_mv_destination(cmd: str, expected: object) -> None:
+    from claude_pilot.permissions import _extract_cp_mv_destination
+
+    assert _extract_cp_mv_destination(cmd) == expected
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cp -rt esc payload",                      # combined short flag -> symlink escape
+        "cp -vt esc payload",
+        "cp -t esc payload",                       # plain -t -> symlink escape
+        "cp -rt .github/workflows evil.yml",       # combined short flag -> control plane
+        "cp --target-directory=.claude evil.md",   # =form -> control plane
+    ],
+)
+def test_dest_validator_target_directory_forms_denied(cmd: str, tmp_path: Path) -> None:
+    worktree = tmp_path / "wt"
+    (worktree / ".github" / "workflows").mkdir(parents=True)
+    (worktree / ".claude").mkdir()
+    (tmp_path / "OUTSIDE").mkdir()
+    (worktree / "esc").symlink_to("../OUTSIDE")
+    assert _dest_effective(cmd, str(worktree)) == "deny"
+
+
+@pytest.mark.parametrize(
+    "cmd, src_marker",
+    [
+        ("git show e95a9d8f:payload >x", "x"),     # no space after >
+        ("git show e95a9d8f:payload > x", "x"),
+        ("git show e95a9d8f:payload >  x", "x"),   # multiple spaces
+    ],
+)
+def test_extract_git_show_redirect_whitespace(cmd: str, src_marker: str) -> None:
+    from claude_pilot.permissions import _extract_write_destinations
+
+    assert _extract_write_destinations("bash-git-show-redirect", cmd) == [src_marker]
+
+
+def test_dest_validator_compound_nonleading_segment_escape(tmp_path: Path) -> None:
+    # The per-segment loop must validate a NON-leading write segment, not just the
+    # first. A clean leading mkdir followed by an escaping cp must still deny.
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("mkdir docs/x && cp s esc/p", cwd) == "deny"
+
+
+def test_dest_validator_compound_nonleading_segment_control_plane(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("mkdir docs/x && cp s .git/config", cwd) == "deny"
+
+
+def test_dest_validator_mkdir_multi_target_one_bad(tmp_path: Path) -> None:
+    # mkdir validates EVERY directory operand: one good + one escaping -> deny.
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("mkdir -p docs/ok esc/bad", cwd) == "deny"
+
+
+def test_dest_validator_mkdir_multi_target_all_good(tmp_path: Path) -> None:
+    cwd = _make_worktree(tmp_path)
+    assert _dest_effective("mkdir -p docs/a docs/b", cwd) == "allow"
+
+
+def test_extract_mkdir_destinations_multi() -> None:
+    from claude_pilot.permissions import _extract_mkdir_destinations
+
+    assert _extract_mkdir_destinations("mkdir -p a/b c/d") == ["a/b", "c/d"]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # P0 (cpp#42 adversarial review): embedding ` grep ` / `;jq` in an operand
+        # shadows the write rule under first-match-wins policy.evaluate, but the
+        # segment is still a cp/mv/mkdir write. Structural classification (leading
+        # command word) must catch these regardless of which policy rule matched.
+        'cp "payload grep x" .git/hooks/post-checkout',   # shadow -> control plane
+        'cp "payload grep x" esc/passwd',                 # shadow -> worktree escape
+        'mv "x grep y" esc/secret',
+        'mkdir ".git/hooks/x grep y"',
+        'cp "a;jq b" esc/passwd',                         # jq shadow
+        # Quoted destination with spaces: shlex tokenization must yield the real
+        # path so the symlink / control-plane component is seen (str.split would
+        # fragment it and validate the wrong token).
+        'cp src "esc/a grep b"',                          # escaping dest, quoted
+        'cp src ".git/hooks/post checkout"',              # control-plane dest, quoted
+    ],
+)
+def test_dest_validator_shadow_rule_and_quoted_dest_denied(cmd: str, tmp_path: Path) -> None:
+    worktree = tmp_path / "wt"
+    (worktree / ".git" / "hooks").mkdir(parents=True)
+    (tmp_path / "OUTSIDE").mkdir()
+    (worktree / "esc").symlink_to("../OUTSIDE")
+    assert _dest_effective(cmd, str(worktree)) == "deny"
+
+
+def test_dest_validator_shadow_bypass_blocked_through_handler(tmp_path: Path) -> None:
+    # End-to-end through the production handler: the shadowed write must DENY with
+    # interrupt=True, not slip through as an allow.
+    worktree = tmp_path / "wt"
+    (worktree / ".git" / "hooks").mkdir(parents=True)
+    handler = create_permission_handler(
+        config=None, relay=False, verbose=False, cwd=str(worktree), policy_path=_BUNDLED
+    )
+    result = asyncio.run(
+        handler("Bash", _bash('cp "payload grep x" .git/hooks/post-checkout'), _mock_ctx())
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert result.interrupt is True
+
+
+def test_dest_validator_fail_closed_on_unparseable_destination(tmp_path: Path) -> None:
+    # KTD-6: a write-capable rule whose destination cannot be parsed is vetoed.
+    # `cp -t out/` (target flag but no source/positional after) yields a dest the
+    # extractors cannot resolve into a real write -> fail-closed deny is exercised
+    # via a directly-constructed veto check on the extractor's None path.
+    from claude_pilot.permissions import _extract_write_destinations
+
+    assert _extract_write_destinations("bash-cp-mv", "cp a") is None
+    assert _extract_write_destinations("bash-git-show-redirect", "git show") is None
+    assert _extract_write_destinations("bash-mkdir", "mkdir") is None
 
 
 # ── Handler end-to-end: interrupt semantics (cpp#20 joint 2) ─────────────────


### PR DESCRIPTION
## Why

claude-pilot's deterministic permission policy gates write-capable Bash rules — `bash-git-show-redirect`, `bash-cp-mv`, `bash-mkdir` — by command-string **shape** only, with no view of the filesystem. Two empirically-confirmed bypasses survived it:

- **cpp#38 — symlink traversal (out-of-worktree write).** A committed symlink `esc -> ../OUTSIDE` turns `git show <SHA>:payload > esc/passwd` (and the `cp`/`mv`/`mkdir` variants) into a write *outside* the worktree. The static regex rejects literal `../` but is blind to a symlinked component.
- **cpp#42 — control-plane overwrite (in-worktree, higher severity, no pre-plant).** `git show <SHA>:payload > .git/hooks/post-checkout` resolves to a *genuinely in-worktree* path, so even a containment check passes it — yet the write executes on next checkout / in CI / rewrites the agent's own slash commands and bundled skills.

## What

A single **destination validator** (`_destination_veto_reason`) invoked at the one point every write-capable allow is honored — the handler in `create_permission_handler`, right after `_bash_allow_is_chain_safe`. For each write segment it runs two ordered checks on the destination operand(s):

1. **Worktree containment FIRST** (load-bearing safety, closes cpp#38) — reuses `tier1.is_within_project` resolve-and-contain.
2. **Control-plane denylist SECOND** (layered policy, closes cpp#42) — anchored literal-prefix match on the canonical worktree-relative resolved path.

Either failure vetoes the allow and the pilot halts honestly via the existing `interrupt=True` path. `Path.resolve` TOCTOU residual is accepted (parity with the Write tool's `is_within_project`).

### Every write-capable structural rule routes through the validator

| Rule | Write destination validated |
|------|------------------------------|
| `bash-git-show-redirect` | redirect target after `>` |
| `bash-cp-mv` | last positional, or `-t`/`--target-directory`/combined-`-rt` target |
| `bash-mkdir` | every directory operand |

`cp`/`mv`/`mkdir` are absent from tier1's `SAFE_SHELL_COMMANDS` and `git show … >` is rejected by tier1's metachar scan, so all three reach an allow **only** through the Tier-2 policy path — one chokepoint, no per-rule duplication.

## AC matrices — all pass

**cpp#38:** AC38.1 `git show > esc/passwd` (symlink) DENY · AC38.2 `cp src esc/passwd` DENY · AC38.3 `mv` DENY · AC38.4 `mkdir esc/newdir` DENY · AC38.5 `git show > docs/plans/X-plan.md` ALLOW · AC38.6 `cp src docs/plans/copy.md` ALLOW.

**cpp#42:** AC42.1 `> .git/hooks/post-checkout` DENY · AC42.2 `> .github/workflows/ci.yml` DENY · AC42.3 `> .claude/commands/mika.md` DENY · AC42.4 `> skills/bundled/dispatch-lib.sh` DENY · AC42.5 `cp src .git/config` DENY · AC42.7 `.gitignore` ALLOW.

## Review hardening (this PR includes the review fixes)

A full adversarial + correctness review (incl. cross-model) found three real bypasses in the first cut, all closed here:

- **P0 (rule-shadow):** write-capability was keyed on `policy.evaluate`'s first-match-wins `rule_id`; `bash-grep`'s `\sgrep\s` matches ` grep ` anywhere, so `cp "payload grep x" .git/hooks/post-checkout` evaluated to `rule_id=bash-grep` and skipped validation. Now classified **structurally** by the segment's leading command word (rule-order-independent).
- **P1 (combined target-flag):** `cp -rt DIR src` mis-identified the destination. Now detects `-[A-Za-z]*t` clusters.
- **P1 (bare control-plane target):** the denylist required a trailing slash (so `.gitignore` passes), letting bare `.git` / `cp -t .claude x` / `git show … > .git` through. Anchored each pattern with `(/|$)`.
- **Quoted-operand evasion:** operands tokenized with `shlex` (POSIX word-split, fail-closed) instead of `str.split`, so a quoted spaced path isn't fragmented.

## Tests

516 → 570 (+54). Full AC matrices for both tickets exercised through `_dest_effective` and the production handler (interrupt semantics), plus: shadow-rule matrix (`grep`/`jq`) end-to-end, combined/`-t`/`--target-directory` forms, quoted destinations, compound non-leading segments, mkdir multi-target, fail-closed, bare-target denials, and direct extraction units. `ruff` + `mypy` clean.

## Out of scope / residuals

- **Adjacent finding filed as cpp#60:** `command` is safe-listed in tier1 unguarded, so `command cp/tee/mkdir …` bypasses Tier 2 entirely (a tier1 allowlist-soundness bug of the cpp#27/#33/#40 class — needs its own isolated adversarial review, not a drive-by in this security PR).
- Denylist residuals to evidence-gate next (noted in the security doc §11): `.github/actions/`, `.github/CODEOWNERS`, `.github/dependabot.yml`.
- `Path.resolve` TOCTOU accepted (documented, parity with Write tool).

## Security boundary

Per cpp#38/#42 ACs: **must not be author-self-merged** — this changes the permission classifier. Adversarial / executed-exploit review (done in-pipeline above) before merge; an independent human/agent sign-off is still required to land.

Closes #38
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)