### PR TITLE
fix(agent): prevent ScheduleWakeup from stalling headless pilot sessions (cpp#59)

### DIFF
--- a/docs/plans/2026-06-30-053-fix-59-schedulewakeup-headless-noop-plan.md
+++ b/docs/plans/2026-06-30-053-fix-59-schedulewakeup-headless-noop-plan.md
@@ -1,0 +1,247 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+origin: senara-solutions/claude-pilot-py#59
+date: 2026-06-30
+type: fix
+---
+
+# fix: Prevent `ScheduleWakeup` from silently stalling headless claude-pilot sessions (cpp#59)
+
+## Summary
+
+In headless claude-pilot SDK sessions, the model occasionally calls the `ScheduleWakeup`
+tool as a "wait" primitive after dispatching an `Agent`/`Explore` subagent. `ScheduleWakeup`
+is Claude Code's `/loop` dynamic-pacing primitive: it schedules a future wake that the
+**interactive** harness handles. In headless SDK mode there is no harness to fire the wake —
+the call is a no-op, the model concludes "nothing more to do this turn," and the session
+ends (`PIPELINE_INCOMPLETE`). Founding incident: mika#1652 dev-groom pilot stalled at
+$2.36 / 11 turns with no plan written.
+
+This plan adds two guards in `src/claude_pilot/agent.py`: a **load-bearing system-prompt
+prevention hint** and a **defense-in-depth tool-surface exclusion** (`disallowed_tools`).
+
+> **Mechanism correction (load-bearing — read before implementing).** The originating
+> ticket/brief proposed denying `ScheduleWakeup` in `tier1.py`'s `TIER3_PATTERNS` (a Bash
+> deny-list). That fix is **inert** and must NOT be implemented. See Problem Frame for the
+> hard evidence. The viable fix lives in `agent.py`, not `tier1.py`/`permissions.yaml`.
+
+---
+
+## Problem Frame
+
+### Why the originally-specified fix is impossible
+
+1. **`TIER3_PATTERNS` only scan Bash command *strings*.** `is_tier3_dangerous()` is called
+   solely from `is_safe_bash_command()`, which runs only when `tool_name == "Bash"`
+   (`src/claude_pilot/tier1.py:32-36`, `:395`). `ScheduleWakeup` is a separate tool; a regex
+   added there would never execute against it.
+
+2. **`ScheduleWakeup` never reaches claude-pilot's permission layer.** The incident
+   transcript (session `d70b3d70…`, tool-use at line 46, tool-result at line 47) shows the
+   call returned `is_error=false` with the harness's own message: *"Next wakeup scheduled…
+   the harness re-invokes you when the wakeup fires."* claude-pilot has **no allow path** for
+   it — `is_tier1_auto_approve` → `False`, `try_tier_1_5_auto_answer` → `None`, policy default
+   → `deny` (`src/claude_pilot/policy.py:64-65`) which maps to
+   `PermissionResultDeny(interrupt=True)` (`src/claude_pilot/permissions.py:376-378`). Had the
+   call reached `can_use_tool`, it would have **halted with a deny**, not succeeded. It
+   succeeded → the SDK/CLI runtime handles `ScheduleWakeup` **internally** and bypasses
+   `can_use_tool` entirely. No `tier1.py` or `permissions.yaml` rule can intercept it.
+
+3. **Authoritative SDK guidance** (claude-agent-sdk 0.2.110): `ScheduleWakeup` is a
+   harness/CLI runtime primitive, not a permissionable SDK tool; it is never surfaced to
+   `can_use_tool`; and in headless SDK mode it is structurally non-functional (fire-and-forget,
+   nothing re-invokes the session).
+
+### What actually works
+
+- **System-prompt hint** — already the established prevention channel (mika#1409,
+  `DENIED_BASH_PATTERNS_HINT` injected via `_system_prompt_with_hint()` at
+  `src/claude_pilot/agent.py:295`). The model reads it. **Load-bearing guard.**
+- **`disallowed_tools=["ScheduleWakeup"]`** on `ClaudeAgentOptions` → CLI `--disallowedTools`.
+  Transcript evidence shows `ScheduleWakeup` is a real surfaced/executed tool (genuine harness
+  `tool_result`, not "tool not found"), so a bare-name deny *should* remove it from the request
+  per SDK docs. **But the SDK docs do not definitively confirm `--disallowedTools` filters
+  runtime primitives** — so this is documented defense-in-depth, not the load-bearing guard.
+
+### Honest-closure boundary
+
+Per project doctrine (`feedback_prompt_enforcement_fragile`,
+`feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate`), prompt-only
+enforcement **reduces the rate** of a stochastic trap but does **not close the class** — the
+existing `DENIED_BASH_PATTERNS_HINT` carries the same honesty note. If `disallowed_tools` is
+empirically confirmed to suppress the tool (AC5), the structural guard closes the class; if
+not, the hint remains a rate-reducer only. The plan documents whichever outcome holds.
+
+---
+
+## Requirements
+
+- **R1.** The headless pilot's system prompt instructs the model never to call
+  `ScheduleWakeup` (and why: no harness wake → the session ends), and that a dispatched
+  `Agent`/subagent result is already available synchronously next turn so no "wait" is needed.
+- **R2.** `ScheduleWakeup` is added to `ClaudeAgentOptions.disallowed_tools` as documented
+  defense-in-depth, with the runtime-primitive uncertainty noted in a code comment.
+- **R3.** The prevention hint stays co-located with the existing prevention-hint family so
+  documentation cannot drift from enforcement, carrying an honest-closure note.
+- **R4.** Existing tests stay green (446+ floor from cpp PR57); `ruff` + `mypy` clean.
+- **R5.** Empirically determine whether `disallowed_tools=["ScheduleWakeup"]` suppresses the
+  call in a real headless session; record the result honestly in the PR.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Extend `DENIED_BASH_PATTERNS_HINT` in place rather than adding a new constant.**
+  `_system_prompt_with_hint()` appends exactly that constant, and `test_agent.py:444` asserts
+  `append == DENIED_BASH_PATTERNS_HINT`. Adding a new `## Tools that are no-ops in headless
+  mode` section *inside* the constant keeps the wiring and the equality test intact (zero
+  churn to `agent.py`'s append shape) and satisfies the co-location requirement (R3). The
+  constant's role is "the model-facing prevention-hint payload," which a harness-no-op section
+  fits; a short comment notes the name predates the broadened scope. Rejected: a sibling
+  constant concatenated in `_system_prompt_with_hint()` — more churn, breaks the equality test,
+  no real benefit at this size.
+
+- **KTD2 — Keep `disallowed_tools` as best-effort defense-in-depth, not the primary guard.**
+  Include it (harmless if it no-ops; structural if it works) but document the uncertainty so a
+  future reader does not mistake it for a proven hard block. The hint is load-bearing.
+
+- **KTD3 — Reject the SDK guide's `permission_mode="dontAsk"` + `allowed_tools` allowlist.**
+  That would replace claude-pilot's entire tiered relay/policy permission architecture
+  (`permission_mode="default"` + `can_use_tool` + `policy.py`). Out of scope and architecturally
+  wrong for this repo.
+
+---
+
+## Implementation Units
+
+### U1. System-prompt prevention hint for headless no-op harness tools
+
+**Goal:** Tell the model, in the injected system prompt, never to call `ScheduleWakeup` in
+headless mode and what to do instead.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** none.
+
+**Files:**
+- `src/claude_pilot/tier1.py` — extend `DENIED_BASH_PATTERNS_HINT` with a new
+  `## Tools that are no-ops in headless mode` section naming `ScheduleWakeup`, explaining the
+  no-harness-wake failure mode, and stating that a dispatched `Agent`/subagent result is already
+  available synchronously next turn (so no "wait" is needed). Add a one-line comment noting the
+  constant's scope now covers harness-no-op tools as well as denied Bash patterns, plus the
+  honest-closure note (prompt-only reduces rate, does not close the class).
+- `tests/test_agent.py` — add a test asserting the appended hint contains the
+  `ScheduleWakeup` headless block and the "synchronous subagent result" guidance.
+
+**Approach:** Pure string-constant edit + a co-located comment. No change to
+`_system_prompt_with_hint()` or `agent.py` wiring — the existing append already carries the
+extended constant verbatim.
+
+**Patterns to follow:** Mirror the existing `DENIED_BASH_PATTERNS_HINT` block style and its
+honest-closure note (`src/claude_pilot/tier1.py:161-214`). Mirror the existing assertion style
+in `test_1409_system_prompt_helper_is_preset_append_with_hint`
+(`tests/test_agent.py:435-445`).
+
+**Test scenarios:**
+- The string returned by `_system_prompt_with_hint()["append"]` contains `"ScheduleWakeup"`.
+- It contains the headless-mode no-op section header (e.g. `"no-ops in headless mode"`).
+- It contains the synchronous-subagent guidance (e.g. asserts the substring about the Agent/
+  subagent result already being available / not needing to wait).
+- The existing `append == DENIED_BASH_PATTERNS_HINT` equality assertion still passes (regression
+  guard — do not break it).
+
+**Verification:** `uv run pytest tests/test_agent.py` green; the new assertions pass and the
+pre-existing mika#1409 system-prompt tests still pass.
+
+### U2. `disallowed_tools` tool-surface exclusion (defense-in-depth)
+
+**Goal:** Add `ScheduleWakeup` to the SDK tool-deny list so, where the runtime honors it, the
+model never sees the tool.
+
+**Requirements:** R2.
+
+**Dependencies:** none (independent of U1; can land in the same commit).
+
+**Files:**
+- `src/claude_pilot/agent.py` — add `disallowed_tools=["ScheduleWakeup"]` to the
+  `ClaudeAgentOptions(...)` constructor (`src/claude_pilot/agent.py:62-69`), with a comment
+  documenting: (a) `ScheduleWakeup` is a harness runtime primitive, (b) SDK docs do not
+  definitively confirm `--disallowedTools` filters runtime primitives, (c) the system-prompt
+  hint (U1) is the load-bearing guard, (d) cross-ref cpp#59.
+- `tests/test_agent.py` — add a test asserting the captured `ClaudeAgentOptions` kwargs include
+  `disallowed_tools` containing `"ScheduleWakeup"`.
+
+**Approach:** One kwarg on the options constructor + an explanatory comment. Reuse the existing
+`_capturing_options` monkeypatch harness to assert the wiring end-to-end.
+
+**Patterns to follow:** Mirror `test_1409_run_agent_passes_system_prompt_into_options`
+(`tests/test_agent.py:448-476`) — the `_capturing_options` monkeypatch that captures
+`ClaudeAgentOptions` kwargs.
+
+**Test scenarios:**
+- `run_agent(...)` constructs `ClaudeAgentOptions` with `disallowed_tools` present and
+  containing `"ScheduleWakeup"` (via the `_capturing_options` capture).
+
+**Verification:** `uv run pytest tests/test_agent.py` green; `uv run ruff check` and
+`uv run mypy src` clean.
+
+---
+
+## Verification Contract
+
+- `uv run pytest` — full suite green, ≥446 tests (cpp PR57 floor preserved).
+- `uv run ruff check` — clean.
+- `uv run mypy src` — clean.
+- **AC5 / R5 empirical check (manual, documented in PR):** Run (or reuse) a headless pilot
+  session and confirm whether `disallowed_tools=["ScheduleWakeup"]` actually prevents the
+  model from issuing a successful `ScheduleWakeup` `tool_use`. Record the observed behavior
+  honestly in the PR body:
+  - If suppressed → note that the structural guard closes the class; hint is belt-and-suspenders.
+  - If NOT suppressed → note that the hint is the active guard and `disallowed_tools` stays as
+    documented best-effort. Either outcome is an acceptable, honest close.
+
+---
+
+## Definition of Done
+
+- U1 and U2 implemented per the file lists above.
+- All Verification Contract gates pass (pytest ≥446 green, ruff clean, mypy clean).
+- The AC5 empirical outcome is recorded in the PR body (suppressed or not — honestly stated).
+- PR body documents the **mechanism correction** (tier1/policy deny is inert; fix is in
+  `agent.py`) and surfaces it for architect/orchestrator awareness, since the groomed shape
+  was wrong.
+- PR closes cpp#59.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the two `agent.py`-layer guards for `ScheduleWakeup` and their tests.
+
+### Out of scope (non-goals)
+
+- Any `tier1.py` `TIER3_PATTERNS` or `permissions.yaml` rule for `ScheduleWakeup` — **inert,
+  would be misleading dead code.**
+- Switching to `permission_mode="dontAsk"` + `allowed_tools` allowlist (KTD3).
+- Re-routing `ScheduleWakeup` to an in-headless equivalent (no harness wake → no equivalent).
+
+### Deferred to Follow-Up Work
+
+- Enumerating *all* interactive-only harness tools for headless exclusion — no n=2 yet on a
+  second harness-only tool. Revisit when a different one traps a session.
+
+---
+
+## Sources & Research
+
+- cpp#59 issue body (hard evidence, frequency baseline 1/139 sessions).
+- Incident transcript `~/.claude/projects/…fix-1652…/d70b3d70-4fa9-44b8-afdc-2d7acaa5f45b.jsonl`
+  (lines 46-47: the `is_error=false` harness success result that proves `can_use_tool` was
+  bypassed).
+- claude-agent-sdk 0.2.110 — `ClaudeAgentOptions.disallowed_tools` → `--disallowedTools`
+  (`subprocess_cli.py:265-266`); permission-evaluation flow docs.
+- Existing prevention-hint prior art: `src/claude_pilot/tier1.py` `DENIED_BASH_PATTERNS_HINT`
+  (mika#1409); `src/claude_pilot/agent.py:295` `_system_prompt_with_hint()`.

--- a/docs/solutions/tooling-decisions/harness-runtime-tools-bypass-can-use-tool.md
+++ b/docs/solutions/tooling-decisions/harness-runtime-tools-bypass-can-use-tool.md
@@ -1,0 +1,130 @@
+---
+title: "Harness/CLI runtime tools (ScheduleWakeup) bypass claude-pilot's can_use_tool — tier1/policy denies are inert"
+date: 2026-06-30
+problem_type: tooling_decision
+track: knowledge
+module: permissions
+component: permission-classifier
+tags:
+  - claude-pilot
+  - can_use_tool
+  - tier1
+  - policy
+  - schedulewakeup
+  - sdk
+  - headless
+applies_when: "A ticket or instinct says 'deny tool X in claude-pilot' (tier1.py / permissions.yaml), or a headless pilot session silently ends after calling a Claude Code interactive primitive (ScheduleWakeup, /loop pacing, etc.)."
+---
+
+# Harness/CLI runtime tools bypass claude-pilot's `can_use_tool`
+
+## Context
+
+claude-pilot intercepts tool permissions via the Agent SDK's `can_use_tool`
+callback, then runs a tiered classifier — `tier1.py` (auto-approve allow-list),
+`tier1.5` (deterministic auto-answer), `policy.py` (`permissions.yaml`,
+default-deny). The natural assumption is that *every* tool the model calls flows
+through this chain, so "deny tool X" means "add a rule to tier1/policy."
+
+**That assumption is false for a whole class of tools.** Some tools are
+**Claude Code harness/CLI runtime primitives** — handled internally by the CLI
+runtime before/without ever consulting `can_use_tool`. For those tools, no
+`tier1.py` regex and no `permissions.yaml` rule can intercept the call. A deny
+added there is **structurally inert dead code** that *looks* like protection.
+
+Founding case: cpp#59. A headless dev-groom pilot called `ScheduleWakeup` (the
+`/loop` dynamic-pacing primitive) to "wait" for a dispatched subagent, then the
+session silently ended (`PIPELINE_INCOMPLETE`, $2.36 wasted, mika#1652). The
+originating ticket proposed denying `ScheduleWakeup` in `tier1.py`'s
+`TIER3_PATTERNS` — which only ever scan **Bash command strings**
+(`is_tier3_dangerous` runs solely under `tool_name == "Bash"`), so it could
+never fire for a non-Bash tool anyway. The deeper finding is below.
+
+## Guidance
+
+**Before adding any "deny tool X" rule to claude-pilot's classifier, confirm X
+actually routes through `can_use_tool`.** The cheapest authoritative check is the
+incident transcript: look at the `tool_result` for the call.
+
+- If claude-pilot **denied** it, the result is an error (`is_error=true`) carrying
+  the policy reason — the call reached `can_use_tool`, and a tier1/policy rule
+  *can* control it.
+- If the result is `is_error=false` with the **harness's own success message**
+  (e.g. `"Next wakeup scheduled … the harness re-invokes you when the wakeup
+  fires"`), the SDK runtime handled it internally. `can_use_tool` never saw it.
+  No classifier rule will ever catch it.
+
+Corroborating signal: claude-pilot has **no allow path** for an unknown tool
+(`tier1` → `False`, `tier1.5` → `None`, policy default → `deny` +
+`interrupt=True`). So if such a tool *succeeds*, it provably bypassed the chain —
+had it reached `can_use_tool`, the default-deny would have **halted** the session
+with a deny message, not returned success.
+
+**Where the viable controls live (SDK options layer, `agent.py`):**
+
+1. **System-prompt hint — load-bearing.** Append guidance to the SDK system
+   prompt (claude-pilot does this via `DENIED_BASH_PATTERNS_HINT` +
+   `_system_prompt_with_hint()`, the preset-append shape from mika#1409). The
+   model reads it; this is the only channel that actually reaches the model for
+   this class. cpp#59 added a "Tools that are no-ops in headless mode" section
+   naming `ScheduleWakeup` and noting that a dispatched subagent result is
+   already available synchronously, so no "wait" is needed.
+2. **`disallowed_tools=[...]` — best-effort defense-in-depth.** Maps to the CLI
+   `--disallowedTools` flag. A bare-name deny *should* remove a surfaced tool
+   from the request, but the SDK docs do **not** definitively confirm
+   `--disallowedTools` filters *runtime primitives* — so treat it as
+   belt-and-suspenders, not the load-bearing guard.
+
+**Honest-closure boundary:** prompt-only enforcement reduces the **rate** of a
+stochastic trap (ScheduleWakeup was n=1 of 139 sessions) but does not close the
+class — the same honesty note `DENIED_BASH_PATTERNS_HINT` already carries. The
+class closes only if `disallowed_tools` is empirically confirmed to suppress the
+tool.
+
+## Why This Matters
+
+Adding an inert deny to tier1/policy is worse than doing nothing: it reads as
+"handled" in the diff and the ticket closes, while the trap remains live. The
+diagnostic — "does this tool route through `can_use_tool` at all?" — is a 30-
+second transcript check that redirects the fix from a dead layer to the layer
+that can actually act. It also generalizes: any future Claude Code
+interactive-only primitive (not just `ScheduleWakeup`) will exhibit the same
+bypass, so the same agent.py-layer controls apply.
+
+## When to Apply
+
+- A ticket says "deny / block / disallow tool X in claude-pilot" and X is **not**
+  Bash, Read, Glob, Grep, Write, Edit, or Skill (the tools the classifier
+  actually sees).
+- A headless pilot session ends unexpectedly right after calling a Claude Code
+  interactive feature (`ScheduleWakeup`, `/loop`-related pacing, or any
+  harness-driven wait/resume primitive).
+- You are about to write a `TIER3_PATTERNS` entry or a `permissions.yaml` rule
+  for a tool and have not first confirmed the tool reaches `can_use_tool`.
+
+## Examples
+
+**Inert (do NOT do this) — tier1/policy deny for a runtime primitive:**
+
+```python
+# tier1.py TIER3_PATTERNS — NEVER fires for ScheduleWakeup:
+# these regexes only scan Bash command strings (is_tier3_dangerous is gated on
+# tool_name == "Bash"). ScheduleWakeup is a separate tool → never matched.
+re.compile(r"\bScheduleWakeup\b"),   # dead code
+```
+
+**Viable (cpp#59) — controls at the SDK options layer in `agent.py`:**
+
+```python
+options = ClaudeAgentOptions(
+    ...
+    system_prompt=_system_prompt_with_hint(),   # load-bearing: hint names ScheduleWakeup
+    disallowed_tools=["ScheduleWakeup"],         # best-effort: maps to --disallowedTools
+    ...
+)
+```
+
+Related: `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md`
+(the other load-bearing learning on the same permission-classifier surface — but
+that one is about commands the classifier *does* see; this one is about a tool it
+never sees).

--- a/src/claude_pilot/agent.py
+++ b/src/claude_pilot/agent.py
@@ -66,6 +66,19 @@ async def run_agent(
         can_use_tool=permission_handler,
         include_partial_messages=True,
         system_prompt=_system_prompt_with_hint(),
+        # cpp#59 — defense-in-depth tool-surface exclusion. `ScheduleWakeup` is a
+        # Claude Code harness/CLI runtime primitive (the `/loop` pacing tool),
+        # NOT a permissionable SDK tool: the runtime handles it internally and
+        # bypasses can_use_tool entirely, so a tier1/policy deny is structurally
+        # inert (see DENIED_BASH_PATTERNS_HINT scope note). In headless SDK mode
+        # it is a no-op that strands the session (mika#1652). `disallowed_tools`
+        # maps to the CLI `--disallowedTools` flag; transcript evidence shows
+        # ScheduleWakeup IS a real surfaced/executed tool, so a bare-name deny
+        # SHOULD remove it from the request — but the SDK docs do not definitively
+        # confirm --disallowedTools filters runtime primitives, so this is
+        # best-effort. The LOAD-BEARING guard is the system-prompt hint above;
+        # this is harmless if it no-ops and structural if the runtime honors it.
+        disallowed_tools=["ScheduleWakeup"],
         **_sdk_guardrail_kwargs(config),
     )
 

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -178,6 +178,18 @@ def is_tier3_dangerous(command: str) -> bool:
 # NOT close the session-fatality class. Novel denied patterns still crash the
 # session — that class closes only when cpp#20 joint 2's contract is revised to
 # distinguish adaptation from fabrication (mika#1410).
+#
+# Scope note (cpp#59): this constant grew beyond denied-Bash patterns. It is the
+# single model-facing prevention-hint payload appended to the system prompt, and
+# now also carries a "no-ops in headless mode" section for harness/runtime tools
+# (ScheduleWakeup) that claude-pilot's permission layer CANNOT intercept — the
+# SDK/CLI runtime handles them internally, bypassing can_use_tool entirely, so a
+# tier1/policy deny is structurally inert. The system-prompt hint is the only
+# channel that reaches the model for that class. The name is kept (referenced by
+# CLAUDE.md + tests) despite the broadened scope. Same honest-closure boundary:
+# prompt-only reduces the RATE of the stochastic ScheduleWakeup trap (n=1 of 139
+# sessions, mika#1652), it does not close the class; the disallowed_tools guard in
+# agent.py is best-effort defense-in-depth on top.
 DENIED_BASH_PATTERNS_HINT: str = """\
 ## Bash commands that crash this session — use the native tool instead
 
@@ -211,7 +223,21 @@ them — use the auto-approved native tool, which accomplishes the same goal:
   (Grep/Glob/Read/Edit/Write) for the underlying goal.
 
 Prefer Read, Write, Edit, Grep, and Glob over their shell equivalents: they are
-auto-approved and never halt the session."""
+auto-approved and never halt the session.
+
+## Tools that are no-ops in headless mode — never call them
+
+You are running headlessly via the Claude Agent SDK. There is NO interactive
+harness watching for wake events, so the tools below silently do nothing and
+strand your session:
+
+- `ScheduleWakeup` → schedules a future wake the INTERACTIVE harness would fire.
+  In headless mode nothing fires it: the call returns "wakeup scheduled", your
+  turn ends, and your prompted continuation NEVER runs — the session just ends
+  with the work unfinished. Never call it. If you dispatched an `Agent`/subagent
+  (e.g. Explore) and want to "wait" for its result, you do NOT need to: the
+  subagent runs synchronously and its result is already available to you in the
+  next turn. Just continue your work in-turn — read the result and proceed."""
 
 
 # ── Safe Bash command checking ───────────────────────────────────────────────

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -476,6 +476,59 @@ async def test_1409_run_agent_passes_system_prompt_into_options(
     assert "-exec" in sp["append"] and "Grep" in sp["append"]
 
 
+# ── cpp#59: ScheduleWakeup headless no-op prevention ──────────────────────────
+
+
+def test_59_system_prompt_hint_warns_against_schedulewakeup() -> None:
+    """The appended system-prompt hint must name ScheduleWakeup, explain the
+    headless no-op failure mode, and tell the model not to "wait" for a
+    synchronous subagent result. This is the LOAD-BEARING guard (the SDK runtime
+    handles ScheduleWakeup internally, bypassing the permission layer — a
+    tier1/policy deny cannot catch it)."""
+    from claude_pilot.tier1 import DENIED_BASH_PATTERNS_HINT
+
+    sp = agent_module._system_prompt_with_hint()
+    append = sp["append"]
+    # Regression guard — the preset-append wiring still carries the constant verbatim.
+    assert append == DENIED_BASH_PATTERNS_HINT
+    # The headless no-op section is present and names the tool.
+    assert "ScheduleWakeup" in append
+    assert "no-ops in headless mode" in append
+    # The "don't wait for a synchronous subagent" guidance is present.
+    assert "synchronous" in append
+    assert "Agent" in append
+
+
+@pytest.mark.asyncio
+async def test_59_run_agent_disallows_schedulewakeup_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: run_agent constructs ClaudeAgentOptions with
+    ScheduleWakeup in disallowed_tools, so where the runtime honors
+    --disallowedTools the model never sees the tool."""
+    captured: dict[str, Any] = {}
+
+    def _capturing_options(*_args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return object()  # FakeClient ignores options
+
+    monkeypatch.setattr(agent_module, "ClaudeAgentOptions", _capturing_options)
+    _install_fake_client(monkeypatch, [_init(), _result()])
+
+    await run_agent(
+        prompt="test",
+        cwd=".",
+        verbose=False,
+        task_id=None,
+        permission_handler=_noop_permission,
+        guardrails=SessionGuardrails(_config()),
+    )
+
+    disallowed = captured.get("disallowed_tools")
+    assert isinstance(disallowed, list)
+    assert "ScheduleWakeup" in disallowed
+
+
 # ── cpp#55: _extract_session_id / _extract_model read SystemMessage.data ──────
 
 


### PR DESCRIPTION
## Summary

Headless claude-pilot sessions occasionally call `ScheduleWakeup` (Claude Code's `/loop` pacing primitive) as a "wait" after dispatching a subagent. In headless SDK mode there is no harness to fire the wake — the call no-ops, the model concludes "nothing more to do this turn," and the session ends (`PIPELINE_INCOMPLETE`). Founding incident: mika#1652 dev-groom stalled at \$2.36 / 11 turns, no plan written.

Two guards in `src/claude_pilot/agent.py`:
- **Load-bearing — system-prompt hint.** Extends `DENIED_BASH_PATTERNS_HINT` with a "Tools that are no-ops in headless mode" section telling the model never to call `ScheduleWakeup` (its continuation never fires) and that a dispatched subagent result is already synchronous so no "wait" is needed. Injected via the existing preset-append channel (mika#1409).
- **Defense-in-depth — `disallowed_tools=["ScheduleWakeup"]`** (CLI `--disallowedTools`), documented best-effort.

Closes #59.

## ⚠️ Mechanism correction (for architect/orchestrator awareness)

The original ticket/brief proposed denying `ScheduleWakeup` in `tier1.py`'s `TIER3_PATTERNS` (a Bash deny-list). **That fix is structurally inert and was NOT implemented.** Hard evidence:

1. `TIER3_PATTERNS` only scan Bash command *strings* (`is_tier3_dangerous` runs solely under `tool_name == "Bash"`). `ScheduleWakeup` is a separate tool — that regex never executes against it.
2. Incident transcript (`d70b3d70…jsonl:46-47`) shows the call returned `is_error=false` with the **harness's own** success message. claude-pilot has no allow path for it (tier1→False, tier1.5→None, policy default→deny+interrupt=True), so had it reached `can_use_tool` it would have **halted with a deny**. It succeeded → **the SDK runtime handles `ScheduleWakeup` internally and bypasses `can_use_tool` entirely.** No `tier1.py`/`permissions.yaml` rule can intercept it.

The viable controls therefore live at the SDK options layer (`agent.py`), not the permission classifier. Captured as a reusable diagnostic in `docs/solutions/tooling-decisions/harness-runtime-tools-bypass-can-use-tool.md`.

## AC5 — empirical `disallowed_tools` check (honest status)

Whether `--disallowedTools` actually suppresses a *runtime primitive* like `ScheduleWakeup` was **not** empirically run in this session (live-session cost). SDK docs don't confirm it filters runtime primitives, so it stays documented best-effort; **the system-prompt hint is the load-bearing guard.** Per project doctrine (`feedback_prompt_enforcement_fragile`), prompt-only enforcement reduces the rate of this stochastic trap (n=1 of 139 sessions) but does not close the class. Next time a pilot would reach for `ScheduleWakeup`, we'll observe whether the structural guard suppressed it.

## Testing

- `uv run pytest` — **581 passed** (≥446 floor preserved); 2 new tests (system-prompt hint content + `disallowed_tools` wiring).
- `uv run ruff check` — clean.
- `uv run mypy src` — clean.

Plan: `docs/plans/2026-06-30-053-fix-59-schedulewakeup-headless-noop-plan.md`