### PR TITLE
docs(policy): AC2 doctrine-anchor comments at tier1/tier2/tier3 classifier entry points (cpp#83) [P1 timeout, DECISION-CORE hand-merge]

### DIFF
--- a/src/claude_pilot/policy.py
+++ b/src/claude_pilot/policy.py
@@ -191,6 +191,26 @@ def load_policy(path: Path | None = None) -> Policy:
 # ── Evaluator ───────────────────────────────────────────────────────────────
 
 
+# DOCTRINE: LLM-classifier permission decision (mika#1733 AC2, mika#1193)
+#
+# Applies per senara-solutions/mika @
+# crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md §AC2:
+#
+#   "This agent structurally cannot do X" applies to pre-classifier engine
+#   gates only, NEVER to LLM classifier decisions.
+#
+# THIS IS THE TIER-2 CLASSIFIER ENTRY POINT — rules-file-driven policy
+# evaluation via first-match regex (YAML-authored rules loaded from
+# `policies/permissions.yaml`). Decisions here are POLICY (deny/allow/escalate
+# per rule regex), NOT structural gates. Agents downstream (mika-dev, mika-qa)
+# MUST NOT frame tier-2 denials as "structurally cannot" — those framings are
+# reserved for the pre-classifier structural gates in mika-agent
+# (`validate_dispatch_readiness`, `is_unauthorized_webhook_dispatch`).
+#
+# Companion tier anchors live in claude_pilot/tier1.py (tier1 + tier3);
+# see cpp#83 for the full-tier-set anchoring rationale + mika#1193 for the
+# retirement reference that moved these classifier tiers from mika-agent
+# into claude-pilot-py.
 def evaluate(policy: Policy, tool_name: str, tool_input: dict[str, Any]) -> PolicyDecision:
     """Evaluate a tool invocation against *policy*.
 

--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -25,6 +25,27 @@ from pathlib import Path
 from typing import Any
 
 
+# DOCTRINE: LLM-classifier permission decision (mika#1733 AC2, mika#1193)
+#
+# Applies per senara-solutions/mika @
+# crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md §AC2:
+#
+#   "This agent structurally cannot do X" applies to pre-classifier engine
+#   gates only, NEVER to LLM classifier decisions.
+#
+# THIS IS THE TIER-1 CLASSIFIER ENTRY POINT. Decisions here are POLICY
+# (allowlist-based fast-path for read-only tools + safe-command shapes),
+# NOT structural gates. Agents downstream (mika-dev, mika-qa) MUST NOT
+# frame tier-1 denials as "structurally cannot" or "structural denial" —
+# those framings are reserved for the pre-classifier structural gates in
+# mika-agent (`validate_dispatch_readiness`, `is_unauthorized_webhook_dispatch`
+# — see mika@crates/mika-agent/src/skills/executor.rs and
+# mika@crates/mika-agent/src/webhook_dispatch.rs for canonical shape).
+#
+# Retirement reference: mika#1193 moved the `permission-policy` skill's
+# classifier tiers from mika-agent into claude-pilot-py; this function
+# is one of the three landing sites (tier1/tier2/tier3) named in cpp#83
+# (this ticket) as needing the AC2 anchor.
 def is_tier1_auto_approve(tool_name: str, tool_input: dict[str, Any], cwd: str) -> bool:
     if tool_name in ("Read", "Glob", "Grep"):
         return True
@@ -150,6 +171,21 @@ TIER3_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+# DOCTRINE: LLM-classifier permission decision (mika#1733 AC2, mika#1193)
+#
+# Applies per senara-solutions/mika @
+# crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md §AC2:
+#
+#   "This agent structurally cannot do X" applies to pre-classifier engine
+#   gates only, NEVER to LLM classifier decisions.
+#
+# THIS IS THE TIER-3 CLASSIFIER ENTRY POINT — the danger-pattern denylist
+# consulted by `is_safe_bash_command` after tier1 allowlist matching. Decisions
+# here are POLICY (regex denylist), NOT structural gates. Agents downstream
+# MUST NOT frame tier-3 denials as "structurally cannot" — same discipline
+# as tier-1 above. Companion pre-classifier structural gates in mika-agent:
+# `validate_dispatch_readiness`, `is_unauthorized_webhook_dispatch` (see the
+# tier-1 anchor above for the retirement reference — mika#1193).
 def is_tier3_dangerous(command: str) -> bool:
     # Strip universal fd-to-/dev/null silencing before the dangerous-pattern
     # check (see _FD_DEVNULL_RE comment). The strip is invisible to all other


### PR DESCRIPTION
Closes senara-solutions/claude-pilot#83

## Context

Follow-up to `senara-solutions/mika#1733` (merged in mika#1760). Lands the claude-pilot-py side of the AC2 doctrine anchor:

> "This agent structurally cannot do X" applies to pre-classifier engine gates only, NEVER to LLM classifier decisions.

mika-agent shipped in-repo anchors at `validate_dispatch_readiness()` + `is_unauthorized_webhook_dispatch()` (pre-classifier gates). This PR lands cpp-side companion anchors — the classifier tiers themselves — which explicitly **invert** the anchor direction: these ARE the classifier decisions, so "structurally cannot" framings by downstream agents about tier-1/2/3 denials are fabricated.

## Changes — 3 anchor blocks (docs-only, no behavior change)

- **Tier 1** (`tier1.py::is_tier1_auto_approve`) — allowlist fast-path
- **Tier 3** (`tier1.py::is_tier3_dangerous`) — danger-pattern regex denylist
- **Tier 2** (`policy.py::evaluate`) — rules-file-driven policy evaluation

Each block: cross-refs mika@`crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md §AC2` + mika#1193 (retirement of in-repo `permission-policy` skill), names pre-classifier structural gate counterparts, states invert-direction rule.

Format mirrors mika-agent shape (`skills/executor.rs`, `webhook_dispatch.rs`).

## Verify

- `uv run pytest`: **711 passed** (docs-only, no behavior change)
- `uv run ruff check`: clean
- `uv run mypy src`: clean

## DECISION-CORE — Vincent hand-merge

Touches permission-classifier tier entry points (comments only, but AT the safety surface).

## Timeout status

Ticket filed 2026-07-10; 14-day/P1 escalation window fired ~2026-07-24. Currently 2026-07-28 → past P1 threshold. This PR closes the timeout window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784