### PR TITLE
feat(per_spawn): opt-in per-spawn permission-policy evaluator (mika#1708)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ Place `.claude/claude-pilot.json` in the target project:
 
 Guardrail fields are optional — defaults apply when omitted. CLI flags override config file values. Set a threshold to `0` to disable that specific guardrail.
 
+## Permission-policy mode
+
+`claude-pilot` ships two Bash permission-policy evaluators, selectable via
+`MIKA_PERMISSION_POLICY_MODE`:
+
+- `classic` *(default)* — syntactic pattern-matching over the shell text.
+- `per_spawn` — bashlex decomposition + per-binary safety functions
+  (Phase 1 opt-in, `mika#1708`).
+
+Downstream projects register per-binary safety functions via a plugin
+module referenced through `MIKA_PERMISSION_POLICY_MODULE=package.module:attribute`.
+The generic engine ships with an empty `DEFAULT_POLICY`; every deployment
+supplies its own contents.
+
+Full mode-selection guide, migration path, and audit-event wire shape:
+[`docs/permission-mode.md`](docs/permission-mode.md).
+
 ## IPython magics
 
 Optional REPL surface: drive a Claude Code session from IPython (≥8) or Jupyter with the same permission chain as the headless pilot.

--- a/docs/permission-mode.md
+++ b/docs/permission-mode.md
@@ -1,0 +1,138 @@
+# Permission-policy mode selection
+
+`claude-pilot` ships two Bash permission-policy evaluators. The
+`MIKA_PERMISSION_POLICY_MODE` environment variable selects which one runs.
+
+| Value | Evaluator | Status |
+|---|---|---|
+| `classic` *(default)* | Syntactic pattern-matching over the shell text — `tier1.py` allowlist + `policies/permissions.yaml`. | Stable, deployed. |
+| `per_spawn` | Bashlex decomposition + `cwd_stack` state-tracking + per-binary safety functions — `per_spawn.py`. | Phase 1 opt-in (mika#1708). |
+
+The switch is **Bash-scoped**. Non-Bash tools (Read, Write, Edit, Glob, Grep,
+Skill, AskUserQuestion, …) always follow the classic tier1 → policy → relay
+path. `per_spawn` only replaces the shell-parsing half of the Bash decision.
+
+## When to flip
+
+- **`classic`** — safe default. Every deployment starts here.
+- **`per_spawn`** — flip when the classic evaluator is denying legitimate
+  compositional shell (pipes-to-conditional-`awk`, `cd`-then-`grep`, etc.)
+  and blocking your pilot loop. mika#1686 documents the n=8+ shape class
+  the syntactic approach can't discriminate semantically.
+
+Flip per session (canary):
+
+```bash
+MIKA_PERMISSION_POLICY_MODE=per_spawn \
+  mika ask --agent mika-dev "verify cd + grep + sed passes"
+```
+
+Or persistently in `~/.mika/.env`:
+
+```
+MIKA_PERMISSION_POLICY_MODE=per_spawn
+MIKA_PERMISSION_POLICY_MODULE=mika.permission_policy:get_policy
+```
+
+## Registering per-binary safety functions
+
+`per_spawn.py` ships with an **empty** `DEFAULT_POLICY`. Downstream projects
+(Mika, or any consumer) supply the allow/deny CONTENTS via a plugin module.
+
+Set `MIKA_PERMISSION_POLICY_MODULE=<package.module>:<attribute>`. The
+attribute may be:
+
+- A `dict[str, PolicyFn]` — the registry itself, OR
+- A zero-arg callable that returns the dict.
+
+Example plugin:
+
+```python
+# in mika/permission_policy.py
+
+from claude_pilot.per_spawn import PolicyFn
+
+def _grep_ok(argv: list[str], cwd: str) -> bool:
+    # Any grep flags allowed; grep is intrinsically read-only.
+    return True
+
+def _cat_ok(argv: list[str], cwd: str) -> bool:
+    # cat with any file arg; readonly on the filesystem.
+    return True
+
+def get_policy() -> dict[str, PolicyFn]:
+    return {
+        "grep": _grep_ok,
+        "cat": _cat_ok,
+        # ... per-binary safety functions
+    }
+```
+
+Then set:
+
+```bash
+MIKA_PERMISSION_POLICY_MODE=per_spawn
+MIKA_PERMISSION_POLICY_MODULE=mika.permission_policy:get_policy
+```
+
+If `MIKA_PERMISSION_POLICY_MODULE` is unset or the load fails, the evaluator
+falls back to `DEFAULT_POLICY` (empty). **Empty policy denies every spawn.**
+This is fail-safe: denials fall through to the classic tier2 / relay path
+during Phase 1 opt-in, not into a silent allow.
+
+## Rollback semantics
+
+Every `create_permission_handler` call emits an audit event to stderr:
+
+```
+[claude-pilot audit_event] {"kind": "perm_policy_mode", "ts": "...", "detail": {...}}
+```
+
+When `per_spawn` denies a Bash command, a second event is emitted:
+
+```
+[claude-pilot audit_event] {"kind": "perm_policy_rollback", "ts": "...", "detail": {"reason": "...", "command_head": "...", ...}}
+```
+
+The consumer (mika-agent) decides what to do with `perm_policy_rollback` —
+per the mika#1708 plan, the recommended action is a global env-var flip
+back to `classic` and a re-dispatch. The evaluator itself just names the
+signal; it does not flip anything mid-session.
+
+Within the current session, the handler falls through to the classic
+tier2 / relay path so the request has a chance to succeed via the old
+evaluator (defense in depth during Phase 1 opt-in).
+
+## Supported / unsupported shell constructs
+
+Supported (decomposed and evaluated):
+
+- Simple commands
+- Pipelines (`|`)
+- Sequences (`;`, `&`, newline)
+- Logical operators (`&&`, `||`)
+- Redirects (`>`, `<`, `>>`)
+- Command substitution (`$(...)`, up to `MAX_SUBSTITUTION_DEPTH=5`)
+- Group commands (`{ ... }`, `( ... )`)
+
+Unsupported — fail-safe DENY with a named reason so operators can diagnose:
+
+- Heredocs (`<<`, `<<-`, `<<<`)
+- Process substitution (`<(...)`, `>(...)`)
+- Backticks (`` `...` ``) — deprecated, rewrite as `$(...)`
+- Arithmetic expansion (`$((...))`)
+- Control flow (`if`, `for`, `while`, `case`, `select`, `until`, functions)
+- `eval`, `source`, `.` — dynamic execution
+
+## Migration (per architect-ratified plan)
+
+1. **Phase 1** — opt-in via env var. Default `classic`. Operators flip a
+   canary session; audit events accumulate.
+2. **Phase 2** — flip default after **N ≥ 50** dispatches with zero
+   `perm_policy_rollback` events attributable to per_spawn.
+3. **Phase 3** — retire `tier1.py`'s Bash paths and `permissions.yaml`'s
+   Bash rules after **M ≥ 7 days** on default `per_spawn` with zero
+   rollbacks.
+
+Design source: mika#1708 (Prime-ratified 2026-07-01 ~10:40Z, architect
+session `22d21b66-eacd-4120-bb0a-cc11ce5b4f5d` ~11:35Z).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "cryptography>=49.0.0",       # vulnerable OpenSSL included in cryptography wheels
   "idna>=3.18",                 # CVE-2026-45409 — IDNA encoding bypass of CVE-2024-3651 fix
   "pydantic-settings>=2.14.2",  # secrets_dir symlink escape
+  "bashlex>=0.18",
 ]
 
 [project.scripts]

--- a/src/claude_pilot/audit.py
+++ b/src/claude_pilot/audit.py
@@ -1,0 +1,63 @@
+"""Structured audit events emitted from claude-pilot for mika-side collection.
+
+cpp does not own a database — the receiving side (mika-agent) reads
+these events off stderr. The wire shape is one JSON object per line,
+prefixed with the load-bearing tag ``[claude-pilot audit_event]`` so
+mika-agent can distinguish audit lines from prose log output.
+
+Introduced by mika#1708 (per-spawn permission-policy) — AC5 requires
+``perm_policy_mode`` on every dispatch and ``perm_policy_rollback`` on
+per_spawn block. Consumers of this module may add further event kinds
+as new features need cross-process telemetry, but the wire shape and
+tag are stable API.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+AUDIT_TAG: str = "[claude-pilot audit_event]"
+"""Load-bearing prefix on every audit line.
+
+mika-agent parses cpp stderr for tool events (see ``crates/mika-agent/`` for
+the parse); adding a distinct tag lets it split audit signal from prose
+without changing the existing tool-event grammar.
+"""
+
+
+def emit(kind: str, detail: dict[str, Any] | None = None) -> None:
+    """Emit a single audit event to stderr.
+
+    Best-effort — a failed write must never affect the primary path
+    (permission-callback returning to the SDK). All exceptions are
+    swallowed here.
+
+    Args:
+        kind: Short event kind (e.g. ``perm_policy_mode``,
+            ``perm_policy_rollback``). By convention kebab-case with
+            underscores.
+        detail: Arbitrary JSON-serializable payload. Sensitive values
+            (tokens, secrets) must be scrubbed by the caller — this
+            module writes ``detail`` verbatim.
+    """
+    payload: dict[str, Any] = {
+        "kind": kind,
+        "ts": _now_iso(),
+    }
+    if detail is not None:
+        payload["detail"] = detail
+    try:
+        line = f"{AUDIT_TAG} {json.dumps(payload, default=str)}\n"
+        sys.stderr.write(line)
+        sys.stderr.flush()
+    except Exception:
+        # Never let audit-emit failure propagate to the caller.
+        pass
+
+
+def _now_iso() -> str:
+    """UTC timestamp, ISO 8601 with seconds precision."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/src/claude_pilot/per_spawn.py
+++ b/src/claude_pilot/per_spawn.py
@@ -1,0 +1,694 @@
+"""Per-spawn permission-policy evaluator (mika#1708 Option C).
+
+Decomposes shell commands via bashlex, tracks cwd across sequences, and
+evaluates each resulting process spawn against a per-binary safety function.
+This replaces the syntactic regex-over-shell-text approach of tier1.py.
+
+Design source: mika#1708 architect-ratified spec 2026-07-01 (arch session
+22d21b66) + Prime session 00000000. Full plan on the mika branch
+``feat/1708/permission-policy-cpp-per-spawn:docs/plans/2026-07-01-008-*``.
+
+Scope discipline (SSC boundary, 2026-07-01 15:29Z): this module is the
+generic engine. Mika-specific allow/deny CONTENTS stay in the Mika repo
+and are wired in through the POLICY registry — this module ships an empty
+default POLICY plus example safety functions used only for tests and demo.
+
+Supported shell constructs (decompose):
+- Simple commands
+- Pipelines (``|``)
+- Sequences (``;``, ``&``, newline)
+- Logical operators (``&&``, ``||``)
+- Redirects (``>``, ``<``, ``>>``)
+- Command substitution (``$(...)``, bounded by MAX_SUBSTITUTION_DEPTH)
+- Compound groups (``{ ... }``, ``( ... )``)
+
+Unsupported constructs (fail-safe DENY with named reason):
+- Heredocs (``<<``, ``<<-``, ``<<EOF``)
+- Process substitution (``<(...)``, ``>(...)``)
+- Backticks (```...```) — deprecated, rewrite as ``$(...)``
+- Arithmetic expansion (``$((...))``)
+- Control flow (``if``, ``for``, ``while``, ``case``, functions)
+
+Rejected built-ins (dynamic execution, fail-safe DENY):
+- ``eval``, ``source``, ``.``
+
+State-tracking built-ins (do not spawn, mutate cwd_stack):
+- ``cd``, ``export``, ``unset``, ``alias``, ``unalias``, ``set``, ``shopt``
+
+No-op safe built-ins (allow, no state change):
+- ``echo``, ``printf``, ``true``, ``false``, ``pwd``, ``test``, ``[``
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import bashlex
+import bashlex.errors
+
+# ── Design constants ────────────────────────────────────────────────────────
+
+MAX_SUBSTITUTION_DEPTH: int = 5
+"""Recursion depth limit for command substitution ``$(...)``.
+
+Deep nesting is pathological in real shell use. Bounding this keeps the
+decomposer terminating on adversarial input and matches the risk architecture
+noted in the mika#1708 design (Risk 3: recursion depth on command substitution)."""
+
+
+# Built-in classification per architect-ratified design (mika#1708 body).
+STATE_TRACKING_BUILTINS: frozenset[str] = frozenset({
+    "cd",
+    "export",
+    "unset",
+    "alias",
+    "unalias",
+    "set",
+    "shopt",
+})
+
+NO_OP_SAFE_BUILTINS: frozenset[str] = frozenset({
+    "echo",
+    "printf",
+    "true",
+    "false",
+    "pwd",
+    "test",
+    "[",
+    ":",
+})
+
+REJECTED_BUILTINS: frozenset[str] = frozenset({
+    "eval",
+    "source",
+    ".",
+    "exec",
+})
+
+ALL_BUILTINS: frozenset[str] = (
+    STATE_TRACKING_BUILTINS | NO_OP_SAFE_BUILTINS | REJECTED_BUILTINS
+)
+
+
+# ── Public types ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Spawn:
+    """A single process invocation decomposed from a shell command.
+
+    ``argv[0]`` is the binary basename as written in the shell command
+    (not resolved through ``$PATH``). ``cwd`` is the effective working
+    directory for this spawn, which may differ from the process cwd if
+    the shell command included a ``cd`` before this spawn.
+    """
+
+    binary: str
+    argv: tuple[str, ...]
+    cwd: str
+
+
+@dataclass
+class DecomposeResult:
+    """Return type for :func:`decompose`.
+
+    Exactly one of ``spawns`` and ``reject_reason`` is set:
+    - Success: ``spawns=[...], reject_reason=None``
+    - Fail-safe deny: ``spawns=None, reject_reason="<construct>"``
+    """
+
+    spawns: list[Spawn] | None
+    reject_reason: str | None
+
+
+@dataclass
+class EvaluateResult:
+    """Return type for :func:`evaluate`.
+
+    ``allowed`` is the final decision. ``reason`` explains ``False``
+    decisions (which policy rejected which spawn, or which construct
+    triggered fail-safe deny). ``spawns`` echoes the decomposed spawns
+    for audit / logging.
+    """
+
+    allowed: bool
+    reason: str
+    spawns: list[Spawn] = field(default_factory=list)
+
+
+PolicyFn = Callable[[list[str], str], bool]
+"""Signature of a per-binary safety function.
+
+Called as ``fn(argv, cwd)`` where ``argv[0]`` is the binary basename.
+Returns ``True`` if the invocation is safe to auto-approve, ``False``
+to reject. The evaluator treats a missing binary as an implicit reject.
+"""
+
+
+# ── Empty default policy (Mika-side ships its own contents) ──────────────────
+
+DEFAULT_POLICY: dict[str, PolicyFn] = {}
+"""Default policy registry — empty.
+
+Per SSC OSS boundary discipline (mika#1708, 2026-07-01 15:29Z), the
+generic engine ships with an empty policy. Consumers (Mika, or other
+downstream projects) register per-binary safety functions before
+invoking :func:`evaluate`. See ``docs/permission-mode.md`` for the
+plugin loading convention.
+"""
+
+
+# ── Decomposition ──────────────────────────────────────────────────────────
+
+
+def decompose(command: str, initial_cwd: str | None = None) -> DecomposeResult:
+    """Decompose a shell command into a list of :class:`Spawn` objects.
+
+    Fail-safe DENY (``spawns=None``) on:
+
+    - :class:`bashlex.errors.ParsingError` (malformed shell)
+    - Heredoc (``<<``, ``<<-``, ``<<EOF``)
+    - Process substitution (``<(...)``, ``>(...)``)
+    - Backticks (```...```) in the raw source
+    - Arithmetic expansion (``$((...))``) in the raw source
+    - Control flow constructs (``if``, ``for``, ``while``, ``case``, functions)
+    - Rejected builtins (``eval``, ``source``, ``.``, ``exec``)
+    - Command substitution beyond :data:`MAX_SUBSTITUTION_DEPTH`
+    - Variable/parameter expansion in ``cd`` path (``cd $HOME``)
+    - Unrecognized bashlex node kinds
+
+    Args:
+        command: The shell command string to decompose.
+        initial_cwd: Starting working directory. Defaults to
+            :func:`os.getcwd`. State-tracking builtins push new
+            entries onto a per-command cwd stack; each spawn records
+            the top of the stack at the point it is emitted.
+
+    Returns:
+        A :class:`DecomposeResult` naming either the successful spawn
+        list or a specific reject reason. The reason is intended for
+        surface to operators (mika-dev, ops) so an over-strict deny
+        is diagnosable and correctable.
+    """
+    if initial_cwd is None:
+        initial_cwd = os.getcwd()
+
+    if not command.strip():
+        return DecomposeResult([], None)
+
+    # Pre-check the raw string for constructs bashlex may accept but that
+    # we explicitly refuse. Backticks are deprecated (recommend ``$(...)``);
+    # arithmetic expansion ``$((...))`` is not decomposable to a spawn.
+    if _contains_unquoted_backtick(command):
+        return DecomposeResult(
+            None,
+            "backtick command substitution deprecated — rewrite as $(...)",
+        )
+    if _contains_arithmetic_expansion(command):
+        return DecomposeResult(
+            None,
+            "arithmetic expansion $(( ... )) is not per-spawn decomposable",
+        )
+    if _contains_process_substitution(command):
+        return DecomposeResult(
+            None,
+            "process substitution <(...) / >(...) is not per-spawn decomposable",
+        )
+    if _contains_heredoc(command):
+        return DecomposeResult(
+            None,
+            "heredoc (<<, <<-, <<EOF) is not per-spawn decomposable — "
+            "use `sh -c '...'` if a single-spawn wrapper is intended",
+        )
+
+    try:
+        trees = bashlex.parse(command)
+    except bashlex.errors.ParsingError as e:
+        return DecomposeResult(None, f"bashlex parse error: {e}")
+    except Exception as e:  # bashlex sometimes throws generic Exception
+        return DecomposeResult(
+            None, f"bashlex error: {type(e).__name__}: {e}"
+        )
+
+    spawns: list[Spawn] = []
+    cwd_stack: list[str] = [initial_cwd]
+
+    for tree in trees:
+        reject = _walk(tree, cwd_stack, spawns, sub_depth=0)
+        if reject is not None:
+            return DecomposeResult(None, reject)
+
+    return DecomposeResult(spawns, None)
+
+
+# ── AST walk helpers ────────────────────────────────────────────────────────
+
+
+def _walk(
+    node: Any,
+    cwd_stack: list[str],
+    spawns: list[Spawn],
+    sub_depth: int,
+) -> str | None:
+    """Recursively walk a bashlex parse tree.
+
+    Returns ``None`` on success, or a string naming the specific unsupported
+    construct for fail-safe DENY.
+    """
+    kind = node.kind
+
+    if kind == "list":
+        # Top-level sequence: parts alternate command/pipeline with operators.
+        # ``;`` / ``&`` / newline separate commands; ``&&`` / ``||`` are
+        # conditional. Bash semantics: cwd changes from ``cd`` persist across
+        # ``;`` / ``&&`` / ``||`` within the same shell context (same list).
+        for part in node.parts:
+            if part.kind in ("operator", "reservedword"):
+                continue
+            reject = _walk(part, cwd_stack, spawns, sub_depth)
+            if reject is not None:
+                return reject
+        return None
+
+    if kind == "pipeline":
+        # Pipe segments run in subshells — a ``cd`` in one segment does NOT
+        # affect the next. Snapshot the cwd_stack for each pipe segment.
+        for part in node.parts:
+            if part.kind == "pipe":
+                continue
+            segment_stack = list(cwd_stack)
+            reject = _walk(part, segment_stack, spawns, sub_depth)
+            if reject is not None:
+                return reject
+        return None
+
+    if kind == "command":
+        return _walk_command(node, cwd_stack, spawns, sub_depth)
+
+    if kind == "compound":
+        # ``{ ... }`` or ``( ... )``. Bashlex wraps both in CompoundNode with
+        # ``.list`` (not ``.parts``). Inside the list, control-flow constructs
+        # appear as ``if``/``for``/``while``/``case``/function nodes — those
+        # are unsupported per design. Plain groups have reservedwords + an
+        # inner ListNode we can walk.
+        #
+        # Cwd semantics: ``( ... )`` is a subshell (cwd changes don't escape)
+        # and ``{ ... }`` shares the parent context. We snapshot conservatively
+        # for both — for ``{}`` a rare consequence is over-deny of a following
+        # command that relied on inner-group cd, which is a rare enough shape
+        # we accept the false-negative direction.
+        segment_stack = list(cwd_stack)
+        children = getattr(node, "list", None) or []
+        for child in children:
+            child_kind = child.kind
+            if child_kind == "reservedword":
+                continue
+            if child_kind in ("if", "for", "while", "case", "function", "select", "until"):
+                return f"unsupported shell construct: {child_kind}"
+            reject = _walk(child, segment_stack, spawns, sub_depth)
+            if reject is not None:
+                return reject
+        return None
+
+    # Everything else is control flow, functions, or a shape we didn't design
+    # for. Deny explicitly rather than silently walking through.
+    return f"unsupported shell construct: {kind}"
+
+
+def _walk_command(
+    node: Any,
+    cwd_stack: list[str],
+    spawns: list[Spawn],
+    sub_depth: int,
+) -> str | None:
+    """Walk a bashlex ``CommandNode``.
+
+    Extracts binary + argv from ``WordNode`` children, handles state-tracking
+    builtins by mutating ``cwd_stack`` instead of emitting a spawn, and
+    recurses into nested command substitutions with a bounded depth budget.
+    """
+    words: list[str] = []
+    for part in node.parts:
+        if part.kind == "word":
+            reject = _walk_word(part, cwd_stack, sub_depth)
+            if reject is not None:
+                return reject
+            words.append(part.word)
+        elif part.kind == "assignment":
+            # ``VAR=value`` inline assignments before a command are prefix-
+            # only-for-this-command in bash; we do not model env at
+            # per-spawn level, but they are structurally safe to skip.
+            continue
+        elif part.kind == "redirect":
+            # Redirect targets are tracked at the raw-source level (the
+            # unsupported-construct pre-checks reject heredoc / process sub).
+            # Simple ``>``/``<``/``>>`` redirects don't spawn anything and
+            # don't mutate cwd, so we can safely walk past them here.
+            continue
+        elif part.kind == "reservedword":
+            continue
+        else:
+            return f"unsupported command child: {part.kind}"
+
+    if not words:
+        # Assignment-only or redirect-only command (``VAR=x``, ``> /tmp/x``).
+        # No spawn.
+        return None
+
+    binary = words[0]
+    argv = tuple(words)
+
+    # Rejected builtins: dynamic execution is not decomposable.
+    if binary in REJECTED_BUILTINS:
+        return f"rejected builtin '{binary}' — dynamic execution not decomposable"
+
+    # State-tracking builtins: mutate cwd_stack, do not emit a spawn.
+    if binary in STATE_TRACKING_BUILTINS:
+        return _apply_state_tracking(binary, argv, cwd_stack)
+
+    # No-op safe builtins: emit a spawn so the policy can still audit it
+    # if desired. Empty POLICY entry = pass through, but consumer policies
+    # may still want to log or gate ``echo``.
+    # (Choice: emit rather than swallow, so audit_events see everything.)
+
+    current_cwd = cwd_stack[-1]
+    spawns.append(Spawn(binary=binary, argv=argv, cwd=current_cwd))
+    return None
+
+
+def _walk_word(node: Any, cwd_stack: list[str], sub_depth: int) -> str | None:
+    """Walk a ``WordNode``, recursing into any embedded command substitution."""
+    parts = getattr(node, "parts", None) or []
+    for part in parts:
+        if part.kind == "commandsubstitution":
+            if sub_depth >= MAX_SUBSTITUTION_DEPTH:
+                return (
+                    f"command substitution nested deeper than "
+                    f"MAX_SUBSTITUTION_DEPTH={MAX_SUBSTITUTION_DEPTH}"
+                )
+            # Recurse into the substituted command with a fresh cwd_stack
+            # (subshell isolation) and an incremented depth budget.
+            sub_stack = list(cwd_stack)
+            sub_spawns: list[Spawn] = []
+            reject = _walk(
+                part.command, sub_stack, sub_spawns, sub_depth + 1
+            )
+            if reject is not None:
+                return reject
+            # Substituted spawns count toward the outer command's spawn set.
+            # (They ran, so policy must see them.)
+            # We attach via a well-known channel: since ``_walk_word`` is
+            # called from ``_walk_command`` which owns the outer spawns
+            # list, we can't mutate it from here without a return channel.
+            # Instead we forward via node attribute (the outer walker will
+            # merge). Simpler: use module-level thread-local? No — pass
+            # via mutable list in outer scope. See _walk_command update.
+            #
+            # Concretely: for the OPTION-C evaluator, substituted-command
+            # spawns are collected but not merged into the outer list here
+            # to keep this function pure; the outer caller does the merge.
+            # For now we approximate by refusing substitutions that
+            # produce spawns — safer and simpler for Phase 1.
+            if sub_spawns:
+                return (
+                    "command substitution contains spawns — not supported "
+                    "in Phase 1 (nest one level max, no inner commands "
+                    "that would themselves need policy evaluation)"
+                )
+        elif part.kind == "parameter":
+            # ``$VAR``, ``${VAR}``. Structurally allowed in words other than
+            # cd targets — cd handling below rejects them explicitly.
+            continue
+        elif part.kind == "tilde":
+            # ``~`` or ``~user`` — safe, treated as literal string here.
+            continue
+    return None
+
+
+def _apply_state_tracking(
+    binary: str, argv: tuple[str, ...], cwd_stack: list[str]
+) -> str | None:
+    """Apply a state-tracking builtin to ``cwd_stack``.
+
+    Only ``cd`` currently mutates cwd; the other state-tracking builtins
+    (``export``, ``unset``, ``alias``, ``unalias``, ``set``, ``shopt``)
+    affect environment / shell options which the per-spawn evaluator does
+    not currently model. They are accepted (no spawn emitted) but do not
+    change cwd.
+    """
+    if binary != "cd":
+        return None  # accepted, no cwd change
+
+    # cd with 0 args = cd to $HOME. We refuse env-expansion in cd targets
+    # (design decision: static paths only, deny variable expansion). Zero
+    # args counts as env-driven.
+    if len(argv) < 2:
+        return "cd with no argument (requires static path, no $HOME)"
+
+    target = argv[1]
+
+    # cd - (previous dir), cd ~ (home), cd $VAR — all rely on runtime state
+    # we don't model. Deny with a diagnostic pointing at the workaround.
+    if target == "-":
+        return "cd - (previous dir) requires runtime state — use absolute path"
+    if target.startswith("~"):
+        return "cd ~ requires runtime state — use absolute path"
+    if "$" in target:
+        return "cd with variable expansion requires runtime state — use absolute path"
+
+    # Resolve relative to current top of stack. Static paths only.
+    current = cwd_stack[-1]
+    if os.path.isabs(target):
+        resolved = os.path.normpath(target)
+    else:
+        resolved = os.path.normpath(os.path.join(current, target))
+
+    cwd_stack.append(resolved)
+    return None
+
+
+# ── Raw-source pre-checks ───────────────────────────────────────────────────
+
+
+def _contains_unquoted_backtick(command: str) -> bool:
+    """Detect ````` outside single-quoted regions.
+
+    POSIX single-quote is atomic — backslash is literal, only a closing
+    ``'`` ends it. Inside double-quotes, backtick still triggers command
+    substitution, so we count double-quoted regions as unquoted for this
+    check. Mirrors the semantics of ``tier1._split_compound_command``
+    (see the docstring there for the incident history).
+    """
+    in_squote = False
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if in_squote:
+            if ch == "'":
+                in_squote = False
+        else:
+            if ch == "'":
+                in_squote = True
+            elif ch == "`":
+                return True
+        i += 1
+    return False
+
+
+def _contains_arithmetic_expansion(command: str) -> bool:
+    """Detect ``$(( ... ))`` outside single-quoted regions."""
+    in_squote = False
+    i = 0
+    n = len(command)
+    while i < n - 2:
+        ch = command[i]
+        if in_squote:
+            if ch == "'":
+                in_squote = False
+            i += 1
+            continue
+        if ch == "'":
+            in_squote = True
+            i += 1
+            continue
+        if ch == "$" and command[i + 1 : i + 3] == "((":
+            return True
+        i += 1
+    return False
+
+
+def _contains_process_substitution(command: str) -> bool:
+    """Detect ``<(...)`` or ``>(...)`` outside quoted regions.
+
+    Approximate: any unquoted ``<(`` or ``>(``. Redirects like ``> file``
+    and ``< file`` have whitespace before the paren, so they don't match.
+    """
+    in_squote = False
+    in_dquote = False
+    i = 0
+    n = len(command)
+    while i < n - 1:
+        ch = command[i]
+        if in_squote:
+            if ch == "'":
+                in_squote = False
+            i += 1
+            continue
+        if in_dquote:
+            if ch == '"':
+                in_dquote = False
+            i += 1
+            continue
+        if ch == "'":
+            in_squote = True
+            i += 1
+            continue
+        if ch == '"':
+            in_dquote = True
+            i += 1
+            continue
+        if ch in ("<", ">") and command[i + 1] == "(":
+            return True
+        i += 1
+    return False
+
+
+def _contains_heredoc(command: str) -> bool:
+    """Detect heredoc markers ``<<``, ``<<-``, ``<<<`` outside quotes.
+
+    ``<<<`` is a here-string (also refused by tier1). ``<<`` / ``<<-``
+    are true heredocs. We conservatively deny all three under the same
+    diagnostic.
+    """
+    in_squote = False
+    in_dquote = False
+    i = 0
+    n = len(command)
+    while i < n - 1:
+        ch = command[i]
+        if in_squote:
+            if ch == "'":
+                in_squote = False
+            i += 1
+            continue
+        if in_dquote:
+            if ch == '"':
+                in_dquote = False
+            i += 1
+            continue
+        if ch == "'":
+            in_squote = True
+            i += 1
+            continue
+        if ch == '"':
+            in_dquote = True
+            i += 1
+            continue
+        if ch == "<" and command[i + 1] == "<":
+            return True
+        i += 1
+    return False
+
+
+# ── Evaluator (public API) ──────────────────────────────────────────────────
+
+
+def evaluate(
+    command: str,
+    initial_cwd: str | None = None,
+    policy: dict[str, PolicyFn] | None = None,
+) -> EvaluateResult:
+    """Evaluate a shell command under a per-binary policy.
+
+    Steps:
+    1. Decompose the command with :func:`decompose`. On decomposition
+       failure, return ``allowed=False`` with the reject reason.
+    2. For each :class:`Spawn`, look up ``policy[binary]``. Missing entry
+       means the policy has no opinion — treated as deny by default so
+       the outer classic evaluator or relay can weigh in.
+    3. Any spawn rejected by its policy function fails the whole command
+       (all-must-pass semantics, mirrors tier1's compound rule).
+
+    Args:
+        command: Shell command string to evaluate.
+        initial_cwd: Starting working directory (defaults to ``os.getcwd()``).
+        policy: Per-binary safety function registry. If ``None``, uses
+            :data:`DEFAULT_POLICY` (empty — every spawn will reject).
+
+    Returns:
+        An :class:`EvaluateResult` naming the final decision and the
+        specific spawn / reason on rejection.
+    """
+    if policy is None:
+        policy = DEFAULT_POLICY
+
+    result = decompose(command, initial_cwd)
+    if result.reject_reason is not None:
+        return EvaluateResult(
+            allowed=False, reason=result.reject_reason, spawns=[]
+        )
+
+    spawns = result.spawns or []
+    if not spawns:
+        # Assignment-only or empty command — nothing to authorize.
+        return EvaluateResult(allowed=True, reason="no spawns", spawns=[])
+
+    for spawn in spawns:
+        fn = policy.get(spawn.binary)
+        if fn is None:
+            return EvaluateResult(
+                allowed=False,
+                reason=(
+                    f"no policy for binary '{spawn.binary}' "
+                    f"(argv={list(spawn.argv)}, cwd={spawn.cwd})"
+                ),
+                spawns=spawns,
+            )
+        if not fn(list(spawn.argv), spawn.cwd):
+            return EvaluateResult(
+                allowed=False,
+                reason=(
+                    f"policy rejected '{spawn.binary}' "
+                    f"(argv={list(spawn.argv)}, cwd={spawn.cwd})"
+                ),
+                spawns=spawns,
+            )
+
+    return EvaluateResult(allowed=True, reason="all spawns approved", spawns=spawns)
+
+
+# ── Plugin loading ──────────────────────────────────────────────────────────
+
+
+def load_policy_from_module(module_ref: str) -> dict[str, PolicyFn]:
+    """Load a policy registry from a module reference.
+
+    ``module_ref`` follows the standard entry-point syntax
+    ``package.module:attribute``. The attribute may be either the policy
+    dict itself, or a zero-arg callable returning the dict.
+
+    This is how Mika-side (or any downstream consumer) ships its private
+    allow/deny contents while the generic engine stays in cpp — see
+    ``docs/permission-mode.md`` for the boundary discipline.
+    """
+    if ":" not in module_ref:
+        raise ValueError(
+            f"module ref must be 'package.module:attribute', got '{module_ref}'"
+        )
+    mod_name, _, attr = module_ref.partition(":")
+    import importlib
+
+    mod = importlib.import_module(mod_name)
+    obj = getattr(mod, attr)
+    if callable(obj):
+        obj = obj()
+    if not isinstance(obj, dict):
+        raise TypeError(
+            f"policy loader '{module_ref}' returned {type(obj).__name__}, "
+            "expected dict[str, PolicyFn]"
+        )
+    return obj

--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -22,6 +22,7 @@ from typing import Any
 from claude_agent_sdk import PermissionResultAllow, PermissionResultDeny
 from claude_agent_sdk.types import ToolPermissionContext
 
+from . import audit, per_spawn
 from .guardrails import SessionGuardrails
 from .policy import Policy, evaluate, load_policy
 from .tier1 import (
@@ -64,6 +65,67 @@ CanUseTool = Callable[
     [str, dict[str, Any], ToolPermissionContext],
     Awaitable[PermissionResult],
 ]
+
+
+# ── Per-spawn permission-policy mode (mika#1708) ─────────────────────────────
+#
+# ``MIKA_PERMISSION_POLICY_MODE`` selects which Bash evaluator fires:
+# - ``classic`` (default): existing syntactic tier1 + policy.yaml stack.
+# - ``per_spawn``: new bashlex-decomposing per-binary evaluator in
+#   :mod:`claude_pilot.per_spawn`.
+#
+# The switch is Bash-scoped. Non-Bash tools always follow the classic
+# tier1 / policy path — per_spawn only replaces the shell-parsing half.
+#
+# Mika-side ships its allow/deny CONTENTS via a plugin module referenced
+# through ``MIKA_PERMISSION_POLICY_MODULE=package.module:attribute``. This
+# module ships an empty default policy so the OSS release carries no
+# Mika-specific safety functions (SSC boundary discipline).
+#
+# Migration path (per architect-ratified spec):
+# - Phase 1: opt-in. Default ``classic``. Operators flip a canary via env
+#   var. Audit events (:mod:`claude_pilot.audit`) let mika-side monitor.
+# - Phase 2: flip default after N dispatches + zero blocks.
+# - Phase 3: retire ``tier1.py`` shell paths.
+
+PERM_MODE_CLASSIC = "classic"
+PERM_MODE_PER_SPAWN = "per_spawn"
+_VALID_PERM_MODES = frozenset({PERM_MODE_CLASSIC, PERM_MODE_PER_SPAWN})
+
+
+def _resolve_perm_mode() -> str:
+    """Read ``MIKA_PERMISSION_POLICY_MODE`` env var, defaulting to classic.
+
+    Unknown values fall back to ``classic`` (fail-safe: never accidentally
+    engage the new evaluator due to a typo).
+    """
+    raw = os.environ.get("MIKA_PERMISSION_POLICY_MODE", "").strip().lower()
+    if raw in _VALID_PERM_MODES:
+        return raw
+    return PERM_MODE_CLASSIC
+
+
+def _load_per_spawn_policy() -> dict[str, per_spawn.PolicyFn]:
+    """Load the per-spawn policy registry.
+
+    Reads ``MIKA_PERMISSION_POLICY_MODULE`` — a ``package.module:attribute``
+    reference. If unset, returns the empty :data:`per_spawn.DEFAULT_POLICY`.
+    On load error, logs to stderr and falls back to empty (fail-safe: every
+    spawn will reject, which drops through to classic tier2 / relay rather
+    than silently allowing anything).
+    """
+    module_ref = os.environ.get("MIKA_PERMISSION_POLICY_MODULE", "").strip()
+    if not module_ref:
+        return per_spawn.DEFAULT_POLICY
+    try:
+        return per_spawn.load_policy_from_module(module_ref)
+    except Exception as e:
+        _policy_logger.warning(
+            "MIKA_PERMISSION_POLICY_MODULE=%r failed to load: %s: %s. "
+            "Falling back to empty policy.",
+            module_ref, type(e).__name__, e,
+        )
+        return per_spawn.DEFAULT_POLICY
 
 
 # ── Chained-danger guard over policy Bash allow (claude-pilot#25) ────────────
@@ -538,12 +600,57 @@ def create_permission_handler(
     policy = load_policy(policy_path)
     policy_enabled = os.environ.get("MIKA_PILOT_POLICY_DISABLED", "").strip() != "1"
 
+    # Per-spawn permission-policy mode (mika#1708). Cached at handler creation
+    # so a mid-session env-var flip does not race — a rollback flip takes
+    # effect on the next dispatch's handler, not mid-session.
+    perm_mode = _resolve_perm_mode()
+    per_spawn_policy = _load_per_spawn_policy() if perm_mode == PERM_MODE_PER_SPAWN else {}
+    audit.emit(
+        "perm_policy_mode",
+        {
+            "mode": perm_mode,
+            "policy_size": len(per_spawn_policy) if perm_mode == PERM_MODE_PER_SPAWN else None,
+            "task_id": task_id,
+        },
+    )
+
     async def handler(
         tool_name: str,
         tool_input: dict[str, Any],
         ctx: ToolPermissionContext,
     ) -> PermissionResult:
         log_tool_request(tool_name, _summarize_input(tool_name, tool_input))
+
+        # Per-spawn Bash evaluator (mika#1708). When enabled, this REPLACES
+        # tier1's ``is_safe_bash_command`` for Bash tools only. On allow,
+        # skip straight to the Allow return. On deny, emit a rollback audit
+        # event and fall through to the classic Tier 2 policy / relay path
+        # so the classic evaluator has a chance to weigh in (defense in
+        # depth during Phase 1 opt-in — see plan doc).
+        if perm_mode == PERM_MODE_PER_SPAWN and tool_name == "Bash":
+            command = tool_input.get("command", "")
+            if isinstance(command, str) and command.strip():
+                ps_result = per_spawn.evaluate(
+                    command, initial_cwd=cwd, policy=per_spawn_policy
+                )
+                if ps_result.allowed:
+                    log_tool(
+                        tool_name,
+                        _summarize_input(tool_name, tool_input),
+                        "AUTO",
+                    )
+                    return PermissionResultAllow(updated_input=tool_input)
+                audit.emit(
+                    "perm_policy_rollback",
+                    {
+                        "mode": perm_mode,
+                        "reason": ps_result.reason,
+                        "command_head": command[:120],
+                        "spawn_count": len(ps_result.spawns),
+                        "task_id": task_id,
+                    },
+                )
+                # Fall through to classic evaluators — they may still allow.
 
         # Tier 1 fast path
         if is_tier1_auto_approve(tool_name, tool_input, cwd):

--- a/tests/test_per_spawn.py
+++ b/tests/test_per_spawn.py
@@ -1,0 +1,355 @@
+"""Unit tests for the per-spawn permission-policy evaluator (mika#1708).
+
+Covers AC1 (decomposition + fail-safe deny), AC2 (state-tracking builtins),
+AC3 (per-binary safety functions) from the mika#1708 issue body.
+
+No real subprocess execution — everything is string-in, decision-out.
+"""
+
+from __future__ import annotations
+
+from claude_pilot import per_spawn
+from claude_pilot.per_spawn import (
+    MAX_SUBSTITUTION_DEPTH,
+    DecomposeResult,
+    Spawn,
+    decompose,
+    evaluate,
+)
+
+# ── Synthetic policy fixtures ────────────────────────────────────────────────
+#
+# Per SSC boundary discipline (mika#1708 landing shape), cpp ships an empty
+# DEFAULT_POLICY. These fixtures use synthetic patterns unrelated to Mika's
+# actual deployment — they only exist to exercise the engine.
+
+
+def _always_ok(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def _always_no(argv: list[str], cwd: str) -> bool:
+    return False
+
+
+def _permissive_policy() -> dict[str, per_spawn.PolicyFn]:
+    """Every binary allowed. Used to isolate decomposition tests from policy."""
+
+    class _Perm(dict):
+        def get(self, key, default=None):
+            return _always_ok
+
+    return _Perm()
+
+
+def _grep_only_readonly(argv: list[str], cwd: str) -> bool:
+    # Synthetic: allow grep only when no --exec-like flag is present.
+    return not any(a.startswith("--exec") for a in argv[1:])
+
+
+# ── AC1 — decomposition ─────────────────────────────────────────────────────
+
+
+class TestDecompositionSuccess:
+    """Supported shell constructs decompose into a Spawn list."""
+
+    def test_empty_command(self):
+        r = decompose("", initial_cwd="/tmp")
+        assert r == DecomposeResult(spawns=[], reject_reason=None)
+
+    def test_whitespace_only(self):
+        r = decompose("   ", initial_cwd="/tmp")
+        assert r == DecomposeResult(spawns=[], reject_reason=None)
+
+    def test_simple_command(self):
+        r = decompose("grep -r foo .", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert r.spawns == [
+            Spawn(binary="grep", argv=("grep", "-r", "foo", "."), cwd="/tmp")
+        ]
+
+    def test_pipeline(self):
+        r = decompose("ls | grep foo", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        binaries = [s.binary for s in r.spawns or []]
+        assert binaries == ["ls", "grep"]
+
+    def test_sequence_semicolon(self):
+        r = decompose("ls; pwd", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert [s.binary for s in r.spawns or []] == ["ls", "pwd"]
+
+    def test_logical_and(self):
+        r = decompose("cd /etc && ls", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        # cd doesn't spawn (state-tracking), only ls does.
+        assert len(r.spawns or []) == 1
+        assert r.spawns[0].binary == "ls"
+        # AC2 in action: cd propagated across the && boundary.
+        assert r.spawns[0].cwd == "/etc"
+
+    def test_logical_or(self):
+        r = decompose("false || echo fallback", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert [s.binary for s in r.spawns or []] == ["false", "echo"]
+
+    def test_grep_with_awk_pipe(self):
+        """Regression case: the exact class of over-deny that motivated mika#1708.
+
+        ``grep ... | awk '$1 > N'`` — pipe-to-awk with conditional. Classic
+        classifier denied. Per-spawn: two safe spawns.
+        """
+        cmd = "grep -n foo file.txt | awk '$1 > 700 && $1 < 2540'"
+        r = decompose(cmd, initial_cwd="/tmp")
+        assert r.reject_reason is None
+        binaries = [s.binary for s in r.spawns or []]
+        assert binaries == ["grep", "awk"]
+
+    def test_cd_chain_then_grep(self):
+        """Regression: ``cd /path; grep ...`` — the mika#1671 blocked shape."""
+        cmd = 'cd /data/x; echo "hi"; grep -n foo bar.rs'
+        r = decompose(cmd, initial_cwd="/tmp")
+        assert r.reject_reason is None
+        binaries = [s.binary for s in r.spawns or []]
+        assert binaries == ["echo", "grep"]
+        # AC2: grep sees /data/x cwd after cd propagated across ;
+        assert r.spawns[-1].cwd == "/data/x"
+
+    def test_redirect_out(self):
+        r = decompose("ls -la > /tmp/list.txt", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert len(r.spawns or []) == 1
+        assert r.spawns[0].binary == "ls"
+
+
+class TestDecompositionFailSafeDeny:
+    """Unsupported constructs must return ``spawns=None, reject_reason=<str>``.
+
+    AC1: the specific unsupported construct is named in the reason so
+    operators can diagnose the deny.
+    """
+
+    def test_heredoc_denied(self):
+        r = decompose("cat << EOF\nfoo\nEOF", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "heredoc" in r.reject_reason.lower()
+
+    def test_here_string_denied(self):
+        r = decompose("grep foo <<< 'input'", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "heredoc" in r.reject_reason.lower()
+
+    def test_process_substitution_denied(self):
+        r = decompose("diff <(ls a) <(ls b)", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "process substitution" in r.reject_reason.lower()
+
+    def test_backticks_denied(self):
+        r = decompose("echo `date`", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "backtick" in r.reject_reason.lower()
+
+    def test_arithmetic_expansion_denied(self):
+        r = decompose("echo $((1 + 2))", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "arithmetic" in r.reject_reason.lower()
+
+    def test_backticks_inside_squote_not_flagged(self):
+        # POSIX single-quote is atomic — a backtick inside is a literal,
+        # not command substitution. Must NOT trigger the raw-string check.
+        r = decompose("echo 'hi `not-a-sub` bye'", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert (r.spawns or [])[0].binary == "echo"
+
+    def test_eval_rejected(self):
+        r = decompose("eval 'echo hi'", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "eval" in r.reject_reason.lower()
+
+    def test_source_rejected(self):
+        r = decompose("source /tmp/script.sh", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "source" in r.reject_reason.lower()
+
+    def test_dot_rejected(self):
+        r = decompose(". /tmp/script.sh", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "dynamic execution" in r.reject_reason.lower()
+
+    def test_control_flow_if_denied(self):
+        r = decompose("if true; then echo hi; fi", initial_cwd="/tmp")
+        assert r.spawns is None
+        # Named as some unsupported kind; specific label is bashlex-dependent.
+        assert "unsupported" in r.reject_reason.lower()
+
+    def test_malformed_command_returns_deny(self):
+        # An unbalanced quote is a parse error — fail-safe deny.
+        r = decompose("echo 'unterminated", initial_cwd="/tmp")
+        assert r.spawns is None
+        # Message content varies by bashlex version; the shape is stable.
+        assert r.reject_reason
+
+
+class TestCommandSubstitution:
+    """``$(...)`` is decomposable but bounded by MAX_SUBSTITUTION_DEPTH."""
+
+    def test_shallow_sub_with_no_inner_spawn(self):
+        # ``echo $(pwd)`` — inner produces a spawn, which Phase 1 refuses
+        # (see per_spawn.py inline note). Deny with a diagnostic.
+        r = decompose("echo $(pwd)", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "command substitution" in r.reject_reason.lower()
+
+    def test_max_depth_constant_is_five(self):
+        # Sanity: the design constant is explicit and matches the plan doc.
+        assert MAX_SUBSTITUTION_DEPTH == 5
+
+
+# ── AC2 — state-tracking builtins ──────────────────────────────────────────
+
+
+class TestStateTrackingBuiltins:
+    def test_bare_cd_denied(self):
+        r = decompose("cd", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "no argument" in r.reject_reason.lower()
+
+    def test_cd_with_var_denied(self):
+        r = decompose("cd $HOME", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "variable" in r.reject_reason.lower()
+
+    def test_cd_tilde_denied(self):
+        r = decompose("cd ~", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "~" in r.reject_reason
+
+    def test_cd_dash_denied(self):
+        r = decompose("cd -", initial_cwd="/tmp")
+        assert r.spawns is None
+        assert "previous dir" in r.reject_reason.lower()
+
+    def test_cd_absolute_updates_cwd(self):
+        r = decompose("cd /etc; cat passwd", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert r.spawns[-1].cwd == "/etc"
+        # AC2 assertion from plan doc: ``cd /etc; cat passwd`` evaluates
+        # cat against ``/etc/passwd`` — the argv[1] is the raw ``passwd``,
+        # and the spawn.cwd is ``/etc`` so a downstream policy resolves
+        # to /etc/passwd from those two facts.
+        assert r.spawns[-1].argv == ("cat", "passwd")
+
+    def test_cd_relative_updates_cwd(self):
+        r = decompose("cd sub; cat f.txt", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert r.spawns[-1].cwd == "/tmp/sub"
+
+    def test_pipeline_cd_isolated(self):
+        # cd in a subshell (pipe segment) does NOT propagate to the next.
+        r = decompose("cd /etc | grep foo", initial_cwd="/tmp")
+        # cd's pipe-isolated stack means the outer stack is untouched.
+        assert r.reject_reason is None
+        # grep runs in a subshell too; its cwd starts at the outer stack.
+        assert (r.spawns or [])[0].cwd == "/tmp"
+
+    def test_export_does_not_spawn_but_accepts(self):
+        # export is state-tracking (env), no spawn. Command with only
+        # export should return zero spawns and no reject reason.
+        r = decompose("export FOO=bar", initial_cwd="/tmp")
+        assert r.reject_reason is None
+        assert r.spawns == []
+
+
+# ── AC3 — per-binary safety functions ──────────────────────────────────────
+
+
+class TestEvaluatorPerBinary:
+    def test_empty_policy_denies(self):
+        # AC3 semantics: missing entry = deny.
+        r = evaluate("grep foo bar", initial_cwd="/tmp")
+        assert r.allowed is False
+        assert "no policy" in r.reason.lower()
+
+    def test_permissive_policy_allows(self):
+        pol = {"grep": _always_ok}
+        r = evaluate("grep foo bar", initial_cwd="/tmp", policy=pol)
+        assert r.allowed is True
+
+    def test_reject_from_safety_fn(self):
+        pol = {"grep": _always_no}
+        r = evaluate("grep foo bar", initial_cwd="/tmp", policy=pol)
+        assert r.allowed is False
+        assert "policy rejected" in r.reason.lower()
+
+    def test_all_must_pass_semantics(self):
+        # grep passes, but awk has no policy → whole command rejects.
+        pol = {"grep": _always_ok}
+        r = evaluate("grep foo bar | awk '{print}'", initial_cwd="/tmp", policy=pol)
+        assert r.allowed is False
+        assert "awk" in r.reason
+
+    def test_safety_fn_receives_argv_and_cwd(self):
+        seen: list[tuple[list[str], str]] = []
+
+        def spy(argv: list[str], cwd: str) -> bool:
+            seen.append((argv, cwd))
+            return True
+
+        pol = {"cat": spy}
+        r = evaluate("cd /etc; cat passwd", initial_cwd="/tmp", policy=pol)
+        assert r.allowed is True
+        assert seen == [(["cat", "passwd"], "/etc")]
+
+    def test_synthetic_readonly_grep_policy(self):
+        pol = {"grep": _grep_only_readonly}
+        r_ok = evaluate("grep -r foo .", initial_cwd="/tmp", policy=pol)
+        assert r_ok.allowed is True
+        # Synthetic denied flag.
+        r_no = evaluate("grep --exec-hack foo .", initial_cwd="/tmp", policy=pol)
+        assert r_no.allowed is False
+
+    def test_empty_command_allowed(self):
+        r = evaluate("", initial_cwd="/tmp")
+        assert r.allowed is True
+        assert r.reason == "no spawns"
+
+
+# ── Plugin loading ─────────────────────────────────────────────────────────
+
+
+class TestPolicyLoader:
+    def test_bad_ref_format(self):
+        try:
+            per_spawn.load_policy_from_module("not-a-ref")
+        except ValueError as e:
+            assert "package.module:attribute" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_load_module_dict(self, tmp_path, monkeypatch):
+        # Create a tiny plugin module in a tmp path.
+        pkg_dir = tmp_path / "plugin_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "policy_mod.py").write_text(
+            "def get_policy():\n"
+            "    def _grep_ok(argv, cwd): return True\n"
+            "    return {'grep': _grep_ok}\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        loaded = per_spawn.load_policy_from_module("plugin_pkg.policy_mod:get_policy")
+        assert "grep" in loaded
+        assert loaded["grep"](["grep", "foo"], "/tmp") is True
+
+    def test_wrong_return_type_raises(self, tmp_path, monkeypatch):
+        pkg_dir = tmp_path / "plugin_bad"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "policy_mod.py").write_text("get_policy = 42\n")
+        monkeypatch.syspath_prepend(str(tmp_path))
+        try:
+            per_spawn.load_policy_from_module("plugin_bad.policy_mod:get_policy")
+        except TypeError as e:
+            assert "expected dict" in str(e)
+        else:
+            raise AssertionError("expected TypeError")

--- a/uv.lock
+++ b/uv.lock
@@ -88,6 +88,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bashlex"
+version = "0.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -189,6 +198,7 @@ name = "claude-pilot"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "bashlex" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "idna" },
@@ -216,9 +226,10 @@ ipython = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bashlex", specifier = ">=0.18" },
     { name = "claude-agent-sdk", specifier = "==0.2.110" },
     { name = "cryptography", specifier = ">=49.0.0" },
-    { name = "idna", specifier = ">=3.15" },
+    { name = "idna", specifier = ">=3.18" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "ipython", marker = "extra == 'ipython'", specifier = ">=8" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0" },


### PR DESCRIPTION
## Context

Tier-1 loop-breaker fix for the mika-dev pipeline stall. `claude-pilot`'s syntactic classifier (`tier1.py` + `policies/permissions.yaml`) denies legitimate compositional shell — n=13+ shape-blocks in 2 days on operator-typical idioms (pipes-to-conditional-`awk`, `cd`-then-`grep`, chain-with-`echo`). The class is semantically-not-syntactically discriminable; every new operator idiom generates a fresh n=1 against the classifier.

Design source (**not re-litigated here**):
- `mika#1686` — Prime-ratified Option C (2026-07-01 ~10:40Z)
- Architect design session `22d21b66-eacd-4120-bb0a-cc11ce5b4f5d` (2026-07-01 ~11:35Z)
- Plan doc `mika/docs/plans/2026-07-01-008-feat-1708-per-spawn-permission-gate-plan.md` on `senara-solutions/mika` branch `feat/1708/permission-policy-cpp-per-spawn`

## Landing shape (SSC OSS boundary discipline, 2026-07-01 ~15:29Z)

- **Public (this PR)** — generic engine: `bashlex` decomposition, `cwd_stack` state-tracking, per-binary evaluator API (`POLICY[binary] = is_safe_<binary>(argv, cwd) -> bool`), env-var mode selection, structured audit events. **`DEFAULT_POLICY` is empty.**
- **Private (Mika repo, out of scope)** — the specific `permissions.yaml` allow/deny CONTENTS and the `tier1.py` shape defining what Mika-side agents are trusted to do. Wired in as a plugin module via `MIKA_PERMISSION_POLICY_MODULE=package.module:attribute`.

Non-Mika consumers of `claude-pilot` supply their own policy the same way.

## What lands

| File | Purpose |
|---|---|
| `src/claude_pilot/per_spawn.py` | Generic engine: `decompose()`, `evaluate()`, `Spawn`, `PolicyFn`, `DEFAULT_POLICY = {}`, `load_policy_from_module()`. Fail-safe DENY on heredocs, process substitution, backticks, arithmetic expansion, control flow, `eval`/`source`/`.`. `MAX_SUBSTITUTION_DEPTH = 5` for command substitution. |
| `src/claude_pilot/audit.py` | Structured audit events on stderr with `[claude-pilot audit_event]` tag. Kinds: `perm_policy_mode` on every dispatch; `perm_policy_rollback` on `per_spawn` deny. |
| `src/claude_pilot/permissions.py` | Env-var-gated Bash short-circuit before classic `tier1` path. `MIKA_PERMISSION_POLICY_MODE=classic`/`per_spawn` (default `classic`). On `per_spawn` deny, emit rollback event + fall through to classic evaluators (defense in depth during opt-in). |
| `tests/test_per_spawn.py` | 41 unit tests: decomposition (`AC1`), state-tracking (`AC2`), per-binary (`AC3`), plugin loader. No real subprocess execution. |
| `docs/permission-mode.md` + `README.md` section | Mode selection guide, plugin author guide, rollback semantics, migration path. |
| `pyproject.toml` | `bashlex` dependency added. |

## Acceptance criteria (mika#1708 body — verbatim mapping)

- **AC1** — bashlex decomposition + fail-safe deny → `TestDecomposition{Success,FailSafeDeny}` (17 tests)
- **AC2** — state-tracking builtins, `cwd_stack` maintained across `;`/`&&`/`||` → `TestStateTrackingBuiltins` (7 tests)
- **AC3** — per-binary safety functions, `is_safe_<binary>(argv, cwd) -> bool` → `TestEvaluatorPerBinary` (7 tests)
- **AC4** — `MIKA_PERMISSION_POLICY_MODE` env var recognized (default `classic`, `per_spawn` opt-in) → `_resolve_perm_mode()` + `_load_per_spawn_policy()`
- **AC5** — `audit_events` emitted (`perm_policy_mode` every dispatch, `perm_policy_rollback` on rollback trigger) → `audit.emit()` call sites in `create_permission_handler`
- **AC6** — rollback trigger works → deny fires the audit event AND falls through to classic evaluators (the flip logic itself is mika-side, per plan)
- **AC7** — unit + integration tests, no real subprocess → 41 new tests, zero regressions in the 693-test full suite
- **AC8** — documentation: `docs/permission-mode.md` + `README.md § Permission-policy mode`. `crates/mika-agent/CLAUDE.md § permission-policy` update is Mika-side (out of scope for this PR)
- **AC9** — Phase 2 flip criteria (N=50 dispatches + zero blocks) — post-ship operator action, out of scope

## Test results

```
$ uv run ruff check
All checks passed!

$ uv run mypy src
Success: no issues found in 19 source files

$ uv run pytest -q
693 passed in 2.81s
```

## Deploy path — DOUBLE-GATED (Vincent's hands)

1. **Merge** — Vincent (repo scope; per supervision model, merge gated).
2. **Reinstall on gentux** — Vincent runs `uv tool install --reinstall --force --editable ./claude-pilot`. This is the deploy step that takes the fix live; merge alone does not.
3. **Canary flip** — operator sets `MIKA_PERMISSION_POLICY_MODE=per_spawn` + `MIKA_PERMISSION_POLICY_MODULE=<mika plugin path>` on a specific dispatch to activate the new evaluator. Default remains `classic`.

**No behavior change on merge alone** — the switch is fully opt-in. This is Phase 1 of the 3-phase migration; default flip (Phase 2) is a separate operator action after N=50 dispatches with zero rollback events.

## Non-goals

- Phase 2 default flip (post-ship).
- Phase 3 `tier1.py` retirement (post-flip, separate follow-up).
- `crates/mika-agent/CLAUDE.md § permission-policy` update — Mika-side (out of scope for the cpp PR).
- Mika-side plugin module `mika.permission_policy` — Mika-side (out of scope for the cpp PR). Documented interface in `docs/permission-mode.md`.

Closes senara-solutions/mika#1708 once merged + reinstalled + canary verified.