### PR TITLE
fix(policy): expand compound-bash allow-list for 18-incident groom/pilot class [P1 DECISION-CORE hand-merge]

### DIFF
--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -182,6 +182,17 @@ _SUBSTITUTION_ALLOWLIST = (
     "$(git rev-parse --abbrev-ref HEAD)",
     "$(git rev-parse HEAD)",
     "$(git rev-parse --short HEAD)",
+    # `merge-base` prints the best common ancestor SHA on stdout — same class as
+    # the rev-parse tokens above (short identifier output, no side effects, no
+    # nested `$(`, backtick, redirect, or pipe). The main / origin/main variants
+    # are the base-drift detection idiom used by dispatch-lib and dev-groom
+    # (`BASE=$(git merge-base main HEAD); git diff --name-only $BASE HEAD`).
+    # 18-incident policy:deny class 2026-07-26 → 2026-07-27 (mika#1852/#1849
+    # groom/pilot halted on this shape). Coupled pair with the `merge-base`
+    # addition to `SAFE_GIT_SUBCOMMANDS` in tier1.py — both must land together
+    # to unblock the compound and its standalone form.
+    "$(git merge-base main HEAD)",
+    "$(git merge-base origin/main HEAD)",
 )
 
 # Inert placeholder a redacted substitution collapses to. Identifier-shaped with

--- a/src/claude_pilot/policies/permissions.yaml
+++ b/src/claude_pilot/policies/permissions.yaml
@@ -125,9 +125,42 @@ rules:
 
   - id: bash-git-readonly
     tool: Bash
-    pattern: "^git\\s+(status|log|diff|show|branch|rev-parse|fetch|ls-remote|worktree)"
+    pattern: "^git\\s+(status|log|diff|show|branch|rev-parse|fetch|ls-remote|worktree|merge-base)"
     decision: allow
-    reason: "git read-only operations"
+    reason: "git read-only operations (merge-base is common-ancestor SHA lookup, no side effects — added 2026-07-27 with 18-incident compound-bash class)"
+
+  # ---- Dispatch-lib deterministic helper scripts ----
+  # `./scripts/derive-{branch-name,worktree-path,phase-from-body}` are the
+  # deterministic shell helpers used by `_shared/dispatch-lib.sh` (mika-platform)
+  # to compute worktree paths, branch refs, and phase-from-body from a groom
+  # brief. Each is:
+  #   - PURE COMPUTATION: reads its args, prints one identifier to stdout.
+  #   - NO FILESYSTEM WRITES: no `>`, no `mkdir`, no `cp/mv/rm`, no `sed -i`.
+  #   - NO NETWORK: no `curl`, `wget`, `gh`, `git push`.
+  #   - NO SUBPROCESS: no `sh -c`, `bash -c`, `eval`, `source`.
+  #
+  # The rule allow-shape is anchored + argument-charset restricted so a
+  # malicious pilot cannot smuggle metachars into an arg to escape the script's
+  # own sanitization:
+  #   - `^\./scripts/derive-(…)` closed-world script set (3 named scripts only)
+  #   - `(\s+[\w./=:-]+)*` args restricted to word-chars + dot/slash/=/colon/hyphen
+  #     — excludes `$`, backtick, quotes, pipe, semicolon, ampersand, redirects,
+  #     spaces (except separator). No substitution risk at THIS layer.
+  #   - `\s*$` trailing anchor — nothing rides after the last arg.
+  #
+  # Chain-safety (`_bash_allow_is_chain_safe`) still applies compound-wide, so
+  # `./scripts/derive-branch-name x && rm -rf ~` still vetoes on the tail segment.
+  #
+  # Founding evidence: 18-incident policy:deny class 2026-07-26 → 2026-07-27
+  # (compound-bash tier1/tier2 gap). Multiple incidents cited
+  # `./scripts/derive-branch-name … 2>/dev/null || echo …` as the deny trigger.
+  # Widening the closed-set (adding a 4th script) requires evidence + a separate
+  # ticket per cpp#34 discipline (mika-arch session 783d4a04).
+  - id: bash-derive-scripts
+    tool: Bash
+    pattern: '^\./scripts/derive-(branch-name|worktree-path|phase-from-body)(\s+[\w./=:-]+)*\s*(2>/dev/null)?\s*$'
+    decision: allow
+    reason: "./scripts/derive-{branch-name,worktree-path,phase-from-body} — dispatch-lib deterministic helpers, pure stdout print, arg charset restricted to [\\w./=:-] (no metachars/substitution)"
 
   - id: bash-git-stage-commit
     tool: Bash

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -447,6 +447,14 @@ SAFE_GIT_SUBCOMMANDS: frozenset[str] = frozenset({
     "fetch", "pull", "add", "stash", "tag", "merge",
     "rebase", "cherry-pick", "symbolic-ref",
     "ls-files", "describe", "shortlog", "blame",
+    # `merge-base` is read-only: prints the best common ancestor commit SHA on
+    # stdout, has no filesystem or ref-mutation side effects. Same safety class
+    # as `rev-parse` / `describe` / `shortlog` already in this set.
+    # Groom-phase pilots need it to detect base-drift before diff (`git merge-base
+    # main HEAD` then `git diff --name-only $BASE HEAD`). Added after 18-incident
+    # policy:deny class observed 2026-07-26 → 2026-07-27 blocked dev-groom /
+    # dev-pilot on mika#1852/#1849/#1401/#1403 (compound-bash tier1/tier2 gap).
+    "merge-base",
 })
 
 _GIT_CMD_RE = re.compile(r"^\s*git\s+(\S+)")

--- a/tests/test_policy_devpilot.py
+++ b/tests/test_policy_devpilot.py
@@ -210,6 +210,84 @@ def test_guard_vetoes_allowlisted_mixed_with_evil_substitution() -> None:
     assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False
 
 
+def test_guard_allows_git_merge_base_substitution_base_drift_idiom() -> None:
+    """18-incident class 2026-07-27 — dispatch-lib base-drift detection uses
+    `$(git merge-base main HEAD)` to compute the merge base then diff. Both
+    variants (main and origin/main) must round-trip through chain-safe."""
+    # Assert both merge-base tokens are enumerated. The broader integration test
+    # above (`test_guard_allows_each_allowlisted_substitution_token`) iterates
+    # every entry inside a `gh pr view --head <TOKEN>` outer, so token addition
+    # is exercised end-to-end there. This test pins the founding-incident tokens
+    # explicitly so a future refactor cannot silently drop them without a
+    # named-test failure pointing at the 18-incident class.
+    for token in (
+        "$(git merge-base main HEAD)",
+        "$(git merge-base origin/main HEAD)",
+    ):
+        assert token in _SUBSTITUTION_ALLOWLIST, token
+
+
+def test_policy_bash_derive_scripts_allow_shape() -> None:
+    """18-incident class 2026-07-27 — dispatch-lib helpers `./scripts/derive-*`
+    were falling through to default-deny. `bash-derive-scripts` policy rule
+    admits the sanctioned invocations; chain-safety still applies to any tail."""
+    for cmd in (
+        "./scripts/derive-branch-name issue-1852",
+        "./scripts/derive-worktree-path fix/1852/foo",
+        "./scripts/derive-phase-from-body ISSUE_BODY.md",
+        "./scripts/derive-branch-name issue-1852 2>/dev/null",
+    ):
+        pd = evaluate(_POLICY, "Bash", {"command": cmd})
+        assert pd.decision == "allow", f"{cmd}: {pd}"
+        assert pd.rule_id == "bash-derive-scripts", f"{cmd}: {pd.rule_id}"
+        # Chain-safe check on the standalone command (single segment = the same
+        # command) must also honor it (via policy re-eval on the segment).
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True, cmd
+
+
+def test_policy_bash_derive_scripts_rejects_metachar_args() -> None:
+    """Charset restriction on args: `$`, backtick, quotes, pipe, semicolon,
+    ampersand, redirects, spaces (except separator) MUST NOT match the rule.
+    The pattern's `[\\w./=:-]+` class enforces this at the regex layer — any
+    metachar in an arg falls through to default-deny.
+    """
+    for cmd in (
+        "./scripts/derive-branch-name $(rm -rf ~)",   # substitution
+        "./scripts/derive-branch-name `id`",           # backtick
+        "./scripts/derive-branch-name 'arg with spaces'",  # quoted arg
+        "./scripts/derive-branch-name arg;rm -rf ~",   # chained via ;
+        "./scripts/derive-branch-name arg|cat",        # piped
+        "./scripts/derive-branch-name arg>file",       # redirect
+        "./scripts/derive-branch-name arg&background", # bare & backgrounding
+    ):
+        pd = evaluate(_POLICY, "Bash", {"command": cmd})
+        # Either the rule doesn't match (falls to default deny) OR
+        # chain-safe subsequently vetoes (compound with a bad tail segment).
+        # Both paths result in the invocation being denied — the safety
+        # invariant is "no metachar in a derive-script arg is auto-approved".
+        if pd.decision == "allow" and pd.rule_id == "bash-derive-scripts":
+            # If the policy rule matched somehow, chain-safe MUST veto.
+            assert (
+                _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False
+            ), f"metachar arg allowed and chain-safe: {cmd}"
+        # else: rule did not match → default deny → safe.
+
+
+def test_policy_bash_derive_scripts_rejects_unknown_script() -> None:
+    """Closed-world script set: only `derive-{branch-name,worktree-path,phase-from-body}`.
+    Any other script (even under ./scripts/) falls through to default-deny.
+    Widening the set requires a separate evidence-gated ticket (cpp#34)."""
+    for cmd in (
+        "./scripts/derive-foo x",           # unknown derive-*
+        "./scripts/other-script x",         # different script family
+        "./scripts/mika-orchestrator-poll", # sibling script not on the closed set
+    ):
+        pd = evaluate(_POLICY, "Bash", {"command": cmd})
+        assert not (
+            pd.decision == "allow" and pd.rule_id == "bash-derive-scripts"
+        ), f"unknown script matched bash-derive-scripts: {cmd}"
+
+
 def test_guard_exempts_sole_command_heredoc() -> None:
     cmd = "cat > /tmp/helper.sh <<'EOF'\nrm -rf /tmp/build\nEOF"
     assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -263,6 +263,41 @@ def test_git_unknown_subcommand_denied() -> None:
     assert is_safe_git_command("git obliterate") is False
 
 
+# ── git merge-base (18-incident class 2026-07-27) ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git merge-base main HEAD",
+        "git merge-base origin/main HEAD",
+        "git merge-base main feature/foo",
+        "git merge-base --octopus branch-a branch-b branch-c",
+    ],
+)
+def test_git_merge_base_allowed(command: str) -> None:
+    """merge-base is read-only stdout SHA lookup — same class as rev-parse."""
+    assert is_safe_git_command(command) is True, command
+
+
+def test_git_merge_base_compound_with_diff_allowed() -> None:
+    """`base=$(git merge-base ...)` companion pattern: compound `git merge-base &&
+    git diff --name-only` also passes via chain-safe (each segment tier1-safe).
+    This covers the 18-incident 'git merge-base + git diff --name-only' shape
+    from mika#1849 dev-pilot code-review halt."""
+    assert (
+        is_safe_bash_command("git merge-base main HEAD && git diff --name-only")
+        is True
+    )
+
+
+def test_git_merge_base_force_flag_still_denied() -> None:
+    """Defense-in-depth: the shared `_FORCE_FLAG_RE` check still fires. There is
+    no legitimate `--force` on merge-base, but the check is uniform across all
+    git subcommands so the coverage is worth asserting."""
+    assert is_safe_git_command("git merge-base --force main HEAD") is False
+
+
 # ── make-specific (cpp#45 / mika#1639; architect 783d4a04) ───────────────────
 #
 # Closed-world `make` allowlist: only `make verify-bundled-skills` auto-approves.


### PR DESCRIPTION
## Empirical evidence — 18-incident class

18 `policy:deny on compound bash` incidents observed 2026-07-26T10:13Z → 2026-07-27T12:15Z, blocking dev-groom + dev-pilot on:

| Ticket | Failure shape |
|---|---|
| mika#1849 code-review | `git merge-base + git diff --name-only` |
| mika#1852 groom (retry) | `./scripts/derive-branch-name … 2>/dev/null \|\| echo …` |
| mika#1712 groom, #1823, #1824 | `find docs/plans -name '*.md' \| sort -r \| head -1; echo; ls \| grep …` |
| mika#1687, #1729, #1403, #1574 | `for` loops with grep body |
| mika#1401 | `cd; grep \| head; sed` |
| mika#1847 | `base=\$(gh pr list …); echo` |

All 18 audit_events reasoning trails cite `claude-pilot-py tier1/tier2 allow-list gaps` as root cause. Per mika-platform PUSH FORT directive 2026-07-27: loop is blocked, mission-priority fix.

## Fix — three narrow allow additions

### 1. `git merge-base` → `tier1.SAFE_GIT_SUBCOMMANDS`
Read-only common-ancestor SHA lookup. Same safety class as `rev-parse` / `describe` / `shortlog`. Defense-in-depth `_FORCE_FLAG_RE` still applies.

### 2. `\$(git merge-base main HEAD)` / `origin/main` → `permissions._SUBSTITUTION_ALLOWLIST`
Companion for the `BASE=\$(git merge-base main HEAD) && git diff --name-only \$BASE HEAD` idiom. Same exact-literal closed-world discipline (cpp#34, mika-arch 783d4a04) as existing `\$(git rev-parse HEAD)` entries.

### 3. `./scripts/derive-{branch-name,worktree-path,phase-from-body}` → policy YAML `bash-derive-scripts`
Closed-world 3-script set (dispatch-lib deterministic helpers, all verified pure-computation stdout print). Regex anchored + arg-charset restricted to `[\w./=:-]` — no `\$`, backtick, quotes, pipe, semicolon, ampersand, redirects, spaces.

**Chain-safety (`_bash_allow_is_chain_safe`) still applies compound-wide** — `./scripts/derive-branch-name x && rm -rf ~` still vetoes on the tail. This is a leaf-safe allow, not a compound exemption.

## Explicitly deferred

- **`for` loops**: whole-command exemption pattern too broad with current regex. P2 follow-up.
- **`\$(gh pr view --json ...)` substitution**: exact-literal constraint doesn't fit variable args. Design ticket if closed-world discipline evolves.

## Tests

Ten new tests, all green:
- `test_git_merge_base_allowed` (4 parametric variants)
- `test_git_merge_base_compound_with_diff_allowed` (18-incident exact shape)
- `test_git_merge_base_force_flag_still_denied` (defense-in-depth)
- `test_guard_allows_git_merge_base_substitution_base_drift_idiom` (pins 2 founding tokens)
- `test_policy_bash_derive_scripts_allow_shape` (4 forms)
- `test_policy_bash_derive_scripts_rejects_metachar_args` (7 negative)
- `test_policy_bash_derive_scripts_rejects_unknown_script` (3 negative)
- Existing `test_guard_allows_each_allowlisted_substitution_token` iterates `_SUBSTITUTION_ALLOWLIST` — new entries get end-to-end coverage.

## Verify

```
uv run pytest              # 703 passed (was 693 before)
uv run ruff check          # clean
uv run mypy src            # clean
```

## DECISION-CORE — Vincent hand-merge

Touches permission-policy safety surface (tier1 + tier2 substitution allowlist + policy YAML). **Do not auto-merge.** Same discipline as senara-solutions/mika#1855 (this repo has no automated forge-gate).

Once merged: samidarko-claude installs via `make deploy` to make the expanded allow-list live. Post-deploy verify: dispatch a groom on any p1 ticket touching `./scripts/derive-*` or `git merge-base` — expect `PLAN_GROOMED` (not `policy:deny`).

## Related

- Founding incident class: mika-platform PUSH FORT 2026-07-27
- Companion merged: senara-solutions/mika#1855 forge-gate closure
- cpp#34 discipline: docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784