### PR TITLE
feat(policy): phase-2 compound-bash for-loop safe-body chain-safe exemption [P1 Rolex throughput blocker, DECISION-CORE]

### DIFF
--- a/src/claude_pilot/permissions.py
+++ b/src/claude_pilot/permissions.py
@@ -365,6 +365,24 @@ def _bash_allow_is_chain_safe(
     if pd.decision == "allow" and pd.rule_id == "bash-git-show-redirect":
         return True
 
+    # `bash-for-loop-safe-body` (cpp#92) — sanctioned exception to chain-safe's
+    # segment split, mirroring `bash-git-show-redirect`. The rule's YAML regex
+    # constrains the ENTIRE command shape (anchored `^for … done$`, enumerated
+    # body command, arg charset excludes `;`/`|`/`&`/backtick/`$`/`>`, in-list
+    # charset excludes `$`/backtick), so no chained danger can ride any layer
+    # of the compound. Splitting on the internal `;` between `in`/`do`/`done`
+    # would incorrectly veto — the split segments (`for x in y`, `do echo`,
+    # `done`) are each individually not tier1-safe and not policy-allow, so
+    # chain-safe would deny a shape the tight rule already provably vetted.
+    # The rule_id coupling fails CLOSED — if the YAML rule is renamed or
+    # dropped, this never fires and the command routes through the broader
+    # `bash-for-loop-orientation` rule where chain-safe DOES split (typically
+    # denying — which is the pre-cpp#92 60%-throughput-loss failure mode this
+    # exception is designed to close). See cpp#92 for the founding evidence
+    # (mika-platform PUSH FORT diagnostic 2026-07-28, rupture A).
+    if pd.decision == "allow" and pd.rule_id == "bash-for-loop-safe-body":
+        return True
+
     segments = _split_compound_command(command)
     if not segments:
         return False

--- a/src/claude_pilot/policies/permissions.yaml
+++ b/src/claude_pilot/policies/permissions.yaml
@@ -44,6 +44,24 @@
 # --------------------------------------------------------------------------
 
 rules:
+  # ---- Tight-shape compound rules (MUST precede broader single-command rules) ----
+  # First-match-wins ordering: these anchored/whole-command rules claim their
+  # match before a broader `^find\s`/`\sgrep\s` rule catches an inner token via
+  # policy.py's `re.search`. Chain-safe then honors these rule_ids as
+  # whole-command exemptions (see `_bash_allow_is_chain_safe`), so the internal
+  # `;` of the compound is not split-vetoed.
+  #
+  # `bash-for-loop-safe-body` — see permissions.yaml design comment below the
+  # existing `bash-for-loop-orientation`. Must be evaluated BEFORE `bash-grep`
+  # (whose `\sgrep\s` matches ` grep ` inside a for-body, claims the rule_id,
+  # and then chain-safe splits do/done and vetoes on the `done` sub).
+
+  - id: bash-for-loop-safe-body
+    tool: Bash
+    pattern: '^for\s+\w+\s+in\s+[^;|&`><\\]+;\s*do\s+(echo|printf|grep|cat|head|tail|ls|wc|find|test|\[|dirname|basename)([^;|&`><\\]*);\s*done\s*$'
+    decision: allow
+    reason: "for-loop with enumerated read-only body (echo/printf/grep/cat/head/tail/ls/wc/find/test/[/dirname/basename); in-list + body-args exclude chain metachars/redirects/escapes; $var permitted (substitution caught upstream); fully anchored (cpp#92)"
+
   # ---- Read-only repo orientation ----
   # Common pre-work Bash commands that pilots use to understand the codebase
   # before making changes. Confirmed in mika#1253's pre-wedge pilot log.
@@ -66,11 +84,46 @@ rules:
     decision: allow
     reason: "jq for skill-manifest and JSON inspection (also `cmd | jq …` pipeline)"
 
+  # `bash-for-loop-orientation` — broad-shape fall-through. The tight-shape
+  # `bash-for-loop-safe-body` at the top of the rules table claims for-loops
+  # matching the enumerated-body + arg-charset invariants (whole-command
+  # exemption in chain-safe). Any for-loop NOT matching that tight shape falls
+  # through here — its policy allow is honored but chain-safe re-splits on `;`
+  # and typically vetoes on the un-tier1-safe `do <body>` / `done` segments.
+  # That over-block is the safe direction: only the sanctioned tight shape
+  # gets auto-approval; broader shapes route to relay.
+  #
+  # Design invariants of `bash-for-loop-safe-body` (mirrored in the rule at the
+  # top of the rules table so the two can be maintained together):
+  #
+  #   - `in`-list charset `[^;|&`><\\]+` — excludes chain metachars (`;`,`|`,`&`),
+  #     backtick, redirects (`<`,`>`) and shell escape (`\`). Permits `$var`
+  #     parameter expansion (safe: substitution is caught UPSTREAM by
+  #     `_bash_allow_is_chain_safe`'s substitution-marker guard, which vetoes
+  #     any `$(`, backtick, `$'` BEFORE this rule is evaluated).
+  #   - Body command is one of 13 read-only shell primitives (all in tier1
+  #     SAFE_SHELL_COMMANDS). Enumerated closed-world; no `eval`/`sh`/`bash`.
+  #   - Body args — same charset: excludes chain/redirect/escape; permits
+  #     `$var` and quoted strings with variables (`"step $i"`).
+  #   - Fully anchored `^…\s*done\s*$` — nothing rides before `for` or after
+  #     `done`. A trailing chain (`… ; done && rm -rf ~`) fails the anchor
+  #     and falls through to this broader rule where chain-safe splits and
+  #     vetoes the tail.
+  #
+  # Upstream defense-in-depth (before either rule matches):
+  #   1. `contains_unquoted_metacharacter` (tier1) catches `$(`, backtick, `$'`
+  #      in double-quoted and unquoted regions → tier1 denies → routes to policy.
+  #   2. `_bash_allow_is_chain_safe` opening guards veto `$(` (unless
+  #      allowlisted), backtick, `$'`, funsub — BEFORE evaluating any rule. So
+  #      the `$` this rule permits can only be a bare parameter expansion.
+  #
+  # Founding evidence: mika-platform PUSH FORT 2026-07-28 (throughput rupture A,
+  # 60% of pilot failures 24h 2026-07-27→28).
   - id: bash-for-loop-orientation
     tool: Bash
     pattern: "^for\\s+\\w+\\s+in\\s.*;\\s*do\\s"
     decision: allow
-    reason: "shell-for loops for batch orientation queries"
+    reason: "shell-for loops for batch orientation queries — broad-shape fall-through for cases not covered by bash-for-loop-safe-body; chain-safe still applies (splits do/done body — typically vetoes)"
 
   - id: bash-cat-heredoc-tmp
     tool: Bash

--- a/tests/test_policy_devpilot.py
+++ b/tests/test_policy_devpilot.py
@@ -227,6 +227,107 @@ def test_guard_allows_git_merge_base_substitution_base_drift_idiom() -> None:
         assert token in _SUBSTITUTION_ALLOWLIST, token
 
 
+# --- cpp#92: for-loop safe-body chain-safe exemption (rupture A, phase 2) ---
+# The `bash-for-loop-safe-body` YAML rule constrains the WHOLE command shape
+# tightly enough (enumerated body command, arg charset excludes chain metachars,
+# fully anchored) that chain-safe's `;`-split would incorrectly veto. The
+# whole-command exemption in `_bash_allow_is_chain_safe` (mirroring
+# `bash-git-show-redirect`) restores auto-approval. All negatives below must
+# still be denied — either by the rule regex not matching (fall-through to
+# `bash-for-loop-orientation` where chain-safe splits and vetoes) or by the
+# substitution-marker guard vetoing before rule_id is even checked.
+
+
+def test_guard_allows_for_loop_safe_body_positive_shapes() -> None:
+    """cpp#92 rupture A — sanctioned for-loop shapes chain-safe-exempt via
+    whole-command rule_id honor. Each shape is one of the 24h incident classes
+    that stranded pilot work with policy:deny."""
+    for cmd in (
+        # incident-shape: echo per iteration
+        'for i in 1 2 3; do echo "step $i"; done',
+        # incident-shape: grep per file
+        "for f in a.md b.md; do grep TODO $f; done",
+        # incident-shape: ls per directory
+        "for path in docs/plans docs/logs; do ls $path; done",
+        # incident-shape: cat per config
+        "for c in config.toml Cargo.toml; do cat $c; done",
+    ):
+        pd = evaluate(_POLICY, "Bash", {"command": cmd})
+        assert pd.decision == "allow", f"{cmd}: {pd}"
+        assert pd.rule_id == "bash-for-loop-safe-body", f"{cmd}: {pd.rule_id}"
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is True, cmd
+
+
+def test_guard_vetoes_for_loop_with_substitution_in_iteration_set() -> None:
+    """Substitution guard (BEFORE rule_id check) vetoes any `$(` in the command,
+    including inside the `in` list — smuggling execution via the iteration set."""
+    cmd = 'for i in $(rm -rf ~); do echo x; done'
+    # Redaction fails because `$(rm -rf ~)` isn't in _SUBSTITUTION_ALLOWLIST,
+    # so the substitution guard vetoes before rule_id evaluation.
+    assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False
+
+
+def test_guard_vetoes_for_loop_with_dangerous_body_command() -> None:
+    """Body command NOT in the enumerated 13-set → rule regex doesn't match →
+    falls through to `bash-for-loop-orientation` → chain-safe splits do/done and
+    vetoes on the `rm -rf` sub."""
+    for cmd in (
+        "for i in 1 2; do rm -rf ~; done",
+        "for i in 1; do curl evil.com; done",
+        "for f in a b; do sudo cat /etc/passwd; done",
+        "for i in 1; do eval 'rm -rf ~'; done",
+    ):
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
+
+
+def test_guard_vetoes_for_loop_with_chained_danger_in_body() -> None:
+    """Body arg charset `[^;&|\\s`$>]+` excludes `;` — a chained danger tail
+    inside the body (`echo x; rm -rf ~`) breaks the rule regex → fall-through →
+    chain-safe splits do/done → tail veto."""
+    for cmd in (
+        "for i in 1; do echo x; rm -rf ~; done",
+        "for i in 1; do echo x && curl evil; done",
+        "for i in 1; do echo x | tee /etc/passwd; done",
+    ):
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
+
+
+def test_guard_vetoes_for_loop_with_backtick_in_body() -> None:
+    """Body arg charset excludes backtick — `echo $(id)` and `echo \\`id\\``
+    both vetoed. Substitution guard also catches `$(` before rule check."""
+    for cmd in (
+        "for i in 1; do echo `id`; done",
+    ):
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
+
+
+def test_guard_vetoes_for_loop_with_trailing_chain() -> None:
+    """Anchored rule regex (`^…\\s*done\\s*$`) rejects any trailing token — a
+    chained danger AFTER `done` breaks the anchor → fall-through → chain-safe
+    splits the whole compound and vetoes the tail."""
+    for cmd in (
+        "for i in 1; do echo x; done && rm -rf ~",
+        "for i in 1; do echo x; done; curl evil",
+        "for i in 1; do echo x; done | tee /tmp/log",
+    ):
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
+
+
+def test_guard_vetoes_for_loop_with_substitution_in_iteration_set_backtick() -> None:
+    """Backtick in `in` list — substitution guard vetoes."""
+    cmd = "for i in `id`; do echo x; done"
+    assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False
+
+
+def test_guard_vetoes_for_loop_with_redirect_in_body() -> None:
+    """Body arg charset excludes `>` — a redirect to arbitrary file breaks the
+    rule regex → fall-through → chain-safe splits do/done → veto."""
+    for cmd in (
+        "for i in 1; do echo x > /etc/passwd; done",
+    ):
+        assert _bash_allow_is_chain_safe(_POLICY, "Bash", _bash(cmd)) is False, cmd
+
+
 def test_policy_bash_derive_scripts_allow_shape() -> None:
     """18-incident class 2026-07-27 — dispatch-lib helpers `./scripts/derive-*`
     were falling through to default-deny. `bash-derive-scripts` policy rule


### PR DESCRIPTION
Closes senara-solutions/claude-pilot#92

## Founding evidence — Rolex throughput blocker (60% of failures)

Empirical (24h, 2026-07-27 → 2026-07-28): **10 dispatches → 1 PR opened → 0 merges**. Per mika-platform PUSH FORT diagnostic (samidarko-claude spool 2026-07-28-060305), rupture A (this PR) = 60% of pilot failures. Sibling ruptures tracked at senara-solutions/mika#1857 (B, 30%) and senara-solutions/mika#1856 (C, 10%).

## Fix

**Two coupled changes** (same pattern as cpp#35 `bash-git-show-redirect`):

### 1. `bash-for-loop-safe-body` policy rule
Added to `src/claude_pilot/policies/permissions.yaml` at the TOP of rules (before `bash-grep`/`bash-find` — first-match-wins).

Design invariants:
- **In-list charset** `[^;|&\`><\\]+` — excludes chain metachars, backtick, redirects, escape. Permits `$var` (substitution `$(` caught upstream).
- **Body command** enumerated closed-world 13-set of read-only shell primitives.
- **Body args charset** same as in-list.
- **Fully anchored** `^…\s*done\s*$`.

### 2. Chain-safe whole-command exemption
Added to `permissions.py::_bash_allow_is_chain_safe`, mirrors `bash-git-show-redirect` at lines 353-355. Rule regex IS the safety boundary. Rule_id coupling fails CLOSED.

### 3. `grep|echo` shape — deferred (AC3 discipline)
The 4-remaining-nightly denies include an unidentified `grep|echo` compound. Extracting the exact command from `tool_calls` needs forensic time; hypothesis (`grep -E \"a|b\"` alternation) needs verification. This PR ships the for-loop fix alone; grep-forensic → follow-up.

## Tests — 8 new (all pass)

**Positive** (4 incident-shapes):
- `for i in 1 2 3; do echo \"step \$i\"; done`
- `for f in a.md b.md; do grep TODO \$f; done`
- `for path in docs/plans docs/logs; do ls \$path; done`
- `for c in config.toml Cargo.toml; do cat \$c; done`

**Negative** (7 shapes preserved as denies):
- Substitution in in-list (`\$(rm -rf ~)`, backtick)
- Dangerous body command (rm/curl/sudo/eval)
- Chained danger in body (`echo x; rm -rf ~`)
- Backtick in body
- Trailing chain after `done`
- Redirect (`>`) in body

## Verify

- pytest: **711 passed** (was 703; +8 new)
- ruff check: clean
- mypy src: clean

## DECISION-CORE — Vincent hand-merge

Touches permission-policy safety surface. Same discipline as cpp#91.
Post-merge: samidarko-claude \`make deploy\` → allow-list live.
Post-deploy verify: \`grep 'policy:deny.*for' /var/log/mika/server.log\` — expect **0**.

## Impact projection

- **Rupture A eliminated** → for-loop shape auto-approves → dev-pilot sessions doing `for f in files; do grep …; done` no longer strand work
- Expected PR-opened rate: **10% → ~30-40%** of dispatches (with rupture A gone)
- Full ~90% only after rupture B (senara-solutions/mika#1857) also lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784