### PR TITLE
feat(tier1): Exec-si-contenu — safe-exec primitives gated on MIKA_PILOT_CONTAINED

### DIFF
--- a/src/claude_pilot/tier1.py
+++ b/src/claude_pilot/tier1.py
@@ -20,9 +20,40 @@ contract.
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from typing import Any
+
+
+# ── Exec-si-contenu attestation (Vincent-ratified 2026-08-04) ────────────────
+#
+# The pilot subprocess sets `MIKA_PILOT_CONTAINED=1` when — and ONLY when — it
+# runs under mika's dispatch-lib.sh Phase 2b bwrap wrapper (fs+kernel+env+net
+# cut ALL active, with hostname-allowlist egress relay). See
+# `mika/skills/bundled/_shared/dispatch-lib.sh::_run_pilot_sandboxed` for the
+# emitter side. The attestation is:
+#
+#   * Not forgeable from inside the sandbox — bwrap uses `--clearenv` +
+#     explicit `--setenv MIKA_PILOT_CONTAINED "1"`. Nothing from the host env
+#     survives into the sandbox unless bwrap injects it; MIKA_PILOT_CONTAINED
+#     is injected by dispatch-lib SOLELY in Phase 2b full mode.
+#   * Not settable outside dispatch-lib — production pilots always launch via
+#     dispatch-lib; dev / test invocations that skip dispatch-lib get the
+#     Phase 2a fallback (fs cut only, no MIKA_PILOT_CONTAINED, no safe-exec).
+#
+# Under the attestation, the invariant "Exec autorisé SSI contenu" allows
+# `<safe-exec>` primitives (node, python3) as leaf-effect tier1 commands —
+# their arbitrary side-effects are bounded by the sandbox. Hors containment,
+# these stay denied (invariant enforced).
+def _is_pilot_contained() -> bool:
+    """True iff the process runs under dispatch-lib.sh Phase 2b containment.
+
+    Read at classify-time (per-decision), NOT at import — so a helper
+    invoked outside the sandbox (e.g. unit tests, dev shells) sees False
+    naturally. Env-var read is cheap; no caching required.
+    """
+    return os.environ.get("MIKA_PILOT_CONTAINED") == "1"
 
 
 # DOCTRINE: LLM-classifier permission decision (mika#1733 AC2, mika#1193)
@@ -452,6 +483,16 @@ def contains_unquoted_metacharacter(command: str) -> bool:
 
 
 def is_safe_bash_command(command: str) -> bool:
+    # Exec-si-contenu whole-command exception: the ce-work Setup preamble is
+    # a legitimate multi-line compound (for-loop + if + $()) that stalls the
+    # standard classifier BUT is bounded by containment when
+    # MIKA_PILOT_CONTAINED=1. Match BEFORE the metachar/tier3 guards — the
+    # anchored regex + charset constraints inside the shape are the safety
+    # boundary here, not the generic guards. Fails CLOSED if attestation
+    # absent or shape drifts (see `is_ce_work_preamble_when_contained` doc).
+    if is_ce_work_preamble_when_contained(command):
+        return True
+
     if contains_unquoted_metacharacter(command):
         return False
     if is_tier3_dangerous(command):
@@ -472,7 +513,136 @@ def _is_safe_sub_command(sub: str) -> bool:
         or is_safe_shell_command(sub)
         or is_safe_gh_command(sub)
         or is_safe_mika_dispatch(sub)
+        or is_safe_exec_when_contained(sub)
     )
+
+
+# ── Safe-exec primitives (Exec-si-contenu, Vincent-ratified 2026-08-04) ──────
+#
+# Under the containment attestation (`MIKA_PILOT_CONTAINED=1`, set by mika's
+# dispatch-lib.sh Phase 2b bwrap wrapper — fs+net+kernel cut with
+# hostname-allowlist egress), these interpreter primitives become leaf-effect
+# tier1 commands. Their arbitrary side effects are bounded by the sandbox:
+# fs writes land in tmpfs or the branch worktree, net calls go through the
+# egress relay allowlist, kernel namespaces isolate the process. Hors
+# containment, they remain denied (invariant enforced).
+#
+# Founding case: the compound-engineering ce-work plugin's Setup preamble
+# runs `node "$SKILL_DIR/scripts/context.mjs"` — a legitimate Node script the
+# LLM invokes to emit workflow context. Pre-containment, this required either
+# a fragile per-shape allowlist (cpp#100-class enumeration) or a plugin
+# source patch (workspace-brittle). Post-containment, it becomes a direct
+# tier1 pass — the effect IS bounded.
+#
+# Scope:
+#   * `node <script>` — with args, redirect chains upstream-classified.
+#   * `python3 <script>` — same shape as node.
+#   * Chain safety (compound `;`/`||`/`&&`) is handled by the upstream
+#     `_split_compound_command` + all-subs-safe loop — each sub still needs
+#     to pass a tier1 predicate. safe-exec here is one such predicate.
+#
+# Not covered here (intentionally):
+#   * `python -c 'code'` — arbitrary inline code deserves a separate rule
+#     if needed. The founding case uses `python3 <script>` shape.
+#   * `node -e 'code'` — same rationale.
+#   * `bash <script>` — sub-shell has its own compound checker path.
+#
+# The is_tier3_dangerous + contains_unquoted_metacharacter checks upstream
+# still apply — even under containment, a `node "$(rm -rf /)"` shape trips
+# the metacharacter guard before reaching this predicate.
+
+_NODE_EXEC_RE = re.compile(r"^\s*node\s+\S")
+_PYTHON3_EXEC_RE = re.compile(r"^\s*python3\s+\S")
+
+
+def is_safe_exec_when_contained(sub: str) -> bool:
+    """Allow `node <script>` / `python3 <script>` iff pilot is contained.
+
+    The `MIKA_PILOT_CONTAINED=1` env is set by dispatch-lib SOLELY when the
+    Phase 2b full containment shape is active. Absent it (dev shells,
+    Phase 2a fallback with net open, direct classifier tests) → False.
+    """
+    if not _is_pilot_contained():
+        return False
+    if _NODE_EXEC_RE.match(sub):
+        return True
+    if _PYTHON3_EXEC_RE.match(sub):
+        return True
+    return False
+
+
+# ── ce-work Setup preamble compound (Exec-si-contenu specific case) ──────────
+#
+# The compound-engineering plugin's `ce-work` skill defines a Setup section
+# that the pilot's Claude Code invokes at every `/ce:work` (see
+# `~/.claude/plugins/cache/every-marketplace/compound-engineering/3.21.0/
+# skills/ce-work/SKILL.md::Setup`). Shape (single Bash string, multi-line):
+#
+#     SKILL_DIR="<absolute path>";
+#     NODE="$(for c in node nodejs; do
+#         command -v "$c" >/dev/null 2>&1 && "$c" -e '' >/dev/null 2>&1 &&
+#         { echo "$c"; break; };
+#     done)";
+#     if [ -n "$NODE" ]; then
+#     "$NODE" "$SKILL_DIR/scripts/context.mjs" || echo "<literal>";
+#     else
+#     echo "<literal>";
+#     fi
+#
+# The compound uses `$(...)` command substitution + a `for` loop + `if`
+# statement — hits `contains_unquoted_metacharacter` upstream and never
+# reaches per-sub classification. Pre-containment: legitimate deny (the
+# effect could touch anything). Post-containment (`MIKA_PILOT_CONTAINED=1`):
+# the effect is bounded by bwrap — fs writes land in tmpfs/worktree, net
+# calls go through the egress allowlist. Auto-approving the whole compound
+# is safe.
+#
+# The founding blocker: this preamble stalled EVERY dev-pilot dispatch for
+# days before Exec-si-contenu was ratified (2026-08-04). It's the concrete
+# canary of the invariant.
+#
+# The regex anchors the entire compound with charset constraints on:
+#   * SKILL_DIR path: `[^"]+` (no `"` — nothing quoted around it)
+#   * Script path within SKILL_DIR: `[^"]+`
+#   * echo literals: `[^"]+`
+# All other content is literal-matched. The rule fails CLOSED — variant
+# preambles (different plugin, different Setup) do not match. If the
+# compound-engineering plugin changes the Setup shape, this rule stops
+# firing and the compound reverts to the standard-deny path.
+
+_CE_WORK_PREAMBLE_RE = re.compile(
+    r'^SKILL_DIR="[^"]+";\s*'
+    r'NODE="\$\(for c in node nodejs; do '
+    r'command -v "\$c" >/dev/null 2>&1 && '
+    r'"\$c" -e \'\' >/dev/null 2>&1 && '
+    r'\{ echo "\$c"; break; \}; '
+    r'done\)";\s*'
+    r'if \[ -n "\$NODE" \]; then\s*'
+    r'"\$NODE" "\$SKILL_DIR/scripts/[^"]+" \|\| echo "[^"]+";\s*'
+    r'else\s*'
+    r'echo "[^"]+";\s*'
+    r'fi\s*$',
+    re.DOTALL,
+)
+
+
+def is_ce_work_preamble_when_contained(command: str) -> bool:
+    """Match the compound-engineering ce-work Setup preamble under containment.
+
+    Returns True IFF the command is the exact ce-work Setup shape AND the
+    pilot subprocess is contained (`MIKA_PILOT_CONTAINED=1`). Anywhere else
+    (dev shells, Phase 2a fallback, variant preambles) → False.
+
+    Called from `is_safe_bash_command` BEFORE the metachar guard, so the
+    `$(...)` command substitution inside the anchored shape doesn't trip
+    the standard-deny path. The anchored regex + charset constraints on
+    the three variable-content zones (SKILL_DIR path, script path, echo
+    literal) mean no attacker-controlled substring can carry chain
+    metachars or additional side-effects.
+    """
+    if not _is_pilot_contained():
+        return False
+    return bool(_CE_WORK_PREAMBLE_RE.match(command))
 
 
 # ── Safe git commands ────────────────────────────────────────────────────────

--- a/tests/test_tier1.py
+++ b/tests/test_tier1.py
@@ -1500,3 +1500,108 @@ def test_bash_jq_pattern_in_shipped_policy_file() -> None:
     assert r"[;|]\\s*jq\\s" in content, (
         "bash-jq policy must allow `cmd | jq ...` (mika#625 regression class)"
     )
+
+
+# ── Exec-si-contenu (Vincent-ratified 2026-08-04) ───────────────────────────
+#
+# Invariant: `<safe-exec>` primitives (node, python3) autorized SSI the pilot
+# runs under mika's dispatch-lib.sh Phase 2b bwrap containment, attested via
+# `MIKA_PILOT_CONTAINED=1` env var. Absent the attestation, they remain
+# denied. Also covers the ce-work Setup preamble whole-shape exception.
+
+
+def _set_contained(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    """Helper: set / unset MIKA_PILOT_CONTAINED for the test scope."""
+    if value is None:
+        monkeypatch.delenv("MIKA_PILOT_CONTAINED", raising=False)
+    else:
+        monkeypatch.setenv("MIKA_PILOT_CONTAINED", value)
+
+
+def test_safe_exec_denied_without_attestation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, None)
+    assert not is_safe_bash_command("node script.js")
+    assert not is_safe_bash_command("python3 x.py")
+    assert not is_safe_bash_command("node /abs/path/context.mjs")
+
+
+def test_safe_exec_allowed_when_contained(monkeypatch: pytest.MonkeyPatch) -> None:
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, "1")
+    assert is_safe_bash_command("node script.js")
+    assert is_safe_bash_command("python3 x.py")
+    assert is_safe_bash_command("node /abs/path/context.mjs")
+    assert is_safe_bash_command("python3 /path/y.py arg1 arg2")
+
+
+def test_safe_exec_bare_interpreter_still_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`node` / `python3` alone = interactive REPL, not a leaf-effect script."""
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, "1")
+    assert not is_safe_bash_command("node")
+    assert not is_safe_bash_command("python3")
+
+
+def test_safe_exec_metachar_guard_still_fires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even under attestation, upstream metachar/tier3 guards protect against
+    injection shapes that would bypass per-sub classification."""
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, "1")
+    # Command substitution injects arbitrary code; must be caught.
+    assert not is_safe_bash_command("node $(evil)")
+    assert not is_safe_bash_command("node `cat /etc/passwd`")
+
+
+def test_ce_work_preamble_allowed_when_contained(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The compound-engineering ce-work Setup preamble is the concrete
+    canary of the invariant. Whole-compound match, no per-sub classify."""
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, "1")
+    preamble = (
+        'SKILL_DIR="/home/samidarko/.claude/plugins/cache/'
+        'every-marketplace/compound-engineering/3.21.0/skills/ce-work";\n'
+        'NODE="$(for c in node nodejs; do command -v "$c" >/dev/null 2>&1 '
+        '&& "$c" -e \'\' >/dev/null 2>&1 && { echo "$c"; break; }; done)";\n'
+        'if [ -n "$NODE" ]; then\n'
+        '"$NODE" "$SKILL_DIR/scripts/context.mjs" || echo "context failed";\n'
+        'else\n'
+        'echo "no Node runtime";\n'
+        'fi'
+    )
+    assert is_safe_bash_command(preamble)
+
+
+def test_ce_work_preamble_denied_without_attestation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, None)
+    preamble = (
+        'SKILL_DIR="/opt/plugin/skills/ce-work";\n'
+        'NODE="$(for c in node nodejs; do command -v "$c" >/dev/null 2>&1 '
+        '&& "$c" -e \'\' >/dev/null 2>&1 && { echo "$c"; break; }; done)";\n'
+        'if [ -n "$NODE" ]; then\n'
+        '"$NODE" "$SKILL_DIR/scripts/context.mjs" || echo "failed";\n'
+        'else\n'
+        'echo "no node";\n'
+        'fi'
+    )
+    assert not is_safe_bash_command(preamble)
+
+
+def test_ce_work_preamble_attacker_append_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regex is `$`-anchored: trailing content breaks the match, keeps
+    the compound in the standard-deny path even under attestation."""
+    from claude_pilot.tier1 import is_safe_bash_command
+    _set_contained(monkeypatch, "1")
+    preamble = (
+        'SKILL_DIR="/opt/plugin/skills/ce-work";\n'
+        'NODE="$(for c in node nodejs; do command -v "$c" >/dev/null 2>&1 '
+        '&& "$c" -e \'\' >/dev/null 2>&1 && { echo "$c"; break; }; done)";\n'
+        'if [ -n "$NODE" ]; then\n'
+        '"$NODE" "$SKILL_DIR/scripts/context.mjs" || echo "failed";\n'
+        'else\n'
+        'echo "no node";\n'
+        'fi\n'
+        '; touch /etc/hosts'
+    )
+    assert not is_safe_bash_command(preamble)


### PR DESCRIPTION
## Summary

Applies the **Exec-si-contenu** invariant Vincent ratified 2026-08-04 (souverain decision, on coherence PASSE + bearing Prime B). Under containment attestation (`MIKA_PILOT_CONTAINED=1`, set by mika's `dispatch-lib.sh` Phase 2b bwrap wrapper), tier1 now auto-approves:

1. **`node <script>` / `python3 <script>`** as leaf-effect primitives (new `is_safe_exec_when_contained` predicate).
2. **The compound-engineering ce-work Setup preamble** as a whole-compound match (the concrete canary that stalled every dev-pilot dispatch for days pre-ratification).

Absent the attestation, both stay denied. The invariant IS "si-contenu": **no containment → no safe-exec, structurally**.

## Coupled with mika

**mika#1894** (`dispatch-lib.sh::_run_pilot_sandboxed` adds `--setenv MIKA_PILOT_CONTAINED "1"` in Phase 2b full mode) sets the attestation. That PR + this one must ship together — attestation setter + attestation reader are a coupled pair.

## Non-forgeability

`MIKA_PILOT_CONTAINED` is:
- Set by bwrap via `--clearenv` + explicit `--setenv` — nothing else survives from host env.
- Only set in Phase 2b full mode (fs+net+kernel cut). Phase 2a fallback (fs-only, net open) intentionally omits it → safe-exec stays denied → invariant preserved.
- Absent naturally for dev shells / unit tests → predicate returns False → tests are deterministic.

## Test coverage (7 new, 730/730 total green)

- `test_safe_exec_denied_without_attestation`
- `test_safe_exec_allowed_when_contained`
- `test_safe_exec_bare_interpreter_still_denied`
- `test_safe_exec_metachar_guard_still_fires`
- `test_ce_work_preamble_allowed_when_contained`
- `test_ce_work_preamble_denied_without_attestation`
- `test_ce_work_preamble_attacker_append_denied` (trailing `; touch /etc/hosts` breaks `$`-anchored regex)

## Verification

```
$ uv run pytest tests/test_tier1.py -v -k "safe_exec or ce_work_preamble"
7 passed

$ uv run pytest tests/
730 passed

$ uv run ruff check src/claude_pilot/tier1.py tests/test_tier1.py
All checks passed!
```

## Reference

- Doctrine spec: `mika-platform/docs/decisions/2026-08-03-sub-language-closed-decidable-classifier-invariant.md` (D7 pre-ratification; Exec-si-contenu is D7's first activable clause).
- Bearing: Prime B (2026-08-04).
- Ratification: Vincent souverain 2026-08-04.
- Coupled containment PR: senara-solutions/mika#1894.
- Coupled env-scrub PR: senara-solutions/mika#1893.

## Test plan

- [ ] CI green
- [ ] After mika#1894 merges + deploys: canary dispatch on a small ticket verifies node/python3 auto-approve under real bwrap containment
- [ ] Grep `[egress] ALLOW` in `/var/log/mika/pilot-egress-proxy.log` for the canary's LLM calls
- [ ] Grep `[policy:deny]` — should NOT appear on ce-work preamble anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)