### PR TITLE
fix(tier1): guard the `command` builtin against Tier-1 bypass (cpp#60)

### DIFF
--- a/docs/plans/2026-06-30-054-fix-60-tier1-command-builtin-guard-plan.md
+++ b/docs/plans/2026-06-30-054-fix-60-tier1-command-builtin-guard-plan.md
@@ -1,0 +1,145 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+issue: senara-solutions/claude-pilot-py#60
+branch: fix/60/tier1-command-builtin-guard
+---
+
+# fix(tier1): guard the `command` builtin — recursive closed-world classification
+
+## Summary
+
+`command` is in tier1 `SAFE_SHELL_COMMANDS` (`src/claude_pilot/tier1.py:565`) with **no inner sub-command guard**. `is_safe_shell_command` returns `True` for `command <anything>`, so `command cp …` / `command tee …` / `command mkdir …` are Tier-1 auto-approved and never reach the Tier-2 policy path or the cpp#38/#42 destination validator. Because `command` is a *run-this-other-command* wrapper, safe-listing it unguarded re-opens exactly the control-plane-write holes (`.git/hooks/*`, `.github/workflows/*`, `.claude/*`) that cpp#42 closed.
+
+Fix: special-case `command` in the `is_safe_shell_command` dispatch — the same architectural move cpp#33 (`find -exec`) and cpp#40 (`xargs`) established — routing to a new `_is_safe_command_builtin(sub)` helper that admits only the read-only `command -v`/`-V` lookup form **or** an inner command that is itself tier1-safe (recursive), and denies everything else.
+
+## Problem Frame
+
+**Evidence (issue cpp#60 body, exploit executed against current tree):**
+
+```python
+is_tier1_auto_approve("Bash", {"command": "command cp src .git/hooks/x"}, "/tmp")   # True (should be False)
+is_tier1_auto_approve("Bash", {"command": "command tee .git/x"}, "/tmp")            # True
+is_tier1_auto_approve("Bash", {"command": "command mkdir .claude/x"}, "/tmp")       # True
+```
+
+The comment at `tier1.py:564-565` states the entry's intent was only `command -v <name>` (read-only `which`-equivalent), but the bare `frozenset` membership admits any inner command. `command tee <path>` is additionally an arbitrary-file-write primitive not otherwise tier1-reachable.
+
+This is the same allowlist-soundness class as `awk`/`sed` (cpp#27, dropped) and `find`/`xargs` (cpp#33/#40, given sub-command allowlists): an allowlist entry is only as sound as each entry's read-only premise (`docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` §6).
+
+## Requirements
+
+- **R1.** `command cp/tee/mkdir/<any-non-safe-listed>` must NOT auto-approve at Tier 1 (must route to policy/relay).
+- **R2.** The existing dev-pilot footprint must keep working: `command -v <name>` lookups (`command -v lefthook`, `command -v cargo && cargo test`, `command -v gh`) continue to auto-approve. (`tests/test_tier1.py:670-672,702` are the regression anchors.)
+- **R3.** A `command <inner>` whose `<inner>` is itself a tier1-safe *shell* command (e.g. `command grep foo file`) auto-approves. `command` must be no *more* permissive than the inner command alone. It is intentionally *narrower* than full tier1-safe — the recursion re-enters `is_safe_shell_command` only, so `command cargo test`/`command git status`/`command gh …` deny (over-block, safe direction; see KTD-2). This matches the brief's explicit `is_safe_shell_command` instruction and the read-only posture of find/xargs.
+- **R4.** Shell wrappers and privilege escalation through `command` (`command sh -c …`, `command bash -c …`, `command sudo …`) continue to deny (AC4 parity with cpp#33).
+- **R5.** Command-substitution anywhere in a `command …` invocation denies (defense-in-depth mirror of `_is_safe_find_command` / `_is_safe_xargs_command`).
+
+### Decision record: brief vs. issue-body divergence
+
+The issue body proposed admitting **only** `command -v`/`-V`, routing every other `command <x>` (including read-only `command grep`) to policy. The spawn brief (this task's contract) chose the **recursive** design: `-v`/`-V` lookup *plus* recursive classification of the inner command. Both deny the actual exploit (`command cp/tee/mkdir`). The recursive design is sounder — it makes `command` a transparent pass-through with permission parity to the inner command — and it is the explicit instruction for this task. **Carried** the brief's design (it completes the closed-world-recursion intent the brief's title invokes); the divergence from the issue body's narrower proposal is intentional and noted in the PR body. This is a *carry* (completes plain intent), not an overturn of a groomed architect resolution.
+
+## Key Technical Decisions
+
+- **KTD-1 — Dispatch parity with find/xargs.** Add `if cmd == "command": return _is_safe_command_builtin(sub)` to `is_safe_shell_command` (`tier1.py:765-780`), alongside the existing `find`/`xargs` branches. The `command` entry STAYS in `SAFE_SHELL_COMMANDS` as a marker that passes the membership gate; the recursive helper is the real guard — identical pattern to `xargs` (see the comment at `tier1.py:551-555`).
+- **KTD-2 — Recursion via `is_safe_shell_command`, not `_is_safe_sub_command`.** The inner command is re-classified through `is_safe_shell_command` only (matching the narrow `FIND_EXEC_SAFE_COMMANDS` discipline find/xargs use), NOT the full dispatch (`is_safe_git_command`/`is_safe_build_command`/…). Consequence: `command git status` / `command cargo build` deny → route to policy. Over-block is the correct, safe failure direction. Recursion terminates: each call strips the leading `command ` token, so the string strictly shrinks.
+- **KTD-3 — Read-only flag allowlist is closed-world.** Only `-v` and `-V` are admitted as the lookup form. `-p` (run with default PATH — *not* read-only), `--help`, and any other leading-dash token deny. Adding `-p` or other variants is an evidence-gated follow-up, never a hunch (cpp#34 discipline).
+- **KTD-4 — Substitution guard reuses `_contains_substitution`.** Same shared helper find/xargs use (`tier1.py:634-643`), so the three gates cannot drift.
+
+## High-Level Technical Design
+
+`_is_safe_command_builtin(sub)` decision flow (directional guidance, not implementation spec):
+
+```
+sub = "command …"
+├─ _contains_substitution(sub)?           → DENY   (R5)
+├─ tokens = sub.split(); rest = tokens[1:]
+├─ rest is empty (bare `command`)?         → DENY
+├─ rest[0] in {"-v", "-V"}?                → ALLOW  (R2 read-only lookup)
+├─ rest[0].startswith("-")?                → DENY   (KTD-3 closed-world: -p, --help, …)
+└─ else recurse: is_safe_shell_command(" ".join(rest))   (R1, R3, R4)
+```
+
+Worked cases: `command -v gh` → ALLOW (rest[0]=="-v"). `command grep foo file` → recurse `is_safe_shell_command("grep foo file")` → ALLOW. `command cp src dst` → recurse → `cp` ∉ `SAFE_SHELL_COMMANDS` → DENY. `command sh -c '…'` → recurse → `sh` ∉ list → DENY. `command find . -delete` → recurse → `_is_safe_find_command` → DENY. `command -p cp src dst` → rest[0]=="-p" leading-dash, not `-v`/`-V` → DENY.
+
+---
+
+## Implementation Units
+
+### U1. Add `_is_safe_command_builtin` helper and dispatch branch
+
+**Goal:** Guard the `command` builtin so it is no more permissive than its inner command.
+
+**Requirements:** R1, R2, R3, R4, R5.
+
+**Dependencies:** none.
+
+**Files:**
+- `src/claude_pilot/tier1.py` — add `_is_safe_command_builtin(sub)` near `_is_safe_xargs_command` (after `tier1.py:762`); add the `if cmd == "command":` branch in `is_safe_shell_command` (`tier1.py:774-778`); update the `command` comment at `tier1.py:564-565` to point at the guard (mirror the `xargs` marker comment at `tier1.py:551-555`).
+
+**Approach:** Follow the decision flow in High-Level Technical Design. Reuse `_contains_substitution` (KTD-4). Recurse through `is_safe_shell_command` (KTD-2). Closed-world `-v`/`-V` only (KTD-3). Write a module-level docstring on the helper in the same voice as `_is_safe_xargs_command` (`tier1.py:704-723`): state the read-only-lookup intent, the recursion-as-pass-through rationale, the deny list, and the closed-world flag discipline.
+
+**Patterns to follow:** `_is_safe_xargs_command` / `_is_safe_find_command` (`tier1.py:646-762`) and their dispatch wiring (`tier1.py:765-780`). The `xargs` marker comment in `SAFE_SHELL_COMMANDS` (`tier1.py:551-555`) is the template for the updated `command` comment.
+
+**Test scenarios:** covered by U2 (single atomic commit — helper + tests land together for a security-boundary change).
+
+**Verification:** `is_safe_shell_command("command cp src dst")` is `False`; `is_safe_shell_command("command -v gh")` is `True`; `is_safe_shell_command("command grep foo file")` is `True`. Recursion does not raise on `command command grep foo`.
+
+### U2. AC matrix tests for the `command` guard
+
+**Goal:** Pin every allow/deny case at the real auto-approve entrypoint, including the executed-exploit regression.
+
+**Requirements:** R1–R5.
+
+**Dependencies:** U1.
+
+**Files:**
+- `tests/test_tier1.py` — add a `# ── cpp#60: command builtin recursive guard ──` block after the xargs block (`tests/test_tier1.py:414+`), mirroring the find/xargs parametrized structure.
+
+**Approach:** Assert through `is_safe_bash_command` (the real compound-split entrypoint) for the allow/deny matrix, matching `test_find_exec_*` convention (`tests/test_tier1.py:326,345`). Add one `is_tier1_auto_approve(...)` end-to-end assertion for the headline exploit (matches the issue body's reproduction).
+
+**Test scenarios:**
+- ALLOW (read-only lookup, dev-pilot footprint — R2): `command -v gh`, `command -v cargo`, `command -v lefthook`, `command -V printf`.
+- ALLOW (recursive tier1-safe inner — R3): `command grep foo file`, `command cat file`, `command ls -la`.
+- DENY (non-safe-listed inner — R1): `command cp src dst`, `command tee /etc/passwd`, `command mkdir foo`, `command rm x`.
+- DENY (shell wrapper / sudo — R4): `command sh -c 'rm -rf /'`, `command bash -c id`, `command sudo whoami`.
+- DENY (closed-world flag — KTD-3): `command -p cp src dst`, `command --help`.
+- DENY (bare / no inner): `command`.
+- DENY (recursion into nested guard): `command find . -delete`, `command xargs rm`.
+- DENY (substitution — R5): ``command grep `id` file``, `command grep "$(id)" file`.
+- End-to-end exploit regression: `is_tier1_auto_approve("Bash", {"command": "command cp src .git/hooks/x"}, "/tmp")` is `False`.
+
+**Verification:** `uv run pytest tests/test_tier1.py` green; new cases all pass; pre-existing `command -v` regression tests (`tests/test_tier1.py:670-672,702`) still pass.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the `command` guard (helper + dispatch branch + comment update) and its AC matrix.
+
+### Deferred to Follow-Up Work
+- Other bash builtins (`builtin`, `exec`) — separate evidence-gated tickets only if they surface (issue cpp#60 "out of scope").
+- Refactoring `SAFE_SHELL_COMMANDS` itself — the `command` entry stays as a marker; the recursive check is the guard.
+
+## Verification Contract
+
+- `uv run pytest` green (full suite, not just the new block).
+- `uv run ruff check` clean.
+- `uv run mypy src` clean.
+- `bash scripts/verify-pipeline.sh` passes (plan doc + source change present).
+
+## Definition of Done
+
+- `_is_safe_command_builtin` added; `command` dispatch branch wired; line-565 comment updated to point at the guard.
+- AC matrix (U2) covers every R1–R5 case plus the executed-exploit regression, all green.
+- All three quality gates (ruff, mypy, pytest) pass.
+- PR opened with `Closes #60`, noting the brief/issue-body divergence (recursive design carried) and flagging this as a security-boundary change that must NOT be author-self-merged (cpp#27/#33/#40 precedent).
+
+## Sources & Research
+
+- Issue: `senara-solutions/claude-pilot-py#60` (body + executed exploit).
+- Class precedent: cpp#27 (awk/sed dropped), cpp#33 (`find -exec` allowlist, `tier1.py:646-681`), cpp#40 (`xargs` allowlist, `tier1.py:704-762`).
+- `docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md` §6 (allowlist entry is only as sound as its read-only premise).
+- cpp#38/#42 destination validator (the Tier-2 protection this bypass evades).

--- a/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
+++ b/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md
@@ -7,7 +7,7 @@ component: permission-classifier
 problem_type: security_issue
 category: security-issues
 severity: critical
-tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, xargs, ugrep, double-quote, ref-resolution, make, funsub, bash-5.3, worktree-containment, control-plane, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-38, claude-pilot-40, claude-pilot-41, claude-pilot-42, claude-pilot-43, claude-pilot-44, claude-pilot-45, claude-pilot-47]
+tags: [permissions, policy, bash, regex, heredoc, allow-list, rce, symlink, toctou, command-substitution, find-exec, xargs, ugrep, double-quote, ref-resolution, make, funsub, bash-5.3, worktree-containment, control-plane, claude-pilot-25, claude-pilot-33, claude-pilot-34, claude-pilot-35, claude-pilot-37, claude-pilot-38, claude-pilot-40, claude-pilot-41, claude-pilot-42, claude-pilot-43, claude-pilot-44, claude-pilot-45, claude-pilot-47, claude-pilot-60, command-builtin]
 applies_when: "adding or reviewing any rule that decides allow/deny on a raw shell command string"
 ---
 
@@ -306,6 +306,38 @@ are admitted. Over-block on arity uncertainty, never under-block. Lesson: skippi
 tokens by flag class is parsing; hold it to the same "no parser differential" bar as
 §2/§4, and pin it with executed-exploit review (§3) against the **real** `getopt`,
 not your model of it.
+
+**Third front-end, recursion instead of a closed-world set (claude-pilot#60).** The
+`command` builtin is the same *run-this-other-command* shape as `find -exec` and
+`xargs`, but it was on `SAFE_SHELL_COMMANDS` **unguarded** — the entry's comment
+claimed the intent was only the read-only `command -v <name>` lookup, but bare
+membership admitted any `command <x>`. `command cp src .git/hooks/x` / `command tee
+.git/x` / `command mkdir .claude/x` all auto-approved at Tier 1, re-opening exactly
+the control-plane-write holes the cpp#42 destination validator closes for bare
+`cp`/`mv`/`mkdir` (`command tee <path>` is additionally a write primitive not
+otherwise tier1-reachable). The unguarded entry is the *same class* as the original
+unguarded `find -exec`: safe-listing a command-wrapper without restricting the inner
+command lets the inner command run unchecked. The fix special-cases `command` in
+`is_safe_shell_command` exactly like `find`/`xargs` (`_is_safe_command_builtin`), but
+the guard is **recursion, not a closed-world allowlist**: because `command <x>` runs
+`<x>` with no semantics of its own beyond bypassing functions/aliases, the soundest
+guard re-classifies `<x>` through `is_safe_shell_command` itself — so `command` is
+*by construction* no more permissive than the inner command alone (`command grep foo`
+allows because `grep foo` does; `command cp …` denies because `cp` is not safe-listed).
+The only special case is the `command -v`/`-V` **lookup** form, which is allowed
+directly (it describes, never executes, its target) — this is what preserves the
+original intent and the dev-pilot `command -v <tool> && <tool>` idiom. Two design
+points worth pinning: (1) the recursion is deliberately the *shell* allowlist, not
+the full `_is_safe_sub_command` dispatch — so `command cargo test`/`command git
+status` over-block (an extra relay round-trip, never a hole), the same read-only
+posture as find/xargs; (2) a leading flag that is **not** `-v`/`-V` (e.g. `-p`, which
+runs with a default PATH and is NOT a lookup) denies closed-world — never widen the
+flag set without an executed-exploit AC (§3). Recursion terminates because each level
+strips the leading `command` token. The general lesson across all three front-ends
+(`find -exec`, `xargs`, `command`): **when a safe-listed command's whole job is to run
+another command, the allowlist entry is a marker, not the guard — the guard is a
+sub-classifier (closed-world set or recursion) that is provably no more permissive
+than running the inner command directly.**
 
 ### 7. A regex's syntactic shape is not a runtime-identity guarantee — document what the matched bytes can REFER TO, not what they look like
 

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -561,7 +561,12 @@ SAFE_SHELL_COMMANDS: frozenset[str] = frozenset({
     # TIER3 command-substitution blockers ($(...), backticks, <(...)) that
     # run on the raw compound before splitting.
     "cd",
-    # `command -v <name>` is equivalent to `which <name>`; already safe.
+    # `command` is NOT read-only on its own — it runs an inner command, bypassing
+    # shell functions/aliases. Membership here only passes the SAFE_SHELL_COMMANDS
+    # gate; the actual safety decision is made by the `command` special-case in
+    # is_safe_shell_command (cpp#60): the read-only `command -v <name>` lookup, or
+    # an inner command that is itself tier1-safe (recursive) — exactly like `find`
+    # (_is_safe_find_command) and `xargs` (_is_safe_xargs_command) are special-cased.
     "command",
 })
 
@@ -762,6 +767,67 @@ def _is_safe_xargs_command(sub: str) -> bool:
     return False  # no inner command found → deny
 
 
+def _is_safe_command_builtin(sub: str) -> bool:
+    """Decide whether a `command` builtin invocation is safe to auto-approve (cpp#60).
+
+    `command [-pVv] <name> [arg ...]` runs <name> while bypassing shell functions
+    and aliases — so, exactly like `find -exec` (cpp#33) and `xargs` (cpp#40),
+    safe-listing `command` without restricting the inner command lets that inner
+    command run unchecked. Membership of `command` in SAFE_SHELL_COMMANDS only
+    passes the gate; THIS function is the actual guard.
+
+    Allow iff:
+    - the read-only lookup form `command -v <name>` / `command -V <name>` — the
+      `which`-equivalent the original entry intended; preserves the dev-pilot
+      footprint (`command -v lefthook`, `command -v cargo && cargo test`), OR
+    - the inner command is itself a tier1-safe SHELL command, decided by recursing
+      through `is_safe_shell_command`. So `command` is never MORE permissive than
+      the inner command alone (`command grep foo` allows because `grep foo` does;
+      `command cp …`/`command tee …`/`command mkdir …` deny because the bare forms
+      do). It is intentionally NARROWER: the recursion re-enters only the shell
+      allowlist (+ the find/xargs/command sub-guards), NOT the full
+      `_is_safe_sub_command` dispatch — so `command cargo test`/`command git status`/
+      `command gh …` deny even though their bare forms auto-approve via the build/
+      git/gh allowlists. That over-block (an extra relay round-trip, never a hole)
+      mirrors the read-only posture of `find`/`xargs`; the live dev-pilot idiom is
+      the `command -v <tool> && <tool>` lookup form above, which is unaffected.
+
+    Denies:
+    - any command substitution (`$(`, backtick, `$'`) anywhere — a read-only
+      `command …` never needs it; its presence smuggles execution (shared
+      `_contains_substitution`, mirrors find/xargs; also caught at the scanner
+      layer by cpp#41).
+    - a leading flag other than `-v`/`-V` (e.g. `-p`, which runs with a default
+      PATH and is NOT a read-only lookup; `--help`). Closed-world: widening needs
+      an evidence-gated ticket, never a hunch (cpp#34 discipline).
+    - a bare `command` with no inner token (ambiguous → over-block).
+    - `command sh -c …`/`command bash -c …`/`command sudo …` and every other
+      non-safe-listed inner command, via the recursion (sh/bash/sudo are not in
+      SAFE_SHELL_COMMANDS; sh -c/bash -c also caught by the TIER3 patterns).
+
+    Recursion terminates: each call strips the leading `command` token, so the
+    re-classified string strictly shrinks.
+    """
+    if _contains_substitution(sub):
+        return False
+
+    tokens = sub.split()
+    if not tokens or tokens[0] != "command":
+        return False
+
+    rest = tokens[1:]
+    if not rest:
+        return False  # bare `command` — no inner command to classify
+
+    if rest[0] in ("-v", "-V"):
+        return True  # read-only lookup form (which-equivalent)
+
+    if rest[0].startswith("-"):
+        return False  # closed-world: -p/--help/etc. are not read-only lookups
+
+    return is_safe_shell_command(" ".join(rest))
+
+
 def is_safe_shell_command(sub: str) -> bool:
     match = _FIRST_WORD_RE.match(sub)
     if not match:
@@ -776,6 +842,9 @@ def is_safe_shell_command(sub: str) -> bool:
 
     if cmd == "xargs":
         return _is_safe_xargs_command(sub)
+
+    if cmd == "command":
+        return _is_safe_command_builtin(sub)
 
     return True
 

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -16,6 +16,7 @@ import pytest
 from claude_pilot.tier1 import (
     DENIED_BASH_PATTERNS_HINT,
     INTRA_PLATFORM_AGENTS,
+    _is_safe_command_builtin,
     _is_safe_xargs_command,
     _split_compound_command,
     contains_unquoted_metacharacter,
@@ -522,6 +523,129 @@ def test_denied_hint_no_longer_lists_xargs_categorically() -> None:
     assert "no longer crashes" in DENIED_BASH_PATTERNS_HINT
     # The old blanket bullet ("`xargs`, `eval`, `bash -c`, `sh -c`") is gone.
     assert "`xargs`, `eval`, `bash -c`, `sh -c`" not in DENIED_BASH_PATTERNS_HINT
+
+
+# ── cpp#60: command builtin recursive guard ──────────────────────────────────
+#
+# `command` is a run-this-other-command wrapper (bypasses shell functions/aliases),
+# so safe-listing it unguarded let `command cp/tee/mkdir` auto-approve at Tier 1 —
+# re-opening the cpp#42 control-plane-write holes. The `command` entry stays in
+# SAFE_SHELL_COMMANDS as a marker; `_is_safe_command_builtin` is the real guard
+# (same architectural move as cpp#33 find-exec / cpp#40 xargs). Allow iff the
+# read-only `command -v`/`-V` lookup OR an inner command that is itself a tier1-safe
+# SHELL command (recursion re-enters is_safe_shell_command — intentionally narrower
+# than the full _is_safe_sub_command dispatch; see test_command_builtin_narrower_than_full_tier1).
+# Assertions run against is_safe_bash_command (the real compound-split auto-approve
+# entrypoint), not just the helper.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Read-only lookup form (R2 — preserves the dev-pilot footprint).
+        "command -v gh",
+        "command -v cargo",
+        "command -v lefthook",
+        "command -V printf",
+        "command -v cargo && cargo test",   # compound: lookup + safe build cmd
+        # Recursive: inner command is itself tier1-safe (R3 — pass-through).
+        "command grep foo file",
+        "command cat file",
+        "command ls -la",
+    ],
+)
+def test_command_builtin_allowed(command: str) -> None:
+    assert is_safe_bash_command(command) is True, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Non-safe-listed inner command (R1 — the exploit class).
+        "command cp src dst",
+        "command tee /etc/passwd",          # arbitrary file-write primitive
+        "command mkdir foo",
+        "command rm x",
+        # Shell wrapper / privilege escalation (R4 — AC4 parity with cpp#33).
+        "command sh -c 'rm -rf /'",
+        "command bash -c id",
+        "command sudo whoami",
+        # Closed-world flag discipline (KTD-3): only -v/-V are read-only lookups.
+        "command -p cp src dst",            # -p runs with default PATH, not read-only
+        "command --help",
+        # Bare command — no inner token to classify (over-block).
+        "command",
+        # Recursion into the nested find/xargs guards must still deny.
+        "command find . -delete",
+        "command xargs rm",
+        # Substitution guard (R5).
+        "command grep `id` file",
+        'command grep "$(id)" file',
+    ],
+)
+def test_command_builtin_denied(command: str) -> None:
+    assert is_safe_bash_command(command) is False, command
+
+
+def test_command_builtin_exploit_regression() -> None:
+    """cpp#60 founding exploit: `command cp …` writing into the control plane must
+    no longer auto-approve at Tier 1 (it now routes to policy / the cpp#42
+    destination validator). Asserted at is_tier1_auto_approve, matching the issue
+    body's executed reproduction."""
+    assert (
+        is_tier1_auto_approve(
+            "Bash", {"command": "command cp src .git/hooks/x"}, "/tmp"
+        )
+        is False
+    )
+    # The honest form was already denied (control); the `command` wrapper now
+    # matches it instead of bypassing.
+    assert (
+        is_tier1_auto_approve("Bash", {"command": "cp src .git/hooks/x"}, "/tmp")
+        is False
+    )
+
+
+def test_command_builtin_substitution_guard_denies_single_quoted() -> None:
+    """The `_is_safe_command_builtin` substring substitution guard denies
+    single-quoted (inert) `$(`/backtick directly — `contains_unquoted_metacharacter`
+    does NOT catch single-quoted forms (mirrors the xargs guard). Over-block is the
+    safe direction. A clean read-only form still passes the helper directly."""
+    assert _is_safe_command_builtin("command grep '$(id)' file") is False
+    assert _is_safe_command_builtin("command grep '`id`' file") is False
+    assert _is_safe_command_builtin("command -v gh") is True
+    assert _is_safe_command_builtin("command grep foo file") is True
+
+
+def test_command_builtin_deny_not_via_tier3() -> None:
+    """Layer placement: `command cp …` is denied at the allow-list layer, NOT by
+    a TIER3 pattern — the guard is the recursion, not the denylist."""
+    assert is_tier3_dangerous("command cp src dst") is False
+    assert is_safe_bash_command("command cp src dst") is False
+
+
+@pytest.mark.parametrize(
+    "inner",
+    [
+        "cargo test",       # build allowlist, not SAFE_SHELL_COMMANDS
+        "git status",       # git allowlist
+        "gh pr list",       # gh allowlist
+        "npm run build",    # build allowlist
+    ],
+)
+def test_command_builtin_narrower_than_full_tier1(inner: str) -> None:
+    """Intentional narrowing (KTD-2): the recursion re-enters is_safe_shell_command
+    (the shell allowlist + find/xargs/command sub-guards) — NOT the full
+    _is_safe_sub_command dispatch. So a tier1-safe inner from the build/git/gh/mika
+    allowlist DENIES when wrapped in `command`, even though its bare form
+    auto-approves. This is an over-block (an extra relay round-trip, never a hole),
+    mirroring the read-only posture of `find`/`xargs`. Pinned so the boundary is
+    a decision, not an accident; the live dev-pilot idiom is `command -v <tool>`
+    (test_command_builtin_allowed), which is unaffected."""
+    # Bare form auto-approves...
+    assert is_safe_bash_command(inner) is True, f"bare: {inner}"
+    # ...but the `command`-wrapped form does not (deliberate narrowing).
+    assert is_safe_bash_command(f"command {inner}") is False, f"wrapped: command {inner}"
 
 
 # ── cpp#27: awk + sed dropped from SAFE_SHELL_COMMANDS ───────────────────────


### PR DESCRIPTION
## Why

`command` was in tier1 `SAFE_SHELL_COMMANDS` (`src/claude_pilot/tier1.py`) **unguarded**. The entry's comment claimed the intent was only the read-only `command -v <name>` lookup, but bare membership admitted any `command <x>` — including write/exec subcommands. `is_safe_shell_command` returned `True` for `command <anything>`, so these were **Tier-1 auto-approved** and never reached the Tier-2 policy path or the cpp#38/#42 destination validator.

Exploit confirmed against the pre-fix tree (from issue #60):

```python
is_tier1_auto_approve("Bash", {"command": "command cp src .git/hooks/x"}, "/tmp")   # True
is_tier1_auto_approve("Bash", {"command": "command tee .git/x"}, "/tmp")            # True
is_tier1_auto_approve("Bash", {"command": "command mkdir .claude/x"}, "/tmp")       # True
```

`command cp/tee/mkdir …` re-opened exactly the control-plane-write holes (`.git/hooks/*` executes on next checkout, `.github/workflows/*` runs in CI, `.claude/*` rewrites the agent's own commands) that cpp#42 closed for bare `cp`/`mv`/`mkdir`. `command tee <path>` is additionally a write primitive not otherwise tier1-reachable.

This is the 4th instance of the same allowlist-soundness class as `awk`/`sed` (cpp#27, dropped), `find -exec` (cpp#33), and `xargs` (cpp#40): a *run-this-other-command* wrapper is only as safe as the inner command it runs.

## What

Special-case `command` in `is_safe_shell_command`'s dispatch (alongside the existing `find`/`xargs` branches), routing to a new `_is_safe_command_builtin(sub)`. The `command` entry stays in `SAFE_SHELL_COMMANDS` as a marker; the helper is the guard. It allows iff:

1. the read-only `command -v`/`-V` lookup form (preserves the dev-pilot footprint `command -v lefthook`, `command -v cargo && cargo test`), **or**
2. the inner command is itself a tier1-safe **shell** command, decided by **recursing** through `is_safe_shell_command` — so `command grep foo` allows (grep is tier1-safe) and `command cp src dst` denies (cp is not). This makes `command` a transparent pass-through, no more permissive than the inner command alone.

Substitution (`$(`/backtick/`$'`), a leading flag other than `-v`/`-V` (e.g. `-p`, which runs with default PATH — not read-only), bare `command`, shell wrappers, and `sudo` all deny. Recursion terminates because each level strips the leading `command` token.

Unlike find/xargs (which use the closed-world `FIND_EXEC_SAFE_COMMANDS` set), `command`'s guard is **recursion** — because `command` has no semantics of its own beyond bypassing functions/aliases, re-classifying the inner command is the soundest possible guard.

### Design note — brief/issue divergence (intentional)

The issue body proposed admitting **only** `command -v`/`-V`, routing read-only `command grep` to policy. This PR uses the **recursive** design (the spawn brief's explicit instruction): `-v`/`-V` lookup *plus* recursive classification, so read-only inner commands also auto-approve. Both deny the actual exploit; the recursive design is sounder (permission parity with the inner command). Carried deliberately.

### Intentional narrowing (pinned by test)

The recursion re-enters `is_safe_shell_command` (the **shell** allowlist + find/xargs/command sub-guards), **not** the full `_is_safe_sub_command` dispatch. So `command cargo test` / `command git status` / `command gh …` deny even though their bare forms auto-approve via the build/git/gh allowlists. This is an over-block (an extra relay round-trip, never a hole) mirroring the read-only posture of find/xargs, pinned by `test_command_builtin_narrower_than_full_tier1`.

## Tests

`tests/test_tier1.py` — full AC matrix asserted through `is_safe_bash_command` (the real compound-split entrypoint):

- **ALLOW:** `command -v gh/cargo/lefthook`, `command -V printf`, `command -v cargo && cargo test`, `command grep/cat/ls …`
- **DENY:** `command cp/tee/mkdir/rm`, `command sh -c`/`bash -c`/`sudo`, `command -p …`, `command --help`, bare `command`, `command find . -delete`, `command xargs rm`, substitution forms
- **Exploit regression:** `is_tier1_auto_approve("Bash", {"command": "command cp src .git/hooks/x"}, "/tmp")` is now `False`
- **Narrowing pin:** `command cargo/git/gh/npm` deny while bare forms allow

Gates: **610 tests pass** (+4 narrowing), `ruff` clean, `mypy src` clean.

## Review

Two independent reviewers (adversarial bypass + correctness):
- **Adversarial:** no auto-approve bypass found across 7 attack vectors (recursion, flag-parsing, `" ".join` re-tokenization, substitution, compound-splitter interaction, nested guards, termination).
- **Correctness:** surfaced a docstring overclaim ("no *less* permissive") vs the deliberate narrowing — fixed (docstring + R3 + test-header corrected, narrowing pinned by test). No security regression.

**This is a security-boundary change to the allowlist — must NOT be author-self-merged** (cpp#27/#33/#40 precedent: needs independent executed-exploit/adversarial review before merge).

### Out of scope (pre-existing, flagged by adversarial review)

`sort -o FILE` is an unguarded write primitive on `SAFE_SHELL_COMMANDS` not caught by the `>` tier3 pattern (`command sort -o FILE` merely mirrors bare `sort -o FILE` — no new exposure from this PR). Candidate for a separate evidence-gated ticket.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
